### PR TITLE
GUVNOR-2854: Increase coverage for moving rows with PriorityOver

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/PrioritySynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/PrioritySynchronizer.java
@@ -23,6 +23,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.cell.GridWidgetCellFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.CellUtilities;
@@ -30,18 +31,17 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.
 
 public class PrioritySynchronizer {
 
-
     private final GuidedDecisionTable52 model;
     private final GuidedDecisionTableUiModel uiModel;
     private final GridWidgetCellFactory gridWidgetCellFactory;
     private final CellUtilities cellUtilities;
     private final ColumnUtilities columnUtilities;
 
-    public PrioritySynchronizer( final GuidedDecisionTable52 model,
-                                 final GuidedDecisionTableUiModel uiModel,
-                                 final GridWidgetCellFactory gridWidgetCellFactory,
-                                 final CellUtilities cellUtilities,
-                                 final ColumnUtilities columnUtilities ) {
+    public PrioritySynchronizer(final GuidedDecisionTable52 model,
+                                final GuidedDecisionTableUiModel uiModel,
+                                final GridWidgetCellFactory gridWidgetCellFactory,
+                                final CellUtilities cellUtilities,
+                                final ColumnUtilities columnUtilities) {
         this.model = model;
         this.uiModel = uiModel;
         this.gridWidgetCellFactory = gridWidgetCellFactory;
@@ -49,46 +49,48 @@ public class PrioritySynchronizer {
         this.columnUtilities = columnUtilities;
     }
 
-    public void update( final int rowNumberColumnIndex,
-                        final RowNumberChanges rowNumberChanges ) {
+    public void update(final int rowNumberColumnIndex,
+                       final RowNumberChanges rowNumberChanges) {
 
         final Optional<BaseColumnInfo> optional = getPriorityColumnInfo();
 
-        if ( optional.isPresent() ) {
+        if (optional.isPresent()) {
 
             final BaseColumnInfo baseColumnInfo = optional.get();
 
-            for ( final List<DTCellValue52> row : model.getData() ) {
+            for (final List<DTCellValue52> row : model.getData()) {
 
-                final DTCellValue52 dtCellValue52 = row.get( baseColumnInfo.getColumnIndex() );
-                final int oldValue = getNumber( dtCellValue52 );
-                final int rowNumber = row.get( rowNumberColumnIndex )
+                final DTCellValue52 dtCellValue52 = row.get(baseColumnInfo.getColumnIndex());
+                final int oldValue = getNumber(dtCellValue52);
+                final int rowNumber = row.get(rowNumberColumnIndex)
                         .getNumericValue()
                         .intValue() - 1;
 
-                if ( oldValue != 0 ) {
+                if (oldValue != 0) {
 
-                    if ( oldValue > rowNumber ) {
-                        dtCellValue52.setStringValue( "" );
+                    GuidedDecisionTableUiCell newUiCell;
+                    if (oldValue > rowNumber || rowNumberChanges.get(oldValue) > rowNumber) {
+                        newUiCell = new GuidedDecisionTableUiCell("");
                     } else {
-                        dtCellValue52.setStringValue( Integer.toString( rowNumberChanges.get( oldValue ) ) );
+                        dtCellValue52.setStringValue(Integer.toString(rowNumberChanges.get(oldValue)));
+                        newUiCell = gridWidgetCellFactory.convertCell(dtCellValue52,
+                                                                      baseColumnInfo.getBaseColumn(),
+                                                                      cellUtilities,
+                                                                      columnUtilities);
                     }
 
-                    uiModel.setCellInternal( rowNumber,
-                                             baseColumnInfo.getColumnIndex(),
-                                             gridWidgetCellFactory.convertCell( dtCellValue52,
-                                                                                baseColumnInfo.getBaseColumn(),
-                                                                                cellUtilities,
-                                                                                columnUtilities ) );
+                    uiModel.setCellInternal(rowNumber,
+                                            baseColumnInfo.getColumnIndex(),
+                                            newUiCell);
                 }
             }
         }
     }
 
-    private int getNumber( final DTCellValue52 dtCellValue52 ) {
+    private int getNumber(final DTCellValue52 dtCellValue52) {
         try {
-            return Integer.parseInt( dtCellValue52.getStringValue() );
-        } catch ( final NumberFormatException e ) {
+            return Integer.parseInt(dtCellValue52.getStringValue());
+        } catch (final NumberFormatException e) {
             return 0;
         }
     }
@@ -97,12 +99,12 @@ public class PrioritySynchronizer {
 
         int attributeColumnIndex = 0;
 
-        for ( final BaseColumn baseColumn : model.getExpandedColumns() ) {
-            if ( baseColumn instanceof MetadataCol52
-                    && GuidedDecisionTable52.HitPolicy.RESOLVED_HIT_METADATA_NAME.equals( ( (MetadataCol52) baseColumn ).getMetadata() ) ) {
+        for (final BaseColumn baseColumn : model.getExpandedColumns()) {
+            if (baseColumn instanceof MetadataCol52
+                    && GuidedDecisionTable52.HitPolicy.RESOLVED_HIT_METADATA_NAME.equals(((MetadataCol52) baseColumn).getMetadata())) {
 
-                return Optional.of( new BaseColumnInfo( attributeColumnIndex,
-                                                        baseColumn ) );
+                return Optional.of(new BaseColumnInfo(attributeColumnIndex,
+                                                      baseColumn));
             } else {
                 attributeColumnIndex++;
             }
@@ -110,35 +112,34 @@ public class PrioritySynchronizer {
         return Optional.empty();
     }
 
-    public void deleteRow( final int deletedRowIndex ) {
-
+    public void deleteRow(final int deletedRowIndex) {
 
         final int deletedRowNumber = deletedRowIndex + 1;
 
-        if ( GuidedDecisionTable52.HitPolicy.RESOLVED_HIT.equals( model.getHitPolicy() ) ) {
+        if (GuidedDecisionTable52.HitPolicy.RESOLVED_HIT.equals(model.getHitPolicy())) {
 
             final Optional<BaseColumnInfo> optional = getPriorityColumnInfo();
 
-            if ( optional.isPresent() ) {
+            if (optional.isPresent()) {
 
                 final BaseColumnInfo baseColumnInfo = optional.get();
 
                 int rowNumber = 0;
 
-                for ( final List<DTCellValue52> row : model.getData() ) {
+                for (final List<DTCellValue52> row : model.getData()) {
 
-                    final DTCellValue52 dtCellValue52 = row.get( baseColumnInfo.getColumnIndex() );
-                    final int oldValue = getNumber( dtCellValue52 );
+                    final DTCellValue52 dtCellValue52 = row.get(baseColumnInfo.getColumnIndex());
+                    final int oldValue = getNumber(dtCellValue52);
 
-                    if ( oldValue == deletedRowNumber ) {
-                        dtCellValue52.setNumericValue( 0 );
+                    if (oldValue == deletedRowNumber) {
+                        dtCellValue52.setNumericValue(0);
 
-                        uiModel.setCellInternal( rowNumber,
-                                                 baseColumnInfo.getColumnIndex(),
-                                                 gridWidgetCellFactory.convertCell( dtCellValue52,
-                                                                                    baseColumnInfo.getBaseColumn(),
-                                                                                    cellUtilities,
-                                                                                    columnUtilities ) );
+                        uiModel.setCellInternal(rowNumber,
+                                                baseColumnInfo.getColumnIndex(),
+                                                gridWidgetCellFactory.convertCell(dtCellValue52,
+                                                                                  baseColumnInfo.getBaseColumn(),
+                                                                                  cellUtilities,
+                                                                                  columnUtilities));
                     }
 
                     rowNumber++;
@@ -157,11 +158,12 @@ public class PrioritySynchronizer {
     }
 
     private class BaseColumnInfo {
+
         private int columnIndex;
         private BaseColumn baseColumn;
 
-        public BaseColumnInfo( final int columnIndex,
-                               final BaseColumn baseColumn ) {
+        public BaseColumnInfo(final int columnIndex,
+                              final BaseColumn baseColumn) {
             this.columnIndex = columnIndex;
             this.baseColumn = baseColumn;
         }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizerTest.java
@@ -87,121 +87,122 @@ public abstract class BaseSynchronizerTest {
 
     protected Instance<DynamicValidator> validatorInstance = new MockDynamicValidatorInstance();
 
+    protected final GuidedDecisionTableView view = mock(GuidedDecisionTableView.class);
+
     private GuidedDecisionTablePresenter.Access editable = new GuidedDecisionTablePresenter.Access();
 
-    private GuidedDecisionTablePresenter.Access readOnly = new GuidedDecisionTablePresenter.Access() {{
-        setReadOnly( true );
+    protected GuidedDecisionTablePresenter.Access readOnly = new GuidedDecisionTablePresenter.Access() {{
+        setReadOnly(true);
     }};
 
     @Before
     public void setup() {
         //Setup model related classes
         model = new GuidedDecisionTable52();
-        uiModel = new GuidedDecisionTableUiModel( modelSynchronizer );
-        incrementalDataModelServiceCaller = new CallerMock<>( incrementalDataModelService );
+        uiModel = new GuidedDecisionTableUiModel(modelSynchronizer);
+        incrementalDataModelServiceCaller = new CallerMock<>(incrementalDataModelService);
 
-        final BRLRuleModel rm = new BRLRuleModel( model );
+        final BRLRuleModel rm = new BRLRuleModel(model);
         final CellUtilities cellUtilities = new CellUtilities();
-        final ColumnUtilities columnUtilities = new ColumnUtilities( model,
-                                                                     oracle );
-        final DependentEnumsUtilities enumsUtilities = new DependentEnumsUtilities( model,
-                                                                                    oracle );
+        final ColumnUtilities columnUtilities = new ColumnUtilities(model,
+                                                                    oracle);
+        final DependentEnumsUtilities enumsUtilities = new DependentEnumsUtilities(model,
+                                                                                   oracle);
         final GridWidgetCellFactory gridWidgetCellFactory = new GridWidgetCellFactoryImpl();
 
         //Setup mocks
-        final GuidedDecisionTableModellerView.Presenter modellerPresenter = mock( GuidedDecisionTableModellerView.Presenter.class );
-        final GuidedDecisionTableModellerView modellerView = mock( GuidedDecisionTableModellerView.class );
-        final GridLayer gridLayer = mock( GridLayer.class );
-        final AbsolutePanel domElementContainer = mock( AbsolutePanel.class );
-        final GuidedDecisionTableView.Presenter dtablePresenter = mock( GuidedDecisionTableView.Presenter.class );
-        final GuidedDecisionTableView view = mock( GuidedDecisionTableView.class );
-        final EventBus eventBus = mock( EventBus.class );
+        final GuidedDecisionTableModellerView.Presenter modellerPresenter = mock(GuidedDecisionTableModellerView.Presenter.class);
+        final GuidedDecisionTableModellerView modellerView = mock(GuidedDecisionTableModellerView.class);
+        final GridLayer gridLayer = mock(GridLayer.class);
+        final AbsolutePanel domElementContainer = mock(AbsolutePanel.class);
+        final GuidedDecisionTableView.Presenter dtablePresenter = mock(GuidedDecisionTableView.Presenter.class);
+        final EventBus eventBus = mock(EventBus.class);
 
-        when( dtablePresenter.getModellerPresenter() ).thenReturn( modellerPresenter );
-        when( modellerPresenter.getView() ).thenReturn( modellerView );
-        when( modellerView.getGridLayerView() ).thenReturn( gridLayer );
-        when( gridLayer.getDomElementContainer() ).thenReturn( domElementContainer );
-        when( domElementContainer.iterator() ).thenReturn( mock( Iterator.class ) );
+        when(dtablePresenter.getModellerPresenter()).thenReturn(modellerPresenter);
+        when(modellerPresenter.getView()).thenReturn(modellerView);
+        when(modellerView.getGridLayerView()).thenReturn(gridLayer);
+        when(gridLayer.getDomElementContainer()).thenReturn(domElementContainer);
+        when(domElementContainer.iterator()).thenReturn(mock(Iterator.class));
 
         //Setup column converters
         final List<BaseColumnConverter> converters = getConverters();
-        gridWidgetColumnFactory.setConverters( converters );
-        gridWidgetColumnFactory.initialise( model,
-                                            oracle,
-                                            columnUtilities,
-                                            dtablePresenter );
+        gridWidgetColumnFactory.setConverters(converters);
+        gridWidgetColumnFactory.initialise(model,
+                                           oracle,
+                                           columnUtilities,
+                                           dtablePresenter);
 
         //Setup synchronizers
         final List<Synchronizer<? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData>> synchronizers = getSynchronizers();
-        modelSynchronizer.setSynchronizers( synchronizers );
-        modelSynchronizer.initialise( model,
-                                      uiModel,
-                                      cellUtilities,
-                                      columnUtilities,
-                                      enumsUtilities,
-                                      gridWidgetCellFactory,
-                                      gridWidgetColumnFactory,
-                                      view,
-                                      rm,
-                                      eventBus,
-                                      editable );
+        modelSynchronizer.setSynchronizers(synchronizers);
+        modelSynchronizer.initialise(model,
+                                     uiModel,
+                                     cellUtilities,
+                                     columnUtilities,
+                                     enumsUtilities,
+                                     gridWidgetCellFactory,
+                                     gridWidgetColumnFactory,
+                                     view,
+                                     rm,
+                                     eventBus,
+                                     editable);
 
         //Dummy columns for Row number and Description
-        uiModel.appendColumn( gridWidgetColumnFactory.convertColumn( new RowNumberCol52(),
-                                                                     readOnly,
-                                                                     view ) );
-        uiModel.appendColumn( gridWidgetColumnFactory.convertColumn( new DescriptionCol52(),
-                                                                     readOnly,
-                                                                     view ) );
+        uiModel.appendColumn(gridWidgetColumnFactory.convertColumn(new RowNumberCol52(),
+                                                                   readOnly,
+                                                                   view));
+        uiModel.appendColumn(gridWidgetColumnFactory.convertColumn(new DescriptionCol52(),
+                                                                   readOnly,
+                                                                   view));
 
-        ApplicationPreferences.setUp( new HashMap<String, String>() {{
-            put( ApplicationPreferences.DATE_FORMAT,
-                 "dd-MM-yyyy" );
-        }} );
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(ApplicationPreferences.DATE_FORMAT,
+                "dd-MM-yyyy");
+        }});
     }
 
     protected AsyncPackageDataModelOracle getOracle() {
-        final AsyncPackageDataModelOracle oracle = new AsyncPackageDataModelOracleImpl( incrementalDataModelServiceCaller,
-                                                                                        validatorInstance );
+        final AsyncPackageDataModelOracle oracle = new AsyncPackageDataModelOracleImpl(incrementalDataModelServiceCaller,
+                                                                                       validatorInstance);
         return oracle;
     }
 
     protected List<BaseColumnConverter> getConverters() {
         final List<BaseColumnConverter> converters = new ArrayList<BaseColumnConverter>();
-        converters.add( new ActionInsertFactColumnConverter() );
-        converters.add( new ActionRetractFactColumnConverter() );
-        converters.add( new ActionSetFieldColumnConverter() );
-        converters.add( new ActionWorkItemColumnConverter() );
-        converters.add( new ActionWorkItemInsertFactColumnConverter() );
-        converters.add( new ActionWorkItemSetFieldColumnConverter() );
-        converters.add( new AttributeColumnConverter() );
-        converters.add( new BRLActionVariableColumnConverter() );
-        converters.add( new BRLConditionVariableColumnConverter() );
-        converters.add( new ConditionColumnConverter() );
-        converters.add( new DescriptionColumnConverter() );
-        converters.add( new LimitedEntryColumnConverter() );
-        converters.add( new MetaDataColumnConverter() );
-        converters.add( new RowNumberColumnConverter() );
+        converters.add(new ActionInsertFactColumnConverter());
+        converters.add(new ActionRetractFactColumnConverter());
+        converters.add(new ActionSetFieldColumnConverter());
+        converters.add(new ActionWorkItemColumnConverter());
+        converters.add(new ActionWorkItemInsertFactColumnConverter());
+        converters.add(new ActionWorkItemSetFieldColumnConverter());
+        converters.add(new AttributeColumnConverter());
+        converters.add(new BRLActionVariableColumnConverter());
+        converters.add(new BRLConditionVariableColumnConverter());
+        converters.add(new ConditionColumnConverter());
+        converters.add(new DescriptionColumnConverter());
+        converters.add(new LimitedEntryColumnConverter());
+        converters.add(new MetaDataColumnConverter());
+        converters.add(new RowNumberColumnConverter());
         return converters;
     }
 
     protected List<Synchronizer<? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData>> getSynchronizers() {
         final List<Synchronizer<? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData>> synchronizers = new ArrayList<>();
-        synchronizers.add( new ActionColumnSynchronizer() );
-        synchronizers.add( new ActionInsertFactColumnSynchronizer() );
-        synchronizers.add( new ActionRetractFactColumnSynchronizer() );
-        synchronizers.add( new ActionSetFieldColumnSynchronizer() );
-        synchronizers.add( new ActionWorkItemColumnSynchronizer() );
-        synchronizers.add( new ActionWorkItemInsertFactColumnSynchronizer() );
-        synchronizers.add( new ActionWorkItemSetFieldColumnSynchronizer() );
-        synchronizers.add( new AttributeColumnSynchronizer() );
-        synchronizers.add( new BRLActionColumnSynchronizer() );
-        synchronizers.add( new BRLConditionColumnSynchronizer() );
-        synchronizers.add( new ConditionColumnSynchronizer() );
-        synchronizers.add( new LimitedEntryBRLActionColumnSynchronizer() );
-        synchronizers.add( new LimitedEntryBRLConditionColumnSynchronizer() );
-        synchronizers.add( new MetaDataColumnSynchronizer() );
-        synchronizers.add( new RowSynchronizer() );
+        synchronizers.add(new ActionColumnSynchronizer());
+        synchronizers.add(new ActionInsertFactColumnSynchronizer());
+        synchronizers.add(new ActionRetractFactColumnSynchronizer());
+        synchronizers.add(new ActionSetFieldColumnSynchronizer());
+        synchronizers.add(new ActionWorkItemColumnSynchronizer());
+        synchronizers.add(new ActionWorkItemInsertFactColumnSynchronizer());
+        synchronizers.add(new ActionWorkItemSetFieldColumnSynchronizer());
+        synchronizers.add(new AttributeColumnSynchronizer());
+        synchronizers.add(new BRLActionColumnSynchronizer());
+        synchronizers.add(new BRLConditionColumnSynchronizer());
+        synchronizers.add(new ConditionColumnSynchronizer());
+        synchronizers.add(new LimitedEntryBRLActionColumnSynchronizer());
+        synchronizers.add(new LimitedEntryBRLConditionColumnSynchronizer());
+        synchronizers.add(new MetaDataColumnSynchronizer());
+        synchronizers.add(new RowSynchronizer());
         return synchronizers;
     }
 
@@ -209,13 +210,13 @@ public abstract class BaseSynchronizerTest {
     private static class MockDynamicValidatorInstance implements Instance<DynamicValidator> {
 
         @Override
-        public Instance<DynamicValidator> select( final Annotation... annotations ) {
+        public Instance<DynamicValidator> select(final Annotation... annotations) {
             return null;
         }
 
         @Override
-        public <U extends DynamicValidator> Instance<U> select( final Class<U> aClass,
-                                                                final Annotation... annotations ) {
+        public <U extends DynamicValidator> Instance<U> select(final Class<U> aClass,
+                                                               final Annotation... annotations) {
             return null;
         }
 
@@ -230,7 +231,7 @@ public abstract class BaseSynchronizerTest {
         }
 
         @Override
-        public void destroy( final DynamicValidator dynamicValidator ) {
+        public void destroy(final DynamicValidator dynamicValidator) {
 
         }
 
@@ -243,7 +244,5 @@ public abstract class BaseSynchronizerTest {
         public DynamicValidator get() {
             return null;
         }
-
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/SystemControlledColumnValuesSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/SystemControlledColumnValuesSynchronizerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SystemControlledColumnValuesSynchronizerTest extends BaseSynchronizerTest {
+
+    private MetadataCol52 resolvedHitMetadata;
+    private AttributeCol52 salienceAttribute;
+    private int rowsCount;
+
+    @Before
+    public void setUp() throws Exception {
+        salienceAttribute = new AttributeCol52();
+        salienceAttribute.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
+
+        resolvedHitMetadata = new MetadataCol52();
+        resolvedHitMetadata.setMetadata(GuidedDecisionTable52.HitPolicy.RESOLVED_HIT_METADATA_NAME);
+
+        model.setHitPolicy(GuidedDecisionTable52.HitPolicy.RESOLVED_HIT);
+        modelSynchronizer.appendColumn(salienceAttribute);
+        modelSynchronizer.appendColumn(resolvedHitMetadata);
+
+        rowsCount = 0;
+    }
+
+    @Test
+    public void testPrioritiesOverSameRowMoveUp() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("2");
+
+        uiModel.moveRowsTo(0,
+                           Arrays.asList(uiModel.getRow(1)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "1",
+                                       "1"));
+    }
+
+    @Test
+    public void testPrioritiesOverSameRowMoveDown() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("");
+
+        uiModel.moveRowsTo(3,
+                           Arrays.asList(uiModel.getRow(0)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       ""));
+    }
+
+    @Test
+    public void testTransitivePrioritiesMoveUp() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("3");
+        addRowWithPriorityOver("");
+
+        uiModel.moveRowsTo(0,
+                           Arrays.asList(uiModel.getRow(4)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "2",
+                                       "3",
+                                       "4"));
+    }
+
+    @Test
+    public void testTransitivePrioritiesMoveDown() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("3");
+        addRowWithPriorityOver("");
+
+        uiModel.moveRowsTo(4,
+                           Arrays.asList(uiModel.getRow(0)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "",
+                                       ""));
+    }
+
+    @Test
+    public void testMoveIntoGroup() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("3");
+
+        uiModel.moveRowsTo(2,
+                           Arrays.asList(uiModel.getRow(0)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "2"));
+    }
+
+    @Test
+    public void testMoveRowWithPriority() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("2");
+
+        uiModel.moveRowsTo(0,
+                           Arrays.asList(uiModel.getRow(2)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "3"));
+    }
+
+    @Test
+    public void testMoveMultipleRows() throws Exception {
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("2");
+        addRowWithPriorityOver("");
+        addRowWithPriorityOver("1");
+        addRowWithPriorityOver("5");
+
+        uiModel.moveRowsTo(3,
+                           Arrays.asList(uiModel.getRow(0)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "",
+                                       "4",
+                                       "5"));
+        uiModel.moveRowsTo(2,
+                           Arrays.asList(uiModel.getRow(3)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "",
+                                       "3",
+                                       "5"));
+
+        uiModel.moveRowsTo(1,
+                           Arrays.asList(uiModel.getRow(4)));
+
+        assertPriorities(Arrays.asList("",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "2"));
+    }
+
+    private void addRowWithPriorityOver(String priorityOverRow) throws Exception {
+        modelSynchronizer.appendRow();
+        uiModel.setCell(rowsCount,
+                        0,
+                        new GuidedDecisionTableUiCell<>(rowsCount + 1));
+        uiModel.setCell(rowsCount,
+                        2,
+                        new GuidedDecisionTableUiCell<>(priorityOverRow));
+        rowsCount++;
+    }
+
+    private void assertPriorities(List<String> priorities) {
+        for (int rowIndex = 0; rowIndex < priorities.size(); rowIndex++) {
+            assertEquals(priorities.get(rowIndex),
+                         uiModel.getCell(rowIndex,
+                                         2).getValue().getValue());
+        }
+    }
+}


### PR DESCRIPTION
This PR increases coverage of moving rows with set PriorityOver and also
fixes two small issues.

The first issue was, that when te row with PriorityOver Row X was moved
to the position X, his PriorityOver wasn't cleared. It means that the
Row X with PriorityOver X was in the table.

The second fixed issue. When there were Rows: 1, 2, 3 with Priorities
None, 1, 1 and the Row 1 was moved to Row 3 then the priorites were None,
3, None. Now the priorities will be None, None, None as expected.