### PR TITLE
Update and clean jcr2vfs migration app scripts

### DIFF
--- a/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-migration-core/src/main/assembly/scripts/bin/runMigration.bat
+++ b/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-migration-core/src/main/assembly/scripts/bin/runMigration.bat
@@ -23,9 +23,8 @@ goto setArgs
 :doneSetArgs
 
 rem You can use -Xmx128m or less too, but it might be slower
-rem Change guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar to a release version
 if exist %JAVA_HOME%\bin\java.exe (
-    %JAVA_HOME%\bin\java -Xms256m -Xmx512m -server -cp ..\libs\guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar;..\libs\*; %mainClass% %CMD_LINE_ARGS%
+    %JAVA_HOME%\bin\java -Xms256m -Xmx512m -server -cp ..\libs\*; %mainClass% %CMD_LINE_ARGS%
 ) else (
-    java -Xms256m -Xmx512m -cp ..\libs\guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar;..\libs\*; %mainClass% %CMD_LINE_ARGS%
+    java -Xms256m -Xmx512m -cp ..\libs\*; %mainClass% %CMD_LINE_ARGS%
 )

--- a/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-migration-core/src/main/assembly/scripts/bin/runMigration.sh
+++ b/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-migration-core/src/main/assembly/scripts/bin/runMigration.sh
@@ -14,11 +14,12 @@ mainClass=org.drools.workbench.jcr2vfsmigration.Jcr2VfsMigrationApp
 # echo "Starting migration app..."
 
 # You can use -Xmx128m or less too, but it might be slower
-# TODO: Change guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar to a release version
-if [ -f $JAVA_HOME/bin/java ]; then
-    $JAVA_HOME/bin/java -Xms256m -Xmx1024m -server -cp ../libs/guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar:../libs/* ${mainClass} $*
+if [ ! -z "$JAVA_HOME" -a -f "$JAVA_HOME/bin/java" ]; then
+    echo "Using $JAVA_HOME/bin/java to run the application..."
+    "$JAVA_HOME/bin/java" -Xms256m -Xmx1024m -server -cp "../libs/*" ${mainClass} $*
 else
-    java -Xms256m -Xmx1024m -cp ../libs/guvnor-jcr2vfs-migration-droolsjbpm-as-uberjar-5.5.1-20130606.153149-125-jars-as-uberjar.jar:../libs/* ${mainClass} $*
+    echo "Using `which java` to run the application..."
+    java -Xms256m -Xmx1024m -cp "../libs/*" ${mainClass} $*
 fi
 
 if [ $? != 0 ] ; then


### PR DESCRIPTION
Remove the droolsjbpm-uberjar from CP in script as it will be loaded by the "../libs/*" pattern and placing it before the other libs won't result in loading it first.

Fix condition that checks if $JAVA_HOME/bin/java exists - first check if $JAVA_HOME is not empty string and the check if $JAVA_HOME/bin/java exists. In case $JAVA_HOME is empty string and /bin/java exists the condition was not behaving as intended.

I did not test the windows bat file, but the change is pretty small so should not cause any problems.
