### PR TITLE
GUVNOR-2976: Guided Decision Table Graph: Save operation saves changes just to selected graph

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
@@ -86,260 +86,65 @@ import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.*;
-import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.*;
-import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.*;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.CURRENT_USER;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.NOBODY;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.OTHER_USER;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.EDITOR_PROVIDED;
+import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentDelete;
+import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentRename;
+import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentUpdate;
 
 /**
  * Guided Decision Table Graph Editor Presenter
  */
 @Dependent
-@WorkbenchEditor(identifier = "GuidedDecisionTableGraphEditor", supportedTypes = { GuidedDTableGraphResourceType.class }, lockingStrategy = EDITOR_PROVIDED)
+@WorkbenchEditor(identifier = "GuidedDecisionTableGraphEditor", supportedTypes = {GuidedDTableGraphResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
 public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionTableEditorPresenter {
 
     private final Caller<GuidedDecisionTableGraphEditorService> graphService;
     private final Event<SaveInProgressEvent> saveInProgressEvent;
     private final LockManager lockManager;
-
-    private GuidedDecisionTableEditorGraphContent content;
-    private LoadGraphLatch loadGraphLatch = null;
-    private SaveGraphLatch saveGraphLatch = null;
-
-    private ProjectContext context;
-    private NewGuidedDecisionTableWizardHelper helper;
-
     protected ObservablePath.OnConcurrentUpdateEvent concurrentUpdateSessionInfo = null;
     protected Access access = new Access();
     protected Integer originalGraphHash;
-
-    private class LoadGraphLatch {
-
-        private int dtGraphElementCount;
-        private Command onAllDocumentGraphEntriesLoadedCommand;
-        private ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand;
-
-        private LoadGraphLatch( final int dtGraphElementCount,
-                                final ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand ) {
-            this( dtGraphElementCount,
-                  onDocumentGraphEntryLoadedCommand,
-                  () -> {/*Do nothing*/} );
-        }
-
-        private LoadGraphLatch( final int dtGraphElementCount,
-                                final ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand,
-                                final Command onAllDocumentGraphEntriesLoadedCommand ) {
-            this.dtGraphElementCount = dtGraphElementCount;
-            this.onDocumentGraphEntryLoadedCommand = onDocumentGraphEntryLoadedCommand;
-            this.onAllDocumentGraphEntriesLoadedCommand = onAllDocumentGraphEntriesLoadedCommand;
-        }
-
-        private void onDocumentGraphEntryLoaded( final GuidedDecisionTableView.Presenter dtPresenter ) {
-            if ( onDocumentGraphEntryLoadedCommand != null ) {
-                onDocumentGraphEntryLoadedCommand.execute( dtPresenter );
-            }
-        }
-
-        private void hideLoadingIndicator() {
-            dtGraphElementCount--;
-            if ( dtGraphElementCount == 0 ) {
-                if ( onAllDocumentGraphEntriesLoadedCommand != null ) {
-                    onAllDocumentGraphEntriesLoadedCommand.execute();
-                }
-                view.hideBusyIndicator();
-            }
-        }
-
-        private void loadDocumentGraphEntry( final GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry entry ) {
-            final PathPlaceRequest placeRequest = getPathPlaceRequest( entry.getPathHead() );
-            final ObservablePath pathHead = placeRequest.getPath();
-            final Path pathVersion = entry.getPathVersion();
-            final Double x = entry.getX();
-            final Double y = entry.getY();
-
-            if ( isReadOnly() ) {
-                placeRequest.addParameter( "readOnly", "" );
-            }
-
-            service.call( getLoadDocumentGraphEntryContentSuccessCallback( pathHead,
-                                                                           placeRequest,
-                                                                           x,
-                                                                           y ),
-                          getLoadErrorCallback() ).loadContent( pathVersion );
-        }
-
-        private RemoteCallback<GuidedDecisionTableEditorContent> getLoadDocumentGraphEntryContentSuccessCallback( final ObservablePath path,
-                                                                                                                  final PlaceRequest placeRequest,
-                                                                                                                  final Double x,
-                                                                                                                  final Double y ) {
-            return ( content ) -> {
-                //Path is set to null when the Editor is closed (which can happen before async calls complete).
-                if ( path == null ) {
-                    return;
-                }
-
-                //Add Decision Table to modeller
-                final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable( path,
-                                                                                                 placeRequest,
-                                                                                                 content,
-                                                                                                 placeRequest.getParameter( "readOnly", null ) != null,
-                                                                                                 x,
-                                                                                                 y );
-                registerDocument( dtPresenter );
-
-                onDocumentGraphEntryLoaded( dtPresenter );
-
-                hideLoadingIndicator();
-            };
-        }
-
-        private void loadDocument( final ObservablePath path,
-                                   final PlaceRequest placeRequest ) {
-            service.call( getLoadContentSuccessCallback( path,
-                                                         placeRequest ),
-                          getLoadErrorCallback() ).loadContent( path );
-        }
-
-        private RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback( final ObservablePath path,
-                                                                                                final PlaceRequest placeRequest ) {
-            return ( content ) -> {
-                //Path is set to null when the Editor is closed (which can happen before async calls complete).
-                if ( path == null ) {
-                    return;
-                }
-
-                //Add Decision Table to modeller
-                final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable( path,
-                                                                                                 placeRequest,
-                                                                                                 content,
-                                                                                                 placeRequest.getParameter( "readOnly", null ) != null,
-                                                                                                 null,
-                                                                                                 null );
-                registerDocument( dtPresenter );
-
-                onDocumentGraphEntryLoaded( dtPresenter );
-
-                hideLoadingIndicator();
-            };
-        }
-
-        private DefaultErrorCallback getLoadErrorCallback() {
-            final CommandDrivenErrorCallback wrapped = getNoSuchFileExceptionErrorCallback();
-            final DefaultErrorCallback callback = new DefaultErrorCallback() {
-                @Override
-                public boolean error( final Message message,
-                                      final Throwable throwable ) {
-                    hideLoadingIndicator();
-                    return wrapped.error( message,
-                                          throwable );
-                }
-            };
-            return callback;
-        }
-
-    }
-
-    private class SaveGraphLatch {
-
-        private int dtGraphElementCount = 0;
-        private final String commitMessage;
-
-        private SaveGraphLatch( final int dtGraphElementCount,
-                                final String commitMessage ) {
-            this.dtGraphElementCount = dtGraphElementCount;
-            this.commitMessage = commitMessage;
-        }
-
-        private void saveDocumentGraph() {
-            dtGraphElementCount--;
-            if ( dtGraphElementCount > 0 ) {
-                return;
-            }
-
-            final GuidedDecisionTableEditorGraphModel model = buildModelFromEditor();
-            graphService.call( new RemoteCallback<Path>() {
-                                   @Override
-                                   public void callback( final Path path ) {
-                                       editorView.hideBusyIndicator();
-                                       versionRecordManager.reloadVersions( path );
-                                       originalGraphHash = model.hashCode();
-                                       concurrentUpdateSessionInfo = null;
-                                       notificationEvent.fire( new NotificationEvent( CommonConstants.INSTANCE.ItemSavedSuccessfully() ) );
-                                   }
-                               },
-                               new HasBusyIndicatorDefaultErrorCallback( view ) ).save( editorPath,
-                                                                                        model,
-                                                                                        content.getOverview().getMetadata(),
-                                                                                        commitMessage );
-        }
-
-        private void saveDocumentGraphEntry( final GuidedDecisionTableView.Presenter dtPresenter ) {
-            final ObservablePath path = dtPresenter.getCurrentPath();
-            final GuidedDecisionTable52 model = dtPresenter.getModel();
-            final Metadata metadata = dtPresenter.getOverview().getMetadata();
-
-            service.call( getSaveSuccessCallback( dtPresenter,
-                                                  model.hashCode() ),
-                          getSaveErrorCallback() ).save( path,
-                                                         model,
-                                                         metadata,
-                                                         commitMessage );
-        }
-
-        private RemoteCallback<Path> getSaveSuccessCallback( final GuidedDecisionTableView.Presenter document,
-                                                             final int currentHashCode ) {
-            return ( path ) -> {
-                document.setConcurrentUpdateSessionInfo( null );
-                document.setOriginalHashCode( currentHashCode );
-                saveDocumentGraph();
-            };
-        }
-
-        private DefaultErrorCallback getSaveErrorCallback() {
-            return new HasBusyIndicatorDefaultErrorCallback( view ) {
-                @Override
-                public boolean error( final Message message,
-                                      final Throwable throwable ) {
-                    saveDocumentGraph();
-                    return super.error( message,
-                                        throwable );
-                }
-            };
-        }
-
-    }
+    private GuidedDecisionTableEditorGraphContent content;
+    private LoadGraphLatch loadGraphLatch = null;
+    private SaveGraphLatch saveGraphLatch = null;
+    private ProjectContext context;
+    private NewGuidedDecisionTableWizardHelper helper;
 
     @Inject
-    public GuidedDecisionTableGraphEditorPresenter( final View view,
-                                                    final Caller<GuidedDecisionTableEditorService> service,
-                                                    final Caller<GuidedDecisionTableGraphEditorService> graphService,
-                                                    final Event<NotificationEvent> notification,
-                                                    final Event<SaveInProgressEvent> saveInProgressEvent,
-                                                    final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
-                                                    final ValidationPopup validationPopup,
-                                                    final GuidedDTableGraphResourceType dtGraphResourceType,
-                                                    final EditMenuBuilder editMenuBuilder,
-                                                    final ViewMenuBuilder viewMenuBuilder,
-                                                    final InsertMenuBuilder insertMenuBuilder,
-                                                    final RadarMenuBuilder radarMenuBuilder,
-                                                    final GuidedDecisionTableModellerView.Presenter modeller,
-                                                    final ProjectContext context,
-                                                    final NewGuidedDecisionTableWizardHelper helper,
-                                                    final SyncBeanManager beanManager,
-                                                    final PlaceManager placeManager,
-                                                    final LockManager lockManager ) {
-        super( view,
-               service,
-               notification,
-               decisionTableSelectedEvent,
-               validationPopup,
-               dtGraphResourceType,
-               editMenuBuilder,
-               viewMenuBuilder,
-               insertMenuBuilder,
-               radarMenuBuilder,
-               modeller,
-               beanManager,
-               placeManager );
+    public GuidedDecisionTableGraphEditorPresenter(final View view,
+                                                   final Caller<GuidedDecisionTableEditorService> service,
+                                                   final Caller<GuidedDecisionTableGraphEditorService> graphService,
+                                                   final Event<NotificationEvent> notification,
+                                                   final Event<SaveInProgressEvent> saveInProgressEvent,
+                                                   final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
+                                                   final ValidationPopup validationPopup,
+                                                   final GuidedDTableGraphResourceType dtGraphResourceType,
+                                                   final EditMenuBuilder editMenuBuilder,
+                                                   final ViewMenuBuilder viewMenuBuilder,
+                                                   final InsertMenuBuilder insertMenuBuilder,
+                                                   final RadarMenuBuilder radarMenuBuilder,
+                                                   final GuidedDecisionTableModellerView.Presenter modeller,
+                                                   final ProjectContext context,
+                                                   final NewGuidedDecisionTableWizardHelper helper,
+                                                   final SyncBeanManager beanManager,
+                                                   final PlaceManager placeManager,
+                                                   final LockManager lockManager) {
+        super(view,
+              service,
+              notification,
+              decisionTableSelectedEvent,
+              validationPopup,
+              dtGraphResourceType,
+              editMenuBuilder,
+              viewMenuBuilder,
+              insertMenuBuilder,
+              radarMenuBuilder,
+              modeller,
+              beanManager,
+              placeManager);
         this.graphService = graphService;
         this.saveInProgressEvent = saveInProgressEvent;
         this.context = context;
@@ -352,41 +157,41 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
         super.init();
 
         //Selecting a Decision Table in the document selector fires a selection event
-        registeredDocumentsMenuBuilder.setActivateDocumentCommand( ( document ) -> {
-            final GuidedDecisionTablePresenter dtPresenter = ( (GuidedDecisionTablePresenter) document );
-            decisionTableSelectedEvent.fire( new DecisionTableSelectedEvent( dtPresenter ) );
-        } );
+        registeredDocumentsMenuBuilder.setActivateDocumentCommand((document) -> {
+            final GuidedDecisionTablePresenter dtPresenter = ((GuidedDecisionTablePresenter) document);
+            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dtPresenter));
+        });
 
         //Removing a Decision Table from the document selector is equivalent to closing the editor
-        registeredDocumentsMenuBuilder.setRemoveDocumentCommand( ( document ) -> {
-            final GuidedDecisionTablePresenter dtPresenter = ( (GuidedDecisionTablePresenter) document );
-            if ( mayClose( dtPresenter ) ) {
-                removeDocument( dtPresenter );
+        registeredDocumentsMenuBuilder.setRemoveDocumentCommand((document) -> {
+            final GuidedDecisionTablePresenter dtPresenter = ((GuidedDecisionTablePresenter) document);
+            if (mayClose(dtPresenter)) {
+                removeDocument(dtPresenter);
             }
-        } );
+        });
 
-        registeredDocumentsMenuBuilder.setNewDocumentCommand( this::onNewDocument );
+        registeredDocumentsMenuBuilder.setNewDocumentCommand(this::onNewDocument);
     }
 
     void onNewDocument() {
         final Path contextPath = context.getActivePackage().getPackageMainResourcesPath();
-        helper.createNewGuidedDecisionTable( contextPath,
-                                             "",
-                                             GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY,
-                                             GuidedDecisionTable52.HitPolicy.NONE,
-                                             view,
-                                             ( path ) -> onOpenDocumentsInEditor( Collections.singletonList( path ) ) );
+        helper.createNewGuidedDecisionTable(contextPath,
+                                            "",
+                                            GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY,
+                                            GuidedDecisionTable52.HitPolicy.NONE,
+                                            view,
+                                            (path) -> onOpenDocumentsInEditor(Collections.singletonList(path)));
     }
 
     @Override
     @OnStartup
-    public void onStartup( final ObservablePath path,
-                           final PlaceRequest placeRequest ) {
-        super.onStartup( path,
-                         placeRequest );
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest placeRequest) {
+        super.onStartup(path,
+                        placeRequest);
 
-        initialiseEditor( path,
-                          placeRequest );
+        initialiseEditor(path,
+                         placeRequest);
     }
 
     @Override
@@ -396,42 +201,43 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     }
 
     @Override
-    public void loadDocument( final ObservablePath path,
-                              final PlaceRequest placeRequest ) {
+    public void loadDocument(final ObservablePath path,
+                             final PlaceRequest placeRequest) {
         throw new UnsupportedOperationException();
     }
 
-    void initialiseEditor( final ObservablePath path,
-                           final PlaceRequest placeRequest ) {
-        this.access.setReadOnly( placeRequest.getParameter( "readOnly", null ) != null );
+    void initialiseEditor(final ObservablePath path,
+                          final PlaceRequest placeRequest) {
+        this.access.setReadOnly(placeRequest.getParameter("readOnly",
+                                                          null) != null);
 
         initialiseLockManager();
         initialiseVersionManager();
-        addFileChangeListeners( path );
+        addFileChangeListeners(path);
 
-        loadDocumentGraph( path );
+        loadDocumentGraph(path);
     }
 
     void initialiseVersionManager() {
-        versionRecordManager.init( null,
-                                   editorPath,
-                                   ( versionRecord ) -> {
-                                       versionRecordManager.setVersion( versionRecord.id() );
-                                       access.setReadOnly( !versionRecordManager.isLatest( versionRecord ) );
-                                       registeredDocumentsMenuBuilder.setReadOnly( isReadOnly() );
-                                       reload();
-                                   } );
+        versionRecordManager.init(null,
+                                  editorPath,
+                                  (versionRecord) -> {
+                                      versionRecordManager.setVersion(versionRecord.id());
+                                      access.setReadOnly(!versionRecordManager.isLatest(versionRecord));
+                                      registeredDocumentsMenuBuilder.setReadOnly(isReadOnly());
+                                      reload();
+                                  });
     }
 
-    void loadDocumentGraph( final ObservablePath path ) {
+    void loadDocumentGraph(final ObservablePath path) {
         view.showLoading();
-        view.refreshTitle( getTitleText() );
-        graphService.call( getLoadGraphContentSuccessCallback(),
-                           getNoSuchFileExceptionErrorCallback() ).loadContent( path );
+        view.refreshTitle(getTitleText());
+        graphService.call(getLoadGraphContentSuccessCallback(),
+                          getNoSuchFileExceptionErrorCallback()).loadContent(path);
     }
 
     private RemoteCallback<GuidedDecisionTableEditorGraphContent> getLoadGraphContentSuccessCallback() {
-        return ( content ) -> {
+        return (content) -> {
             this.content = content;
             this.originalGraphHash = content.getModel().hashCode();
             this.concurrentUpdateSessionInfo = null;
@@ -440,38 +246,38 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
 
             initialiseEditorTabsWhenNoDocuments();
 
-            if ( modelEntries == null || modelEntries.isEmpty() ) {
+            if (modelEntries == null || modelEntries.isEmpty()) {
                 view.hideBusyIndicator();
                 return;
             }
 
-            loadGraphLatch = new LoadGraphLatch( modelEntries.size(),
-                                                 getSelectDecisionTableCommand( modelEntries.iterator().next().getPathHead() ),
-                                                 () -> originalGraphHash = buildModelFromEditor().hashCode() );
+            loadGraphLatch = new LoadGraphLatch(modelEntries.size(),
+                                                getSelectDecisionTableCommand(modelEntries.iterator().next().getPathHead()),
+                                                () -> originalGraphHash = buildModelFromEditor().hashCode());
 
-            modelEntries.stream().forEach( loadGraphLatch::loadDocumentGraphEntry );
+            modelEntries.stream().forEach(loadGraphLatch::loadDocumentGraphEntry);
         };
     }
 
-    private ParameterizedCommand<GuidedDecisionTableView.Presenter> getSelectDecisionTableCommand( final Path dtToSelectPath ) {
-        return ( dtPresenter ) -> {
-            if ( dtPresenter.getCurrentPath().getOriginal().equals( dtToSelectPath ) ) {
-                decisionTableSelectedEvent.fire( new DecisionTableSelectedEvent( dtPresenter,
-                                                                                 false ) );
+    private ParameterizedCommand<GuidedDecisionTableView.Presenter> getSelectDecisionTableCommand(final Path dtToSelectPath) {
+        return (dtPresenter) -> {
+            if (dtPresenter.getCurrentPath().getOriginal().equals(dtToSelectPath)) {
+                decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dtPresenter,
+                                                                               false));
             }
         };
     }
 
-    PathPlaceRequest getPathPlaceRequest( final Path path ) {
-        return new PathPlaceRequest( path );
+    PathPlaceRequest getPathPlaceRequest(final Path path) {
+        return new PathPlaceRequest(path);
     }
 
     void initialiseLockManager() {
-        lockManager.init( new LockTarget( editorPath,
-                                          view.asWidget(),
-                                          editorPlaceRequest,
-                                          () -> editorPath.getFileName() + " - " + resourceType.getDescription(),
-                                          () -> {/*nothing*/} ) );
+        lockManager.init(new LockTarget(editorPath,
+                                        view.asWidget(),
+                                        editorPlaceRequest,
+                                        () -> editorPath.getFileName() + " - " + resourceType.getDescription(),
+                                        () -> {/*nothing*/}));
     }
 
     @Override
@@ -495,19 +301,39 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     @Override
     @OnMayClose
     public boolean mayClose() {
-        boolean mayClose = mayClose( originalGraphHash,
-                                     buildModelFromEditor().hashCode() );
+        setMayCloseHandler(this::doMayCloseGraph);
+        boolean mayClose = mayClose(originalGraphHash,
+                                    buildModelFromEditor().hashCode());
+        setMayCloseHandler(this::doMayCloseDocument);
         mayClose = mayClose && super.mayClose();
         return mayClose;
     }
 
+    private boolean doMayCloseGraph(final Integer originalHashCode,
+                                    final Integer currentHashCode) {
+        if (this.isDirty(originalHashCode,
+                         currentHashCode) || overviewWidget.isDirty()) {
+            return this.editorView.confirmClose();
+        }
+        return true;
+    }
+
+    private boolean doMayCloseDocument(final Integer originalHashCode,
+                                       final Integer currentHashCode) {
+        if (this.isDirty(originalHashCode,
+                         currentHashCode)) {
+            return this.editorView.confirmClose();
+        }
+        return true;
+    }
+
     GuidedDecisionTableEditorGraphModel buildModelFromEditor() {
         final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel();
-        for ( GuidedDecisionTableView.Presenter dtPresenter : modeller.getAvailableDecisionTables() ) {
-            model.getEntries().add( new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry( dtPresenter.getLatestPath(),
-                                                                                                           dtPresenter.getCurrentPath(),
-                                                                                                           dtPresenter.getView().getX(),
-                                                                                                           dtPresenter.getView().getY() ) );
+        for (GuidedDecisionTableView.Presenter dtPresenter : modeller.getAvailableDecisionTables()) {
+            model.getEntries().add(new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry(dtPresenter.getLatestPath(),
+                                                                                                         dtPresenter.getCurrentPath(),
+                                                                                                         dtPresenter.getView().getX(),
+                                                                                                         dtPresenter.getView().getY()));
         }
         return model;
     }
@@ -520,11 +346,11 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     }
 
     @Override
-    protected void onDecisionTableSelected( final @Observes DecisionTableSelectedEvent event ) {
-        super.onDecisionTableSelected( event );
+    protected void onDecisionTableSelected(final @Observes DecisionTableSelectedEvent event) {
+        super.onDecisionTableSelected(event);
 
-        if ( event.isLockRequired() ) {
-            if ( !isReadOnly() ) {
+        if (event.isLockRequired()) {
+            if (!isReadOnly()) {
                 lockManager.acquireLock();
             }
         }
@@ -533,63 +359,63 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     @Override
     public void makeMenuBar() {
         this.menus = fileMenuBuilder
-                .addSave( getSaveMenuItem() )
-                .addCopy( versionRecordManager::getCurrentPath,
-                          fileNameValidator )
-                .addRename( versionRecordManager::getPathToLatest,
-                            fileNameValidator )
-                .addDelete( versionRecordManager::getPathToLatest )
-                .addValidate( () -> onValidate( getActiveDocument() ) )
-                .addNewTopLevelMenu( getEditMenuItem() )
-                .addNewTopLevelMenu( getViewMenuItem() )
-                .addNewTopLevelMenu( getInsertMenuItem() )
-                .addNewTopLevelMenu( getRadarMenuItem() )
-                .addNewTopLevelMenu( getRegisteredDocumentsMenuItem() )
-                .addNewTopLevelMenu( getVersionManagerMenuItem() )
+                .addSave(getSaveMenuItem())
+                .addCopy(versionRecordManager::getCurrentPath,
+                         fileNameValidator)
+                .addRename(versionRecordManager::getPathToLatest,
+                           fileNameValidator)
+                .addDelete(versionRecordManager::getPathToLatest)
+                .addValidate(() -> onValidate(getActiveDocument()))
+                .addNewTopLevelMenu(getEditMenuItem())
+                .addNewTopLevelMenu(getViewMenuItem())
+                .addNewTopLevelMenu(getInsertMenuItem())
+                .addNewTopLevelMenu(getRadarMenuItem())
+                .addNewTopLevelMenu(getRegisteredDocumentsMenuItem())
+                .addNewTopLevelMenu(getVersionManagerMenuItem())
                 .build();
     }
 
     @Override
-    protected void enableMenus( final boolean enabled ) {
-        super.enableMenus( enabled );
-        getRegisteredDocumentsMenuItem().setEnabled( enabled );
+    protected void enableMenus(final boolean enabled) {
+        super.enableMenus(enabled);
+        getRegisteredDocumentsMenuItem().setEnabled(enabled);
     }
 
     @Override
-    public void getAvailableDocumentPaths( final Callback<List<Path>> callback ) {
+    public void getAvailableDocumentPaths(final Callback<List<Path>> callback) {
         view.showLoading();
-        graphService.call( new RemoteCallback<List<Path>>() {
-                               @Override
-                               public void callback( final List<Path> paths ) {
-                                   view.hideBusyIndicator();
-                                   callback.callback( paths );
-                               }
-                           },
-                           new HasBusyIndicatorDefaultErrorCallback( view ) ).listDecisionTablesInPackage( editorPath );
+        graphService.call(new RemoteCallback<List<Path>>() {
+                              @Override
+                              public void callback(final List<Path> paths) {
+                                  view.hideBusyIndicator();
+                                  callback.callback(paths);
+                              }
+                          },
+                          new HasBusyIndicatorDefaultErrorCallback(view)).listDecisionTablesInPackage(editorPath);
     }
 
     @Override
-    public void onOpenDocumentsInEditor( final List<Path> selectedDocumentPaths ) {
-        if ( selectedDocumentPaths == null || selectedDocumentPaths.isEmpty() ) {
+    public void onOpenDocumentsInEditor(final List<Path> selectedDocumentPaths) {
+        if (selectedDocumentPaths == null || selectedDocumentPaths.isEmpty()) {
             return;
         }
 
         view.showLoading();
 
-        loadGraphLatch = new LoadGraphLatch( selectedDocumentPaths.size(),
-                                             getSelectDecisionTableCommand( selectedDocumentPaths.get( 0 ) ) );
+        loadGraphLatch = new LoadGraphLatch(selectedDocumentPaths.size(),
+                                            getSelectDecisionTableCommand(selectedDocumentPaths.get(0)));
 
-        selectedDocumentPaths.stream().forEach( ( p ) -> {
-            final PathPlaceRequest placeRequest = getPathPlaceRequest( p );
-            loadGraphLatch.loadDocument( placeRequest.getPath(),
-                                         placeRequest );
-        } );
+        selectedDocumentPaths.stream().forEach((p) -> {
+            final PathPlaceRequest placeRequest = getPathPlaceRequest(p);
+            loadGraphLatch.loadDocument(placeRequest.getPath(),
+                                        placeRequest);
+        });
     }
 
     @Override
     protected void doSave() {
-        if ( isReadOnly() ) {
-            if ( versionRecordManager.isCurrentLatest() ) {
+        if (isReadOnly()) {
+            if (versionRecordManager.isCurrentLatest()) {
                 view.alertReadOnly();
                 return;
             } else {
@@ -598,19 +424,19 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
             }
         }
 
-        final Set<GuidedDecisionTableView.Presenter> allDecisionTables = new HashSet<>( modeller.getAvailableDecisionTables() );
+        final Set<GuidedDecisionTableView.Presenter> allDecisionTables = new HashSet<>(modeller.getAvailableDecisionTables());
         final Set<ObservablePath.OnConcurrentUpdateEvent> concurrentUpdateSessionInfos = new HashSet<>();
-        allDecisionTables.stream().forEach( dtPresenter -> {
+        allDecisionTables.stream().forEach(dtPresenter -> {
             final ObservablePath.OnConcurrentUpdateEvent concurrentUpdateSessionInfo = dtPresenter.getConcurrentUpdateSessionInfo();
-            if ( concurrentUpdateSessionInfo != null ) {
-                concurrentUpdateSessionInfos.add( concurrentUpdateSessionInfo );
+            if (concurrentUpdateSessionInfo != null) {
+                concurrentUpdateSessionInfos.add(concurrentUpdateSessionInfo);
             }
-        } );
-        if ( concurrentUpdateSessionInfo != null ) {
-            concurrentUpdateSessionInfos.add( concurrentUpdateSessionInfo );
+        });
+        if (concurrentUpdateSessionInfo != null) {
+            concurrentUpdateSessionInfos.add(concurrentUpdateSessionInfo);
         }
 
-        if ( !concurrentUpdateSessionInfos.isEmpty() ) {
+        if (!concurrentUpdateSessionInfos.isEmpty()) {
             showConcurrentUpdatesPopup();
         } else {
             saveDocumentGraphEntries();
@@ -618,116 +444,116 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     }
 
     void showConcurrentUpdatesPopup() {
-        newConcurrentUpdate( concurrentUpdateSessionInfo.getPath(),
-                             concurrentUpdateSessionInfo.getIdentity(),
-                             this::saveDocumentGraphEntries,
-                             () -> {/*Do nothing*/},
-                             this::reload ).show();
+        newConcurrentUpdate(concurrentUpdateSessionInfo.getPath(),
+                            concurrentUpdateSessionInfo.getIdentity(),
+                            this::saveDocumentGraphEntries,
+                            () -> {/*Do nothing*/},
+                            this::reload).show();
     }
 
     void saveDocumentGraphEntries() {
-        final Set<GuidedDecisionTableView.Presenter> allDecisionTables = new HashSet<>( modeller.getAvailableDecisionTables() );
-        savePopUpPresenter.show( editorPath,
-                                 ( commitMessage ) -> {
-                                     editorView.showSaving();
-                                     saveGraphLatch = new SaveGraphLatch( allDecisionTables.size(),
-                                                                          commitMessage );
-                                     allDecisionTables.stream().forEach( ( dtPresenter ) -> {
-                                         saveGraphLatch.saveDocumentGraphEntry( dtPresenter );
-                                         saveInProgressEvent.fire( new SaveInProgressEvent( dtPresenter.getLatestPath() ) );
-                                     } );
-                                 } );
+        final Set<GuidedDecisionTableView.Presenter> allDecisionTables = new HashSet<>(modeller.getAvailableDecisionTables());
+        savePopUpPresenter.show(editorPath,
+                                (commitMessage) -> {
+                                    editorView.showSaving();
+                                    saveGraphLatch = new SaveGraphLatch(allDecisionTables.size(),
+                                                                        commitMessage);
+                                    allDecisionTables.stream().forEach((dtPresenter) -> {
+                                        saveGraphLatch.saveDocumentGraphEntry(dtPresenter);
+                                        saveInProgressEvent.fire(new SaveInProgressEvent(dtPresenter.getLatestPath()));
+                                    });
+                                });
     }
 
     @Override
-    protected void initialiseVersionManager( final GuidedDecisionTableView.Presenter dtPresenter ) {
+    protected void initialiseVersionManager(final GuidedDecisionTableView.Presenter dtPresenter) {
         //Do nothing. We maintain a single VersionRecordManager for the graph itself.
     }
 
     @Override
-    protected void initialiseKieEditorTabs( final GuidedDecisionTableView.Presenter document,
-                                            final Overview overview,
-                                            final AsyncPackageDataModelOracle dmo,
-                                            final Imports imports,
-                                            final boolean isReadOnly ) {
+    protected void initialiseKieEditorTabs(final GuidedDecisionTableView.Presenter document,
+                                           final Overview overview,
+                                           final AsyncPackageDataModelOracle dmo,
+                                           final Imports imports,
+                                           final boolean isReadOnly) {
         kieEditorWrapperView.clear();
-        kieEditorWrapperView.addMainEditorPage( editorView );
-        kieEditorWrapperView.addOverviewPage( overviewWidget,
-                                              () -> overviewWidget.refresh( versionRecordManager.getVersion() ) );
-        kieEditorWrapperView.addSourcePage( sourceWidget );
-        kieEditorWrapperView.addImportsTab( importsWidget );
-        overviewWidget.setContent( content.getOverview(),
-                                   versionRecordManager.getPathToLatest() );
-        importsWidget.setContent( dmo,
-                                  imports,
-                                  isReadOnly );
+        kieEditorWrapperView.addMainEditorPage(editorView);
+        kieEditorWrapperView.addOverviewPage(overviewWidget,
+                                             () -> overviewWidget.refresh(versionRecordManager.getVersion()));
+        kieEditorWrapperView.addSourcePage(sourceWidget);
+        kieEditorWrapperView.addImportsTab(importsWidget);
+        overviewWidget.setContent(content.getOverview(),
+                                  versionRecordManager.getPathToLatest());
+        importsWidget.setContent(dmo,
+                                 imports,
+                                 isReadOnly);
     }
 
     void initialiseEditorTabsWhenNoDocuments() {
-        getEditMenuItem().setEnabled( false );
-        getViewMenuItem().setEnabled( false );
-        getInsertMenuItem().setEnabled( false );
-        getRadarMenuItem().setEnabled( false );
-        enableMenuItem( false,
-                        MenuItems.VALIDATE );
+        getEditMenuItem().setEnabled(false);
+        getViewMenuItem().setEnabled(false);
+        getInsertMenuItem().setEnabled(false);
+        getRadarMenuItem().setEnabled(false);
+        enableMenuItem(false,
+                       MenuItems.VALIDATE);
 
         kieEditorWrapperView.clear();
-        kieEditorWrapperView.addMainEditorPage( editorView );
-        kieEditorWrapperView.addOverviewPage( overviewWidget,
-                                              () -> overviewWidget.refresh( versionRecordManager.getVersion() ) );
-        overviewWidget.setContent( content.getOverview(),
-                                   versionRecordManager.getPathToLatest() );
+        kieEditorWrapperView.addMainEditorPage(editorView);
+        kieEditorWrapperView.addOverviewPage(overviewWidget,
+                                             () -> overviewWidget.refresh(versionRecordManager.getVersion()));
+        overviewWidget.setContent(content.getOverview(),
+                                  versionRecordManager.getPathToLatest());
     }
 
-    void addFileChangeListeners( final ObservablePath path ) {
-        path.onRename( this::onRename );
-        path.onDelete( this::onDelete );
+    void addFileChangeListeners(final ObservablePath path) {
+        path.onRename(this::onRename);
+        path.onDelete(this::onDelete);
 
-        path.onConcurrentUpdate( ( info ) -> concurrentUpdateSessionInfo = info );
+        path.onConcurrentUpdate((info) -> concurrentUpdateSessionInfo = info);
 
-        path.onConcurrentRename( ( info ) -> newConcurrentRename( info.getSource(),
-                                                                  info.getTarget(),
-                                                                  info.getIdentity(),
-                                                                  () -> enableMenus( false ),
-                                                                  this::reload ).show() );
+        path.onConcurrentRename((info) -> newConcurrentRename(info.getSource(),
+                                                              info.getTarget(),
+                                                              info.getIdentity(),
+                                                              () -> enableMenus(false),
+                                                              this::reload).show());
 
-        path.onConcurrentDelete( ( info ) -> newConcurrentDelete( info.getPath(),
-                                                                  info.getIdentity(),
-                                                                  () -> enableMenus( false ),
-                                                                  () -> placeManager.closePlace( editorPlaceRequest ) ).show() );
+        path.onConcurrentDelete((info) -> newConcurrentDelete(info.getPath(),
+                                                              info.getIdentity(),
+                                                              () -> enableMenus(false),
+                                                              () -> placeManager.closePlace(editorPlaceRequest)).show());
     }
 
     void onDelete() {
-        scheduleClosure( () -> placeManager.forceClosePlace( editorPlaceRequest ) );
+        scheduleClosure(() -> placeManager.forceClosePlace(editorPlaceRequest));
     }
 
-    void scheduleClosure( final Scheduler.ScheduledCommand command ) {
-        Scheduler.get().scheduleDeferred( command );
+    void scheduleClosure(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 
     void onRename() {
         reload();
-        changeTitleEvent.fire( new ChangeTitleWidgetEvent( editorPlaceRequest,
-                                                           getTitleText(),
-                                                           editorView.getTitleWidget() ) );
+        changeTitleEvent.fire(new ChangeTitleWidgetEvent(editorPlaceRequest,
+                                                         getTitleText(),
+                                                         editorView.getTitleWidget()));
     }
 
     void reload() {
-        final List<GuidedDecisionTableView.Presenter> documents = new ArrayList<>( this.documents );
-        documents.stream().forEach( this::deregisterDocument );
+        final List<GuidedDecisionTableView.Presenter> documents = new ArrayList<>(this.documents);
+        documents.stream().forEach(this::deregisterDocument);
         modeller.getView().clear();
         modeller.releaseDecisionTables();
-        loadDocumentGraph( versionRecordManager.getCurrentPath() );
+        loadDocumentGraph(versionRecordManager.getCurrentPath());
     }
 
-    void onRestore( final @Observes RestoreEvent restore ) {
-        if ( versionRecordManager.getCurrentPath() == null || restore == null || restore.getPath() == null ) {
+    void onRestore(final @Observes RestoreEvent restore) {
+        if (versionRecordManager.getCurrentPath() == null || restore == null || restore.getPath() == null) {
             return;
         }
-        if ( versionRecordManager.getCurrentPath().equals( restore.getPath() ) ) {
-            initialiseEditor( versionRecordManager.getPathToLatest(),
-                              editorPlaceRequest );
-            notification.fire( new NotificationEvent( CommonConstants.INSTANCE.ItemRestored() ) );
+        if (versionRecordManager.getCurrentPath().equals(restore.getPath())) {
+            initialiseEditor(versionRecordManager.getPathToLatest(),
+                             editorPlaceRequest);
+            notification.fire(new NotificationEvent(CommonConstants.INSTANCE.ItemRestored()));
         }
     }
 
@@ -735,17 +561,213 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
         return !this.access.isEditable();
     }
 
-    void onUpdatedLockStatusEvent( final @Observes UpdatedLockStatusEvent event ) {
-        if ( editorPath == null ) {
+    void onUpdatedLockStatusEvent(final @Observes UpdatedLockStatusEvent event) {
+        if (editorPath == null) {
             return;
         }
-        if ( editorPath.equals( event.getFile() ) ) {
-            if ( event.isLocked() ) {
-                access.setLock( event.isLockedByCurrentUser() ? CURRENT_USER : OTHER_USER );
+        if (editorPath.equals(event.getFile())) {
+            if (event.isLocked()) {
+                access.setLock(event.isLockedByCurrentUser() ? CURRENT_USER : OTHER_USER);
             } else {
-                access.setLock( NOBODY );
+                access.setLock(NOBODY);
             }
         }
     }
 
+    private class LoadGraphLatch {
+
+        private int dtGraphElementCount;
+        private Command onAllDocumentGraphEntriesLoadedCommand;
+        private ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand;
+
+        private LoadGraphLatch(final int dtGraphElementCount,
+                               final ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand) {
+            this(dtGraphElementCount,
+                 onDocumentGraphEntryLoadedCommand,
+                 () -> {/*Do nothing*/});
+        }
+
+        private LoadGraphLatch(final int dtGraphElementCount,
+                               final ParameterizedCommand<GuidedDecisionTableView.Presenter> onDocumentGraphEntryLoadedCommand,
+                               final Command onAllDocumentGraphEntriesLoadedCommand) {
+            this.dtGraphElementCount = dtGraphElementCount;
+            this.onDocumentGraphEntryLoadedCommand = onDocumentGraphEntryLoadedCommand;
+            this.onAllDocumentGraphEntriesLoadedCommand = onAllDocumentGraphEntriesLoadedCommand;
+        }
+
+        private void onDocumentGraphEntryLoaded(final GuidedDecisionTableView.Presenter dtPresenter) {
+            if (onDocumentGraphEntryLoadedCommand != null) {
+                onDocumentGraphEntryLoadedCommand.execute(dtPresenter);
+            }
+        }
+
+        private void hideLoadingIndicator() {
+            dtGraphElementCount--;
+            if (dtGraphElementCount == 0) {
+                if (onAllDocumentGraphEntriesLoadedCommand != null) {
+                    onAllDocumentGraphEntriesLoadedCommand.execute();
+                }
+                view.hideBusyIndicator();
+            }
+        }
+
+        private void loadDocumentGraphEntry(final GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry entry) {
+            final PathPlaceRequest placeRequest = getPathPlaceRequest(entry.getPathHead());
+            final ObservablePath pathHead = placeRequest.getPath();
+            final Path pathVersion = entry.getPathVersion();
+            final Double x = entry.getX();
+            final Double y = entry.getY();
+
+            if (isReadOnly()) {
+                placeRequest.addParameter("readOnly",
+                                          "");
+            }
+
+            service.call(getLoadDocumentGraphEntryContentSuccessCallback(pathHead,
+                                                                         placeRequest,
+                                                                         x,
+                                                                         y),
+                         getLoadErrorCallback()).loadContent(pathVersion);
+        }
+
+        private RemoteCallback<GuidedDecisionTableEditorContent> getLoadDocumentGraphEntryContentSuccessCallback(final ObservablePath path,
+                                                                                                                 final PlaceRequest placeRequest,
+                                                                                                                 final Double x,
+                                                                                                                 final Double y) {
+            return (content) -> {
+                //Path is set to null when the Editor is closed (which can happen before async calls complete).
+                if (path == null) {
+                    return;
+                }
+
+                //Add Decision Table to modeller
+                final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable(path,
+                                                                                                placeRequest,
+                                                                                                content,
+                                                                                                placeRequest.getParameter("readOnly",
+                                                                                                                          null) != null,
+                                                                                                x,
+                                                                                                y);
+                registerDocument(dtPresenter);
+
+                onDocumentGraphEntryLoaded(dtPresenter);
+
+                hideLoadingIndicator();
+            };
+        }
+
+        private void loadDocument(final ObservablePath path,
+                                  final PlaceRequest placeRequest) {
+            service.call(getLoadContentSuccessCallback(path,
+                                                       placeRequest),
+                         getLoadErrorCallback()).loadContent(path);
+        }
+
+        private RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback(final ObservablePath path,
+                                                                                               final PlaceRequest placeRequest) {
+            return (content) -> {
+                //Path is set to null when the Editor is closed (which can happen before async calls complete).
+                if (path == null) {
+                    return;
+                }
+
+                //Add Decision Table to modeller
+                final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable(path,
+                                                                                                placeRequest,
+                                                                                                content,
+                                                                                                placeRequest.getParameter("readOnly",
+                                                                                                                          null) != null,
+                                                                                                null,
+                                                                                                null);
+                registerDocument(dtPresenter);
+
+                onDocumentGraphEntryLoaded(dtPresenter);
+
+                hideLoadingIndicator();
+            };
+        }
+
+        private DefaultErrorCallback getLoadErrorCallback() {
+            final CommandDrivenErrorCallback wrapped = getNoSuchFileExceptionErrorCallback();
+            final DefaultErrorCallback callback = new DefaultErrorCallback() {
+                @Override
+                public boolean error(final Message message,
+                                     final Throwable throwable) {
+                    hideLoadingIndicator();
+                    return wrapped.error(message,
+                                         throwable);
+                }
+            };
+            return callback;
+        }
+    }
+
+    private class SaveGraphLatch {
+
+        private final String commitMessage;
+        private int dtGraphElementCount = 0;
+
+        private SaveGraphLatch(final int dtGraphElementCount,
+                               final String commitMessage) {
+            this.dtGraphElementCount = dtGraphElementCount;
+            this.commitMessage = commitMessage;
+        }
+
+        private void saveDocumentGraph() {
+            dtGraphElementCount--;
+            if (dtGraphElementCount > 0) {
+                return;
+            }
+
+            final GuidedDecisionTableEditorGraphModel model = buildModelFromEditor();
+            graphService.call(new RemoteCallback<Path>() {
+                                  @Override
+                                  public void callback(final Path path) {
+                                      editorView.hideBusyIndicator();
+                                      versionRecordManager.reloadVersions(path);
+                                      originalGraphHash = model.hashCode();
+                                      concurrentUpdateSessionInfo = null;
+                                      notificationEvent.fire(new NotificationEvent(CommonConstants.INSTANCE.ItemSavedSuccessfully()));
+                                  }
+                              },
+                              new HasBusyIndicatorDefaultErrorCallback(view)).save(editorPath,
+                                                                                   model,
+                                                                                   content.getOverview().getMetadata(),
+                                                                                   commitMessage);
+        }
+
+        private void saveDocumentGraphEntry(final GuidedDecisionTableView.Presenter dtPresenter) {
+            final ObservablePath path = dtPresenter.getCurrentPath();
+            final GuidedDecisionTable52 model = dtPresenter.getModel();
+            final Metadata metadata = dtPresenter.getOverview().getMetadata();
+
+            service.call(getSaveSuccessCallback(dtPresenter,
+                                                model.hashCode()),
+                         getSaveErrorCallback()).save(path,
+                                                      model,
+                                                      metadata,
+                                                      commitMessage);
+        }
+
+        private RemoteCallback<Path> getSaveSuccessCallback(final GuidedDecisionTableView.Presenter document,
+                                                            final int currentHashCode) {
+            return (path) -> {
+                document.setConcurrentUpdateSessionInfo(null);
+                document.setOriginalHashCode(currentHashCode);
+                saveDocumentGraph();
+            };
+        }
+
+        private DefaultErrorCallback getSaveErrorCallback() {
+            return new HasBusyIndicatorDefaultErrorCallback(view) {
+                @Override
+                public boolean error(final Message message,
+                                     final Throwable throwable) {
+                    saveDocumentGraph();
+                    return super.error(message,
+                                       throwable);
+                }
+            };
+        }
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
@@ -142,53 +142,53 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
     @Captor
     private ArgumentCaptor<RemoteCallback<Path>> onSaveSuccessCallbackCaptor;
 
-    private Event<SaveInProgressEvent> saveInProgressEvent = spy( new EventSourceMock<SaveInProgressEvent>() {
+    private Event<SaveInProgressEvent> saveInProgressEvent = spy(new EventSourceMock<SaveInProgressEvent>() {
         @Override
-        public void fire( final SaveInProgressEvent event ) {
+        public void fire(final SaveInProgressEvent event) {
             //Do nothing
         }
-    } );
+    });
 
     private GuidedDTableGraphResourceType dtGraphResourceType = new GuidedDTableGraphResourceType();
 
     @Before
     public void setup() {
-        this.dtGraphServiceCaller = new CallerMock<>( dtGraphService );
+        this.dtGraphServiceCaller = new CallerMock<>(dtGraphService);
 
-        when( view.asWidget() ).thenReturn( mock( Widget.class ) );
-        when( context.getActivePackage() ).thenReturn( activePackage );
-        when( activePackage.getPackageMainResourcesPath() ).thenReturn( activePackageResourcesPath );
+        when(view.asWidget()).thenReturn(mock(Widget.class));
+        when(context.getActivePackage()).thenReturn(activePackage);
+        when(activePackage.getPackageMainResourcesPath()).thenReturn(activePackageResourcesPath);
 
         super.setup();
     }
 
     @Override
     protected GuidedDecisionTableGraphEditorPresenter getPresenter() {
-        return new GuidedDecisionTableGraphEditorPresenter( view,
-                                                            dtServiceCaller,
-                                                            dtGraphServiceCaller,
-                                                            notification,
-                                                            saveInProgressEvent,
-                                                            decisionTableSelectedEvent,
-                                                            validationPopup,
-                                                            dtGraphResourceType,
-                                                            editMenuBuilder,
-                                                            viewMenuBuilder,
-                                                            insertMenuBuilder,
-                                                            radarMenuBuilder,
-                                                            modeller,
-                                                            context,
-                                                            helper,
-                                                            beanManager,
-                                                            placeManager,
-                                                            lockManager ) {
+        return new GuidedDecisionTableGraphEditorPresenter(view,
+                                                           dtServiceCaller,
+                                                           dtGraphServiceCaller,
+                                                           notification,
+                                                           saveInProgressEvent,
+                                                           decisionTableSelectedEvent,
+                                                           validationPopup,
+                                                           dtGraphResourceType,
+                                                           editMenuBuilder,
+                                                           viewMenuBuilder,
+                                                           insertMenuBuilder,
+                                                           radarMenuBuilder,
+                                                           modeller,
+                                                           context,
+                                                           helper,
+                                                           beanManager,
+                                                           placeManager,
+                                                           lockManager) {
             @Override
-            PathPlaceRequest getPathPlaceRequest( final Path path ) {
+            PathPlaceRequest getPathPlaceRequest(final Path path) {
                 //Avoid use of IOC.getBeanManager().lookupBean(..) in PathPlaceRequest for Unit Tests
-                final PathPlaceRequest pathPlaceRequest = new PathPlaceRequest( path ) {
+                final PathPlaceRequest pathPlaceRequest = new PathPlaceRequest(path) {
                     @Override
-                    protected ObservablePath createObservablePath( final Path path ) {
-                        final ObservablePath op = new ObservablePathImpl().wrap( path );
+                    protected ObservablePath createObservablePath(final Path path) {
+                        final ObservablePath op = new ObservablePathImpl().wrap(path);
                         return op;
                     }
                 };
@@ -200,381 +200,388 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
     @Test
     @SuppressWarnings("unchecked")
     public void checkInit() {
-        verify( viewMenuBuilder,
-                times( 1 ) ).setModeller( eq( modeller ) );
-        verify( insertMenuBuilder,
-                times( 1 ) ).setModeller( eq( modeller ) );
-        verify( radarMenuBuilder,
-                times( 1 ) ).setModeller( eq( modeller ) );
-        verify( view,
-                times( 1 ) ).setModellerView( eq( modellerView ) );
+        verify(viewMenuBuilder,
+               times(1)).setModeller(eq(modeller));
+        verify(insertMenuBuilder,
+               times(1)).setModeller(eq(modeller));
+        verify(radarMenuBuilder,
+               times(1)).setModeller(eq(modeller));
+        verify(view,
+               times(1)).setModellerView(eq(modellerView));
 
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setActivateDocumentCommand( any( ParameterizedCommand.class ) );
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setRemoveDocumentCommand( any( ParameterizedCommand.class ) );
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setNewDocumentCommand( any( Command.class ) );
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setActivateDocumentCommand(any(ParameterizedCommand.class));
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setRemoveDocumentCommand(any(ParameterizedCommand.class));
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setNewDocumentCommand(any(Command.class));
     }
 
     @Test
     public void checkInitActivateDocumentFromRegisteredDocumentMenu() {
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setActivateDocumentCommand( activateDocumentCommandCaptor.capture() );
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setActivateDocumentCommand(activateDocumentCommandCaptor.capture());
 
-        final GuidedDecisionTablePresenter dtPresenter = mock( GuidedDecisionTablePresenter.class );
+        final GuidedDecisionTablePresenter dtPresenter = mock(GuidedDecisionTablePresenter.class);
 
         final ParameterizedCommand<KieDocument> activeDocumentCommand = activateDocumentCommandCaptor.getValue();
-        assertNotNull( activeDocumentCommand );
-        activeDocumentCommand.execute( dtPresenter );
-        verify( decisionTableSelectedEvent,
-                times( 1 ) ).fire( dtSelectedEventCaptor.capture() );
-        assertNotNull( dtSelectedEventCaptor.getValue() );
-        assertEquals( dtPresenter,
-                      dtSelectedEventCaptor.getValue().getPresenter() );
+        assertNotNull(activeDocumentCommand);
+        activeDocumentCommand.execute(dtPresenter);
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
+        assertNotNull(dtSelectedEventCaptor.getValue());
+        assertEquals(dtPresenter,
+                     dtSelectedEventCaptor.getValue().getPresenter());
     }
 
     @Test
     public void checkInitRemoveDocumentFromRegisteredDocumentMenu() {
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setRemoveDocumentCommand( removeDocumentCommandCaptor.capture() );
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setRemoveDocumentCommand(removeDocumentCommandCaptor.capture());
 
-        final GuidedDecisionTablePresenter dtPresenter = mock( GuidedDecisionTablePresenter.class );
+        final GuidedDecisionTablePresenter dtPresenter = mock(GuidedDecisionTablePresenter.class);
 
-        doReturn( true ).when( presenter ).mayClose( eq( dtPresenter ) );
-        doNothing().when( presenter ).removeDocument( any( GuidedDecisionTablePresenter.class ) );
+        doReturn(true).when(presenter).mayClose(eq(dtPresenter));
+        doNothing().when(presenter).removeDocument(any(GuidedDecisionTablePresenter.class));
 
         final ParameterizedCommand<KieDocument> removeDocumentCommand = removeDocumentCommandCaptor.getValue();
-        assertNotNull( removeDocumentCommand );
-        removeDocumentCommand.execute( dtPresenter );
-        verify( presenter,
-                times( 1 ) ).mayClose( eq( dtPresenter ) );
-        verify( presenter,
-                times( 1 ) ).removeDocument( eq( dtPresenter ) );
+        assertNotNull(removeDocumentCommand);
+        removeDocumentCommand.execute(dtPresenter);
+        verify(presenter,
+               times(1)).mayClose(eq(dtPresenter));
+        verify(presenter,
+               times(1)).removeDocument(eq(dtPresenter));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void checkInitNewDocumentFromRegisteredDocumentMenu() {
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setNewDocumentCommand( newDocumentCommandCaptor.capture() );
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setNewDocumentCommand(newDocumentCommandCaptor.capture());
 
         final Command newDocumentCommand = newDocumentCommandCaptor.getValue();
-        assertNotNull( newDocumentCommand );
+        assertNotNull(newDocumentCommand);
         newDocumentCommand.execute();
 
-        verify( presenter,
-                times( 1 ) ).onNewDocument();
-        verify( helper,
-                times( 1 ) ).createNewGuidedDecisionTable( eq( activePackageResourcesPath ),
-                                                           eq( "" ),
-                                                           eq( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY ),
-                                                           eq( GuidedDecisionTable52.HitPolicy.NONE ),
-                                                           eq( view ),
-                                                           onSaveSuccessCallbackCaptor.capture() );
+        verify(presenter,
+               times(1)).onNewDocument();
+        verify(helper,
+               times(1)).createNewGuidedDecisionTable(eq(activePackageResourcesPath),
+                                                      eq(""),
+                                                      eq(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY),
+                                                      eq(GuidedDecisionTable52.HitPolicy.NONE),
+                                                      eq(view),
+                                                      onSaveSuccessCallbackCaptor.capture());
 
-        final Path dtPath = mock( Path.class );
+        final Path dtPath = mock(Path.class);
         final RemoteCallback<Path> onSaveSuccessCallback = onSaveSuccessCallbackCaptor.getValue();
-        assertNotNull( onSaveSuccessCallback );
+        assertNotNull(onSaveSuccessCallback);
 
-        doNothing().when( presenter ).onOpenDocumentsInEditor( any( List.class ) );
+        doNothing().when(presenter).onOpenDocumentsInEditor(any(List.class));
 
-        onSaveSuccessCallback.callback( dtPath );
+        onSaveSuccessCallback.callback(dtPath);
 
-        verify( presenter,
-                times( 1 ) ).onOpenDocumentsInEditor( dtPathsCaptor.capture() );
+        verify(presenter,
+               times(1)).onOpenDocumentsInEditor(dtPathsCaptor.capture());
 
         final List<Path> dtPaths = dtPathsCaptor.getValue();
-        assertNotNull( dtPaths );
-        assertEquals( 1,
-                      dtPaths.size() );
-        assertEquals( dtPath,
-                      dtPaths.get( 0 ) );
+        assertNotNull(dtPaths);
+        assertEquals(1,
+                     dtPaths.size());
+        assertEquals(dtPath,
+                     dtPaths.get(0));
     }
 
     @Test
     public void testSetupMenuBar() {
-        verify( fileMenuBuilder,
-                times( 1 ) ).addSave( any( MenuItem.class ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addCopy( any( BasicFileMenuBuilder.PathProvider.class ),
-                                      eq( fileNameValidator ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addRename( any( BasicFileMenuBuilder.PathProvider.class ),
-                                        eq( fileNameValidator ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addDelete( any( BasicFileMenuBuilder.PathProvider.class ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addValidate( any( Command.class ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( editMenuItem ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( viewMenuItem ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( insertMenuItem ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( radarMenuItem ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( versionManagerMenuItem ) );
-        verify( fileMenuBuilder,
-                times( 1 ) ).addNewTopLevelMenu( eq( registeredDocumentsMenuItem ) );
+        verify(fileMenuBuilder,
+               times(1)).addSave(any(MenuItem.class));
+        verify(fileMenuBuilder,
+               times(1)).addCopy(any(BasicFileMenuBuilder.PathProvider.class),
+                                 eq(fileNameValidator));
+        verify(fileMenuBuilder,
+               times(1)).addRename(any(BasicFileMenuBuilder.PathProvider.class),
+                                   eq(fileNameValidator));
+        verify(fileMenuBuilder,
+               times(1)).addDelete(any(BasicFileMenuBuilder.PathProvider.class));
+        verify(fileMenuBuilder,
+               times(1)).addValidate(any(Command.class));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(editMenuItem));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(viewMenuItem));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(insertMenuItem));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(radarMenuItem));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(versionManagerMenuItem));
+        verify(fileMenuBuilder,
+               times(1)).addNewTopLevelMenu(eq(registeredDocumentsMenuItem));
     }
 
     @Test
     public void checkOnStartupBasicInitialisation() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( INITIAL_HASH_CODE );
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent(INITIAL_HASH_CODE);
 
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
+        when(dtGraphPath.getFileName()).thenReturn("filename");
 
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
 
-        assertEquals( dtGraphPath,
-                      presenter.editorPath );
-        assertEquals( dtGraphPlaceRequest,
-                      presenter.editorPlaceRequest );
-        assertEquals( INITIAL_HASH_CODE,
-                      (int) presenter.originalGraphHash );
+        assertEquals(dtGraphPath,
+                     presenter.editorPath);
+        assertEquals(dtGraphPlaceRequest,
+                     presenter.editorPlaceRequest);
+        assertEquals(INITIAL_HASH_CODE,
+                     (int) presenter.originalGraphHash);
 
-        verify( presenter,
-                times( 1 ) ).initialiseEditor( eq( dtGraphPath ),
-                                               eq( dtGraphPlaceRequest ) );
-        verify( presenter,
-                times( 1 ) ).initialiseVersionManager();
-        verify( presenter,
-                times( 1 ) ).addFileChangeListeners( eq( dtGraphPath ) );
+        verify(presenter,
+               times(1)).initialiseEditor(eq(dtGraphPath),
+                                          eq(dtGraphPlaceRequest));
+        verify(presenter,
+               times(1)).initialiseVersionManager();
+        verify(presenter,
+               times(1)).addFileChangeListeners(eq(dtGraphPath));
 
-        verify( lockManager,
-                times( 1 ) ).init( lockTargetCaptor.capture() );
+        verify(lockManager,
+               times(1)).init(lockTargetCaptor.capture());
 
         final LockTarget lockTarget = lockTargetCaptor.getValue();
-        assertNotNull( lockTarget );
-        assertEquals( dtGraphPath,
-                      lockTarget.getPath() );
-        assertEquals( dtGraphPlaceRequest,
-                      lockTarget.getPlace() );
-        assertNotNull( lockTarget.getTitle() );
+        assertNotNull(lockTarget);
+        assertEquals(dtGraphPath,
+                     lockTarget.getPath());
+        assertEquals(dtGraphPlaceRequest,
+                     lockTarget.getPlace());
+        assertNotNull(lockTarget.getTitle());
     }
 
     @Test
     public void checkOnStartupLoadGraphEntries() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( INITIAL_HASH_CODE );
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent(INITIAL_HASH_CODE);
 
-        final Path dtPath = mock( Path.class );
+        final Path dtPath = mock(Path.class);
         final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent();
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtGraphPath,
-                                                                                 dtGraphPlaceRequest,
-                                                                                 dtContent );
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtGraphPath,
+                                                                                dtGraphPlaceRequest,
+                                                                                dtContent);
 
-        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry( dtPath,
-                                                                                              dtPath );
-        dtGraphContent.getModel().getEntries().add( dtGraphEntry );
+        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry(dtPath,
+                                                                                             dtPath);
+        dtGraphContent.getModel().getEntries().add(dtGraphEntry);
 
-        when( dtPath.toURI() ).thenReturn( "dtPath" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtPath.toURI()).thenReturn("dtPath");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath))).thenReturn(dtContent);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
         //Fake building of Graph Model from Editor to control hashCode
-        doReturn( makeDecisionTableGraphContent( EDITOR_HASH_CODE ).getModel() ).when( presenter ).buildModelFromEditor();
+        doReturn(makeDecisionTableGraphContent(EDITOR_HASH_CODE).getModel()).when(presenter).buildModelFromEditor();
 
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
 
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
 
-        verify( view,
-                times( 1 ) ).showLoading();
-        verify( presenter,
-                times( 1 ) ).loadDocumentGraph( eq( dtGraphPath ) );
+        verify(view,
+               times(1)).showLoading();
+        verify(presenter,
+               times(1)).loadDocumentGraph(eq(dtGraphPath));
 
-        verify( dtService,
-                times( 1 ) ).loadContent( eq( dtPath ) );
-        verify( modeller,
-                times( 1 ) ).addDecisionTable( dtObservablePathCaptor.capture(),
-                                               dtPathPlaceRequestCaptor.capture(),
-                                               eq( dtContent ),
-                                               any( Boolean.class ),
-                                               eq( null ),
-                                               eq( null ) );
+        verify(dtService,
+               times(1)).loadContent(eq(dtPath));
+        verify(modeller,
+               times(1)).addDecisionTable(dtObservablePathCaptor.capture(),
+                                          dtPathPlaceRequestCaptor.capture(),
+                                          eq(dtContent),
+                                          any(Boolean.class),
+                                          eq(null),
+                                          eq(null));
         final ObservablePath dtObservablePath = dtObservablePathCaptor.getValue();
         final PathPlaceRequest dtPathPlaceRequest = dtPathPlaceRequestCaptor.getValue();
-        assertNotNull( dtObservablePath );
-        assertNotNull( dtPathPlaceRequest );
-        assertEquals( dtPath.toURI(),
-                      dtObservablePath.toURI() );
-        assertEquals( dtPath.toURI(),
-                      dtPathPlaceRequest.getPath().toURI() );
-        assertEquals( EDITOR_HASH_CODE,
-                      (int) presenter.originalGraphHash );
+        assertNotNull(dtObservablePath);
+        assertNotNull(dtPathPlaceRequest);
+        assertEquals(dtPath.toURI(),
+                     dtObservablePath.toURI());
+        assertEquals(dtPath.toURI(),
+                     dtPathPlaceRequest.getPath().toURI());
+        assertEquals(EDITOR_HASH_CODE,
+                     (int) presenter.originalGraphHash);
 
-        verify( presenter,
-                times( 1 ) ).registerDocument( eq( dtPresenter ) );
-        verify( view,
-                times( 1 ) ).hideBusyIndicator();
+        verify(presenter,
+               times(1)).registerDocument(eq(dtPresenter));
+        verify(view,
+               times(1)).hideBusyIndicator();
 
-        verify( decisionTableSelectedEvent,
-                times( 1 ) ).fire( dtSelectedEventCaptor.capture() );
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
         final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
-        assertNotNull( dtSelectedEvent );
-        assertNotNull( dtSelectedEvent.getPresenter() );
-        assertEquals( dtPresenter,
-                      dtSelectedEvent.getPresenter() );
+        assertNotNull(dtSelectedEvent);
+        assertNotNull(dtSelectedEvent.getPresenter());
+        assertEquals(dtPresenter,
+                     dtSelectedEvent.getPresenter());
 
-        verify( lockManager,
-                never() ).acquireLock();
+        verify(lockManager,
+               never()).acquireLock();
     }
 
     @Test
     public void checkMayCloseWithCleanDecisionTableGraph() {
-        checkMayClose( 0,
-                       () -> assertTrue( presenter.mayClose() ) );
+        checkMayClose(0,
+                      () -> assertTrue(presenter.mayClose()));
     }
 
     @Test
     public void checkMayCloseWithDirtyDecisionTableGraph() {
-        checkMayClose( 1,
-                       () -> assertFalse( presenter.mayClose() ) );
+        checkMayClose(1,
+                      () -> assertFalse(presenter.mayClose()));
     }
 
-    private void checkMayClose( final int uiModelHashCode,
-                                final Command assertion ) {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( 0 );
+    private void checkMayClose(final int uiModelHashCode,
+                               final Command assertion) {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent(0);
 
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
-        doReturn( makeDecisionTableGraphContent( uiModelHashCode ).getModel() ).when( presenter ).buildModelFromEditor();
+        doReturn(makeDecisionTableGraphContent(uiModelHashCode).getModel()).when(presenter).buildModelFromEditor();
 
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
 
         assertion.execute();
     }
 
     @Test
     public void checkMayCloseWithCleanDecisionTableGraphEntries() {
-        checkMayCloseWithDecisionTableGraphEntries( 0,
-                                                    () -> assertTrue( presenter.mayClose() ) );
+        checkMayCloseWithDecisionTableGraphEntries(0,
+                                                   () -> assertTrue(presenter.mayClose()));
+    }
+
+    @Test
+    public void checkMayCloseWithCleanDecisionTableGraphEntriesButDirtyGraphOverview() {
+        when(overviewWidget.isDirty()).thenReturn(true);
+        checkMayCloseWithDecisionTableGraphEntries(0,
+                                                   () -> assertFalse(presenter.mayClose()));
     }
 
     @Test
     public void checkMayCloseWithDirtyDecisionTableGraphEntries() {
-        checkMayCloseWithDecisionTableGraphEntries( 1,
-                                                    () -> assertFalse( presenter.mayClose() ) );
+        checkMayCloseWithDecisionTableGraphEntries(1,
+                                                   () -> assertFalse(presenter.mayClose()));
     }
 
-    private void checkMayCloseWithDecisionTableGraphEntries( final int uiModelHashCode,
-                                                             final Command assertion ) {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
+    private void checkMayCloseWithDecisionTableGraphEntries(final int uiModelHashCode,
+                                                            final Command assertion) {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
         final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
 
-        final ObservablePath dtPath = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtPath,
-                                                                                 dtPlaceRequest,
-                                                                                 dtContent );
+        final ObservablePath dtPath = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtPath,
+                                                                                dtPlaceRequest,
+                                                                                dtContent);
 
-        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry( dtPath,
-                                                                                              dtPath );
-        dtGraphContent.getModel().getEntries().add( dtGraphEntry );
+        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry(dtPath,
+                                                                                             dtPath);
+        dtGraphContent.getModel().getEntries().add(dtGraphEntry);
 
-        when( dtPath.toURI() ).thenReturn( "dtPath" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtPath.toURI()).thenReturn("dtPath");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath))).thenReturn(dtContent);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
-        when( dtPresenter.getOriginalHashCode() ).thenReturn( uiModelHashCode );
-        doReturn( makeDecisionTableGraphContent( uiModelHashCode ).getModel() ).when( presenter ).buildModelFromEditor();
+        when(dtPresenter.getOriginalHashCode()).thenReturn(uiModelHashCode);
+        doReturn(makeDecisionTableGraphContent(uiModelHashCode).getModel()).when(presenter).buildModelFromEditor();
 
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter );
-        }} );
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+        }});
 
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
 
         assertion.execute();
     }
 
     @Test
     public void checkBuildModelFromEditor() {
-        final ObservablePath dtPath1 = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest1 = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent1 = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter1 = makeDecisionTable( dtPath1,
-                                                                                  dtPath1,
-                                                                                  dtPlaceRequest1,
-                                                                                  dtContent1 );
+        final ObservablePath dtPath1 = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest1 = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent1 = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter1 = makeDecisionTable(dtPath1,
+                                                                                 dtPath1,
+                                                                                 dtPlaceRequest1,
+                                                                                 dtContent1);
 
-        final ObservablePath dtPath2 = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest2 = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent2 = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter2 = makeDecisionTable( dtPath2,
-                                                                                  dtPath2,
-                                                                                  dtPlaceRequest2,
-                                                                                  dtContent2 );
+        final ObservablePath dtPath2 = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest2 = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent2 = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter2 = makeDecisionTable(dtPath2,
+                                                                                 dtPath2,
+                                                                                 dtPlaceRequest2,
+                                                                                 dtContent2);
 
-        when( dtPresenter1.getView().getX() ).thenReturn( 100.0 );
-        when( dtPresenter1.getView().getY() ).thenReturn( 110.0 );
-        when( dtPresenter2.getView().getX() ).thenReturn( 200.0 );
-        when( dtPresenter2.getView().getY() ).thenReturn( 220.0 );
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter1 );
-            add( dtPresenter2 );
-        }} );
+        when(dtPresenter1.getView().getX()).thenReturn(100.0);
+        when(dtPresenter1.getView().getY()).thenReturn(110.0);
+        when(dtPresenter2.getView().getX()).thenReturn(200.0);
+        when(dtPresenter2.getView().getY()).thenReturn(220.0);
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter1);
+            add(dtPresenter2);
+        }});
 
         final GuidedDecisionTableEditorGraphModel model = presenter.buildModelFromEditor();
-        assertNotNull( model );
-        assertNotNull( model.getEntries() );
-        assertEquals( 2,
-                      model.getEntries().size() );
-        assertContains( model.getEntries(),
-                        dtPath1,
-                        100.0,
-                        110.0 );
-        assertContains( model.getEntries(),
-                        dtPath2,
-                        200.0,
-                        220.0 );
+        assertNotNull(model);
+        assertNotNull(model.getEntries());
+        assertEquals(2,
+                     model.getEntries().size());
+        assertContains(model.getEntries(),
+                       dtPath1,
+                       100.0,
+                       110.0);
+        assertContains(model.getEntries(),
+                       dtPath2,
+                       200.0,
+                       220.0);
     }
 
-    private void assertContains( final Set<GuidedDecisionTableGraphEntry> entries,
-                                 final ObservablePath path,
-                                 final Double x,
-                                 final Double y ) {
-        if ( entries.stream().filter( ( e ) -> e.getPathHead().equals( path ) && x.equals( e.getX() ) && y.equals( e.getY() ) ).collect( Collectors.toList() ).isEmpty() ) {
-            fail( "Path [" + path.toURI() + " not found in GuidedDecisionTableEditorGraphModel.entries()" );
+    private void assertContains(final Set<GuidedDecisionTableGraphEntry> entries,
+                                final ObservablePath path,
+                                final Double x,
+                                final Double y) {
+        if (entries.stream().filter((e) -> e.getPathHead().equals(path) && x.equals(e.getX()) && y.equals(e.getY())).collect(Collectors.toList()).isEmpty()) {
+            fail("Path [" + path.toURI() + " not found in GuidedDecisionTableEditorGraphModel.entries()");
         }
     }
 
@@ -582,225 +589,225 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
     public void checkOnClose() {
         presenter.onClose();
 
-        verify( modeller,
-                times( 1 ) ).onClose();
-        verify( lockManager,
-                times( 1 ) ).releaseLock();
+        verify(modeller,
+               times(1)).onClose();
+        verify(lockManager,
+               times(1)).releaseLock();
     }
 
     @Test
     public void checkOnDecisionTableSelectedReadOnly() {
-        checkOnDecisionTableSelected( ( dtGraphPlaceRequest ) -> when( dtGraphPlaceRequest.getParameter( eq( "readOnly" ),
-                                                                                                         any() ) ).thenReturn( Boolean.toString( true ) ),
-                                      () -> verify( lockManager,
-                                                    never() ).acquireLock() );
+        checkOnDecisionTableSelected((dtGraphPlaceRequest) -> when(dtGraphPlaceRequest.getParameter(eq("readOnly"),
+                                                                                                    any())).thenReturn(Boolean.toString(true)),
+                                     () -> verify(lockManager,
+                                                  never()).acquireLock());
     }
 
     @Test
     public void checkOnDecisionTableSelectedNotReadOnly() {
-        checkOnDecisionTableSelected( ( dtGraphPlaceRequest ) -> {/*Nothing*/},
-                                      () -> verify( lockManager,
-                                                    times( 1 ) ).acquireLock() );
+        checkOnDecisionTableSelected((dtGraphPlaceRequest) -> {/*Nothing*/},
+                                     () -> verify(lockManager,
+                                                  times(1)).acquireLock());
     }
 
-    private void checkOnDecisionTableSelected( final ParameterizedCommand<PlaceRequest> setup,
-                                               final Command assertion ) {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
+    private void checkOnDecisionTableSelected(final ParameterizedCommand<PlaceRequest> setup,
+                                              final Command assertion) {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
         final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
 
-        final ObservablePath dtPath = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtPath,
-                                                                                 dtPlaceRequest,
-                                                                                 dtContent );
+        final ObservablePath dtPath = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtPath,
+                                                                                dtPlaceRequest,
+                                                                                dtContent);
 
-        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry( dtPath,
-                                                                                              dtPath );
-        dtGraphContent.getModel().getEntries().add( dtGraphEntry );
+        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry(dtPath,
+                                                                                             dtPath);
+        dtGraphContent.getModel().getEntries().add(dtGraphEntry);
 
-        when( dtPath.toURI() ).thenReturn( "dtPath" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtPath.toURI()).thenReturn("dtPath");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath))).thenReturn(dtContent);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter );
-        }} );
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+        }});
 
-        setup.execute( dtGraphPlaceRequest );
+        setup.execute(dtGraphPlaceRequest);
 
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
 
-        final DecisionTableSelectedEvent event = new DecisionTableSelectedEvent( dtPresenter );
+        final DecisionTableSelectedEvent event = new DecisionTableSelectedEvent(dtPresenter);
 
-        presenter.onDecisionTableSelected( event );
+        presenter.onDecisionTableSelected(event);
 
         assertion.execute();
     }
 
     @Test
     public void checkEnableMenus() {
-        presenter.enableMenus( true );
+        presenter.enableMenus(true);
 
-        checkMenuItems( true );
+        checkMenuItems(true);
     }
 
     @Test
     public void checkDisableMenus() {
-        presenter.enableMenus( false );
+        presenter.enableMenus(false);
 
-        checkMenuItems( false );
+        checkMenuItems(false);
     }
 
-    private void checkMenuItems( final boolean enabled ) {
-        verify( saveMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( versionManagerMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( editMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( viewMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( insertMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( radarMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
-        verify( registeredDocumentsMenuItem,
-                times( 1 ) ).setEnabled( eq( enabled ) );
+    private void checkMenuItems(final boolean enabled) {
+        verify(saveMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(versionManagerMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(editMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(viewMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(insertMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(radarMenuItem,
+               times(1)).setEnabled(eq(enabled));
+        verify(registeredDocumentsMenuItem,
+               times(1)).setEnabled(eq(enabled));
     }
 
     @Test
     public void checkGetAvailableDocumentPaths() {
-        when( dtGraphService.listDecisionTablesInPackage( eq( presenter.editorPath ) ) ).thenReturn( new ArrayList<Path>() {{
-            add( PathFactory.newPath( "file1",
-                                      "file1Url" ) );
-        }} );
+        when(dtGraphService.listDecisionTablesInPackage(eq(presenter.editorPath))).thenReturn(new ArrayList<Path>() {{
+            add(PathFactory.newPath("file1",
+                                    "file1Url"));
+        }});
 
-        presenter.getAvailableDocumentPaths( ( List<Path> result ) -> {
-            assertNotNull( result );
-            assertEquals( 1,
-                          result.size() );
-            assertEquals( "file1",
-                          result.get( 0 ).getFileName() );
-            assertEquals( "file1Url",
-                          result.get( 0 ).toURI() );
-        } );
+        presenter.getAvailableDocumentPaths((List<Path> result) -> {
+            assertNotNull(result);
+            assertEquals(1,
+                         result.size());
+            assertEquals("file1",
+                         result.get(0).getFileName());
+            assertEquals("file1Url",
+                         result.get(0).toURI());
+        });
 
-        verify( view,
-                times( 1 ) ).showLoading();
-        verify( dtGraphService,
-                times( 1 ) ).listDecisionTablesInPackage( eq( presenter.editorPath ) );
-        verify( view,
-                times( 1 ) ).hideBusyIndicator();
+        verify(view,
+               times(1)).showLoading();
+        verify(dtGraphService,
+               times(1)).listDecisionTablesInPackage(eq(presenter.editorPath));
+        verify(view,
+               times(1)).hideBusyIndicator();
     }
 
     @Test
     public void checkOnOpenDocumentsInEditor() {
-        final Path dtPath1 = PathFactory.newPath( "file1",
-                                                  "file1Url" );
-        final Path dtPath2 = PathFactory.newPath( "file2",
-                                                  "file2Url" );
+        final Path dtPath1 = PathFactory.newPath("file1",
+                                                 "file1Url");
+        final Path dtPath2 = PathFactory.newPath("file2",
+                                                 "file2Url");
         final List<Path> dtPaths = new ArrayList<Path>() {{
-            add( dtPath1 );
-            add( dtPath2 );
+            add(dtPath1);
+            add(dtPath2);
         }};
 
-        final ObservablePath dtPath = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtPath,
-                                                                                 dtPlaceRequest,
-                                                                                 dtContent );
+        final ObservablePath dtPath = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtPath,
+                                                                                dtPlaceRequest,
+                                                                                dtContent);
 
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
 
-        presenter.onOpenDocumentsInEditor( dtPaths );
+        presenter.onOpenDocumentsInEditor(dtPaths);
 
-        verify( dtService,
-                times( 2 ) ).loadContent( dtPathCaptor.capture() );
+        verify(dtService,
+               times(2)).loadContent(dtPathCaptor.capture());
 
         final List<Path> dtLoadedPaths = dtPathCaptor.getAllValues();
-        assertNotNull( dtLoadedPaths );
-        assertEquals( 2,
-                      dtLoadedPaths.size() );
-        assertContains( dtLoadedPaths,
-                        dtPath1 );
-        assertContains( dtLoadedPaths,
-                        dtPath2 );
+        assertNotNull(dtLoadedPaths);
+        assertEquals(2,
+                     dtLoadedPaths.size());
+        assertContains(dtLoadedPaths,
+                       dtPath1);
+        assertContains(dtLoadedPaths,
+                       dtPath2);
     }
 
-    private void assertContains( final List<Path> paths,
-                                 final Path path ) {
-        if ( paths.stream().filter( ( p ) -> p.toURI().equals( path.toURI() ) ).collect( Collectors.toList() ).isEmpty() ) {
-            fail( "Document for path [" + path.toURI() + "] not loaded by GuidedDecisionTableGraphEditorPresenter.loadDocument()." );
+    private void assertContains(final List<Path> paths,
+                                final Path path) {
+        if (paths.stream().filter((p) -> p.toURI().equals(path.toURI())).collect(Collectors.toList()).isEmpty()) {
+            fail("Document for path [" + path.toURI() + "] not loaded by GuidedDecisionTableGraphEditorPresenter.loadDocument().");
         }
     }
 
     @Test
     public void checkDoSaveWhenReadOnlyWithLatestPath() {
-        when( versionRecordManager.isCurrentLatest() ).thenReturn( true );
-        checkDoSave( ( setup ) -> {
-                         when( setup.getDecisionTableGraphPlaceRequest().getParameter( eq( "readOnly" ),
-                                                                                       any() ) ).thenReturn( Boolean.toString( true ) );
-                         presenter.onStartup( setup.getDecisionTableGraphPath(),
-                                              setup.getDecisionTableGraphPlaceRequest() );
-                     },
-                     () -> verify( view,
-                                   times( 1 ) ).alertReadOnly() );
+        when(versionRecordManager.isCurrentLatest()).thenReturn(true);
+        checkDoSave((setup) -> {
+                        when(setup.getDecisionTableGraphPlaceRequest().getParameter(eq("readOnly"),
+                                                                                    any())).thenReturn(Boolean.toString(true));
+                        presenter.onStartup(setup.getDecisionTableGraphPath(),
+                                            setup.getDecisionTableGraphPlaceRequest());
+                    },
+                    () -> verify(view,
+                                 times(1)).alertReadOnly());
     }
 
     @Test
     public void checkDoSaveWhenReadOnlyWithHistoricPath() {
-        checkDoSave( ( setup ) -> {
-                         when( setup.getDecisionTableGraphPlaceRequest().getParameter( eq( "readOnly" ),
-                                                                                       any() ) ).thenReturn( Boolean.toString( true ) );
-                         presenter.onStartup( setup.getDecisionTableGraphPath(),
-                                              setup.getDecisionTableGraphPlaceRequest() );
-                     },
-                     () -> verify( versionRecordManager,
-                                   times( 1 ) ).restoreToCurrentVersion() );
+        checkDoSave((setup) -> {
+                        when(setup.getDecisionTableGraphPlaceRequest().getParameter(eq("readOnly"),
+                                                                                    any())).thenReturn(Boolean.toString(true));
+                        presenter.onStartup(setup.getDecisionTableGraphPath(),
+                                            setup.getDecisionTableGraphPlaceRequest());
+                    },
+                    () -> verify(versionRecordManager,
+                                 times(1)).restoreToCurrentVersion());
     }
 
     @Test
     public void checkDoSaveWithConcurrentModificationOfGraph() {
-        doNothing().when( presenter ).showConcurrentUpdatesPopup();
+        doNothing().when(presenter).showConcurrentUpdatesPopup();
 
-        checkDoSave( ( dtGraphPlaceRequest ) -> presenter.concurrentUpdateSessionInfo = mock( OnConcurrentUpdateEvent.class ),
-                     () -> verify( presenter,
-                                   times( 1 ) ).showConcurrentUpdatesPopup() );
+        checkDoSave((dtGraphPlaceRequest) -> presenter.concurrentUpdateSessionInfo = mock(OnConcurrentUpdateEvent.class),
+                    () -> verify(presenter,
+                                 times(1)).showConcurrentUpdatesPopup());
     }
 
-    private void checkDoSave( final ParameterizedCommand<OnSaveSetupDataHolder> setup,
-                              final Command assertion ) {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
+    private void checkDoSave(final ParameterizedCommand<OnSaveSetupDataHolder> setup,
+                             final Command assertion) {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
         final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
 
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
-        setup.execute( new OnSaveSetupDataHolder( dtGraphPath,
-                                                  dtGraphPlaceRequest ) );
+        setup.execute(new OnSaveSetupDataHolder(dtGraphPath,
+                                                dtGraphPlaceRequest));
 
         presenter.doSave();
 
@@ -809,69 +816,429 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
     @Test
     public void checkDoSaveWithConcurrentModificationOfGraphEntry() {
-        doNothing().when( presenter ).showConcurrentUpdatesPopup();
+        doNothing().when(presenter).showConcurrentUpdatesPopup();
 
-        checkDoSaveWithGraphEntry( ( setup ) -> {
-                                       when( setup.getDecisionTablePresenter().getConcurrentUpdateSessionInfo() ).thenReturn( mock( OnConcurrentUpdateEvent.class ) );
-                                       presenter.onStartup( setup.getDecisionTableGraphPath(),
-                                                            setup.getDecisionTableGraphPlaceRequest() );
-                                   },
-                                   () -> verify( presenter,
-                                                 times( 1 ) ).showConcurrentUpdatesPopup() );
+        checkDoSaveWithGraphEntry((setup) -> {
+                                      when(setup.getDecisionTablePresenter().getConcurrentUpdateSessionInfo()).thenReturn(mock(OnConcurrentUpdateEvent.class));
+                                      presenter.onStartup(setup.getDecisionTableGraphPath(),
+                                                          setup.getDecisionTableGraphPlaceRequest());
+                                  },
+                                  () -> verify(presenter,
+                                               times(1)).showConcurrentUpdatesPopup());
     }
 
     @Test
     public void checkDoSaveWithGraphEntry() {
-        doNothing().when( presenter ).saveDocumentGraphEntries();
+        doNothing().when(presenter).saveDocumentGraphEntries();
 
-        checkDoSaveWithGraphEntry( ( setup ) -> presenter.onStartup( setup.getDecisionTableGraphPath(),
-                                                                     setup.getDecisionTableGraphPlaceRequest() ),
-                                   () -> verify( presenter,
-                                                 times( 1 ) ).saveDocumentGraphEntries() );
+        checkDoSaveWithGraphEntry((setup) -> presenter.onStartup(setup.getDecisionTableGraphPath(),
+                                                                 setup.getDecisionTableGraphPlaceRequest()),
+                                  () -> verify(presenter,
+                                               times(1)).saveDocumentGraphEntries());
     }
 
-    private void checkDoSaveWithGraphEntry( final ParameterizedCommand<OnSaveSetupDataHolder> setup,
-                                            final Command assertion ) {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PathPlaceRequest dtGraphPlaceRequest = mock( PathPlaceRequest.class );
+    private void checkDoSaveWithGraphEntry(final ParameterizedCommand<OnSaveSetupDataHolder> setup,
+                                           final Command assertion) {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PathPlaceRequest dtGraphPlaceRequest = mock(PathPlaceRequest.class);
         final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
 
-        final ObservablePath dtPath = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtPath,
-                                                                                 dtPlaceRequest,
-                                                                                 dtContent );
+        final ObservablePath dtPath = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtPath,
+                                                                                dtPlaceRequest,
+                                                                                dtContent);
 
-        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry( dtPath,
-                                                                                              dtPath );
-        dtGraphContent.getModel().getEntries().add( dtGraphEntry );
+        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry(dtPath,
+                                                                                             dtPath);
+        dtGraphContent.getModel().getEntries().add(dtGraphEntry);
 
-        when( dtPath.toURI() ).thenReturn( "dtPath" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+        when(dtPath.toURI()).thenReturn("dtPath");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath))).thenReturn(dtContent);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
 
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter );
-        }} );
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+        }});
 
-        setup.execute( new OnSaveSetupDataHolder( dtGraphPath,
-                                                  dtGraphPlaceRequest,
-                                                  dtPresenter ) );
+        setup.execute(new OnSaveSetupDataHolder(dtGraphPath,
+                                                dtGraphPlaceRequest,
+                                                dtPresenter));
 
         presenter.doSave();
 
         assertion.execute();
+    }
+
+    @Test
+    public void checkSaveDocumentGraphEntries() {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PathPlaceRequest dtGraphPlaceRequest = mock(PathPlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
+
+        final ObservablePath dtPath1 = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest1 = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent1 = makeDecisionTableContent();
+        final GuidedDecisionTableView.Presenter dtPresenter1 = makeDecisionTable(dtPath1,
+                                                                                 dtPath1,
+                                                                                 dtPlaceRequest1,
+                                                                                 dtContent1);
+        final ObservablePath dtPath2 = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest2 = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent2 = makeDecisionTableContent();
+        final GuidedDecisionTableView.Presenter dtPresenter2 = makeDecisionTable(dtPath2,
+                                                                                 dtPath2,
+                                                                                 dtPlaceRequest2,
+                                                                                 dtContent2);
+
+        when(dtPath1.toURI()).thenReturn("dtPath1");
+        when(dtPath2.toURI()).thenReturn("dtPath2");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath1))).thenReturn(dtContent1);
+        when(dtService.loadContent(eq(dtPath2))).thenReturn(dtContent2);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
+
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       eq(dtContent1),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter1);
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       eq(dtContent2),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter2);
+
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter1);
+            add(dtPresenter2);
+        }});
+
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
+
+        presenter.saveDocumentGraphEntries();
+
+        verify(savePopUpPresenter,
+               times(1)).show(any(Path.class),
+                              commitMessageCommandCaptor.capture());
+
+        final ParameterizedCommand<String> commitMessageCommand = commitMessageCommandCaptor.getValue();
+        assertNotNull(commitMessageCommand);
+        commitMessageCommand.execute("message");
+
+        verify(view,
+               times(1)).showSaving();
+        verify(saveInProgressEvent,
+               times(2)).fire(any(SaveInProgressEvent.class));
+        verify(dtGraphService,
+               times(1)).save(eq(dtGraphPath),
+                              any(GuidedDecisionTableEditorGraphModel.class),
+                              any(Metadata.class),
+                              eq("message"));
+        verify(dtService,
+               times(1)).save(eq(dtPath2),
+                              any(GuidedDecisionTable52.class),
+                              any(Metadata.class),
+                              eq("message"));
+        verify(dtService,
+               times(1)).save(eq(dtPath2),
+                              any(GuidedDecisionTable52.class),
+                              any(Metadata.class),
+                              eq("message"));
+        verify(notificationEvent,
+               times(1)).fire(any(NotificationEvent.class));
+        verify(dtPresenter1,
+               times(1)).setConcurrentUpdateSessionInfo(eq(null));
+        verify(dtPresenter2,
+               times(1)).setConcurrentUpdateSessionInfo(eq(null));
+        assertNull(presenter.concurrentUpdateSessionInfo);
+    }
+
+    @Test
+    public void checkInitialiseVersionManager() {
+        doNothing().when(presenter).reload();
+        when(versionRecordManager.isLatest(any(VersionRecord.class))).thenReturn(true);
+
+        presenter.initialiseVersionManager();
+
+        verify(versionRecordManager,
+               times(1)).init(eq(null),
+                              eq(presenter.editorPath),
+                              versionRecordCallbackCaptor.capture());
+
+        final Callback<VersionRecord> versionRecordCallback = versionRecordCallbackCaptor.getValue();
+        assertNotNull(versionRecordCallback);
+        versionRecordCallback.callback(new PortableVersionRecord("id",
+                                                                 "author",
+                                                                 "email",
+                                                                 "comment",
+                                                                 mock(Date.class),
+                                                                 "uri"));
+
+        verify(versionRecordManager,
+               times(1)).setVersion(eq("id"));
+        verify(registeredDocumentsMenuBuilder,
+               times(1)).setReadOnly(eq(false));
+        verify(presenter,
+               times(1)).reload();
+        assertFalse(presenter.access.isReadOnly());
+    }
+
+    @Test
+    public void checkInitialiseKieEditorTabs() {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PlaceRequest dtGraphPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent(0);
+
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
+        when(versionRecordManager.getVersion()).thenReturn("version");
+
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
+
+        verify(kieEditorWrapperView,
+               times(1)).clear();
+
+        final GuidedDecisionTableView.Presenter document = mock(GuidedDecisionTableView.Presenter.class);
+        final AsyncPackageDataModelOracle dmo = mock(AsyncPackageDataModelOracle.class);
+        final Imports imports = mock(Imports.class);
+        final boolean isReadOnly = true;
+
+        final ArgumentCaptor<com.google.gwt.user.client.Command> onFocusCommandCaptor = ArgumentCaptor.forClass(com.google.gwt.user.client.Command.class);
+
+        presenter.initialiseKieEditorTabs(document,
+                                          dtGraphContent.getOverview(),
+                                          dmo,
+                                          imports,
+                                          isReadOnly);
+
+        verify(kieEditorWrapperView,
+               times(2)).clear();
+        verify(kieEditorWrapperView,
+               times(2)).addMainEditorPage(view);
+        verify(kieEditorWrapperView,
+               times(2)).addOverviewPage(eq(overviewWidget),
+                                         onFocusCommandCaptor.capture());
+        verify(overviewWidget,
+               times(2)).setContent(eq(dtGraphContent.getOverview()),
+                                    any(ObservablePath.class));
+
+        verify(kieEditorWrapperView,
+               times(1)).addSourcePage(any(ViewDRLSourceWidget.class));
+        verify(kieEditorWrapperView,
+               times(1)).addImportsTab(eq(importsWidget));
+        verify(importsWidget,
+               times(1)).setContent(eq(dmo),
+                                    eq(imports),
+                                    eq(isReadOnly));
+
+        final com.google.gwt.user.client.Command onFocusCommand = onFocusCommandCaptor.getValue();
+        assertNotNull(onFocusCommand);
+        onFocusCommand.execute();
+
+        verify(overviewWidget,
+               times(1)).refresh(eq("version"));
+    }
+
+    @Test
+    public void checkOnDelete() {
+        final PlaceRequest placeRequest = mock(PlaceRequest.class);
+        presenter.editorPlaceRequest = placeRequest;
+
+        presenter.onDelete();
+
+        final ArgumentCaptor<Scheduler.ScheduledCommand> commandCaptor = ArgumentCaptor.forClass(Scheduler.ScheduledCommand.class);
+
+        verify(presenter,
+               times(1)).scheduleClosure(commandCaptor.capture());
+
+        final Scheduler.ScheduledCommand command = commandCaptor.getValue();
+        assertNotNull(command);
+        command.execute();
+
+        verify(placeManager,
+               times(1)).forceClosePlace(eq(placeRequest));
+    }
+
+    @Test
+    public void checkOnRename() {
+        doNothing().when(presenter).reload();
+        when(versionRecordManager.getCurrentPath()).thenReturn(mock(ObservablePath.class));
+
+        presenter.onRename();
+
+        verify(presenter,
+               times(1)).reload();
+        verify(changeTitleEvent,
+               times(1)).fire(any(ChangeTitleWidgetEvent.class));
+    }
+
+    @Test
+    public void checkReload() {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PathPlaceRequest dtGraphPlaceRequest = mock(PathPlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
+
+        final ObservablePath dtPath = mock(ObservablePath.class);
+        final PlaceRequest dtPlaceRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent(0);
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(dtPath,
+                                                                                dtPath,
+                                                                                dtPlaceRequest,
+                                                                                dtContent);
+
+        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry(dtPath,
+                                                                                             dtPath);
+        dtGraphContent.getModel().getEntries().add(dtGraphEntry);
+
+        when(dtPath.toURI()).thenReturn("dtPath");
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtService.loadContent(eq(dtPath))).thenReturn(dtContent);
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
+
+        when(modeller.addDecisionTable(any(ObservablePath.class),
+                                       any(PlaceRequest.class),
+                                       any(GuidedDecisionTableEditorContent.class),
+                                       any(Boolean.class),
+                                       any(Double.class),
+                                       any(Double.class))).thenReturn(dtPresenter);
+        when(modeller.getAvailableDecisionTables()).thenReturn(new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+        }});
+
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
+
+        verify(presenter,
+               times(1)).loadDocumentGraph(dtGraphPath);
+
+        presenter.reload();
+
+        verify(presenter,
+               times(1)).deregisterDocument(eq(dtPresenter));
+        verify(presenter,
+               times(2)).loadDocumentGraph(dtGraphPath);
+        verify(modeller,
+               times(1)).releaseDecisionTables();
+        verify(modellerView,
+               times(1)).clear();
+    }
+
+    @Test
+    public void checkOnRestore() {
+        final ObservablePath dtGraphPath = mock(ObservablePath.class);
+        final PathPlaceRequest dtGraphPlaceRequest = mock(PathPlaceRequest.class);
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
+        final RestoreEvent event = new RestoreEvent(dtGraphPath);
+
+        when(dtGraphPath.toURI()).thenReturn("dtGraphPath");
+        when(dtGraphPath.getFileName()).thenReturn("filename");
+        when(dtGraphService.loadContent(eq(dtGraphPath))).thenReturn(dtGraphContent);
+        when(versionRecordManager.getCurrentPath()).thenReturn(dtGraphPath);
+        when(versionRecordManager.getPathToLatest()).thenReturn(dtGraphPath);
+
+        presenter.onStartup(dtGraphPath,
+                            dtGraphPlaceRequest);
+
+        verify(presenter,
+               times(1)).initialiseEditor(eq(dtGraphPath),
+                                          eq(dtGraphPlaceRequest));
+
+        presenter.onRestore(event);
+
+        verify(presenter,
+               times(2)).initialiseEditor(eq(dtGraphPath),
+                                          eq(dtGraphPlaceRequest));
+        verify(notification,
+               times(1)).fire(any(NotificationEvent.class));
+    }
+
+    @Test
+    public void checkOnUpdatedLockStatusEventWithNullPath() {
+        checkOnUpdatedLockStatusEvent(null,
+                                      false,
+                                      false,
+                                      () -> assertEquals(LockedBy.NOBODY,
+                                                         presenter.access.getLock()));
+    }
+
+    @Test
+    public void checkOnUpdatedLockStatusEventNotLocked() {
+        checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
+                                      false,
+                                      false,
+                                      () -> assertEquals(LockedBy.NOBODY,
+                                                         presenter.access.getLock()));
+    }
+
+    @Test
+    public void checkOnUpdatedLockStatusEventLockedByOtherUser() {
+        checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
+                                      true,
+                                      false,
+                                      () -> assertEquals(LockedBy.OTHER_USER,
+                                                         presenter.access.getLock()));
+    }
+
+    @Test
+    public void checkOnUpdatedLockStatusEventLockedByCurrentUser() {
+        checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
+                                      true,
+                                      true,
+                                      () -> assertEquals(LockedBy.CURRENT_USER,
+                                                         presenter.access.getLock()));
+    }
+
+    private void checkOnUpdatedLockStatusEvent(final ObservablePath path,
+                                               final boolean locked,
+                                               final boolean lockedByCurrentUser,
+                                               final Command assertion) {
+        presenter.editorPath = path;
+        presenter.access.setLock(LockedBy.NOBODY);
+
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent(path,
+                                                                        locked,
+                                                                        lockedByCurrentUser);
+
+        presenter.onUpdatedLockStatusEvent(event);
+
+        assertion.execute();
+    }
+
+    protected GuidedDecisionTableEditorGraphContent makeDecisionTableGraphContent() {
+        return makeDecisionTableGraphContent(0);
+    }
+
+    protected GuidedDecisionTableEditorGraphContent makeDecisionTableGraphContent(final int hashCode) {
+        final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel() {
+            @Override
+            public int hashCode() {
+                return hashCode;
+            }
+        };
+        return new GuidedDecisionTableEditorGraphContent(model,
+                                                         mock(Overview.class));
     }
 
     private static class OnSaveSetupDataHolder {
@@ -880,16 +1247,16 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
         private PlaceRequest dtGraphPlaceRequest;
         private GuidedDecisionTableView.Presenter dtPresenter;
 
-        public OnSaveSetupDataHolder( final ObservablePath dtGraphPath,
-                                      final PlaceRequest dtGraphPlaceRequest ) {
-            this( dtGraphPath,
-                  dtGraphPlaceRequest,
-                  null );
+        public OnSaveSetupDataHolder(final ObservablePath dtGraphPath,
+                                     final PlaceRequest dtGraphPlaceRequest) {
+            this(dtGraphPath,
+                 dtGraphPlaceRequest,
+                 null);
         }
 
-        public OnSaveSetupDataHolder( final ObservablePath dtGraphPath,
-                                      final PlaceRequest dtGraphPlaceRequest,
-                                      final GuidedDecisionTableView.Presenter dtPresenter ) {
+        public OnSaveSetupDataHolder(final ObservablePath dtGraphPath,
+                                     final PlaceRequest dtGraphPlaceRequest,
+                                     final GuidedDecisionTableView.Presenter dtPresenter) {
             this.dtGraphPath = dtGraphPath;
             this.dtGraphPlaceRequest = dtGraphPlaceRequest;
             this.dtPresenter = dtPresenter;
@@ -907,365 +1274,4 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
             return dtPresenter;
         }
     }
-
-    @Test
-    public void checkSaveDocumentGraphEntries() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PathPlaceRequest dtGraphPlaceRequest = mock( PathPlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
-
-        final ObservablePath dtPath1 = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest1 = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent1 = makeDecisionTableContent();
-        final GuidedDecisionTableView.Presenter dtPresenter1 = makeDecisionTable( dtPath1,
-                                                                                  dtPath1,
-                                                                                  dtPlaceRequest1,
-                                                                                  dtContent1 );
-        final ObservablePath dtPath2 = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest2 = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent2 = makeDecisionTableContent();
-        final GuidedDecisionTableView.Presenter dtPresenter2 = makeDecisionTable( dtPath2,
-                                                                                  dtPath2,
-                                                                                  dtPlaceRequest2,
-                                                                                  dtContent2 );
-
-        when( dtPath1.toURI() ).thenReturn( "dtPath1" );
-        when( dtPath2.toURI() ).thenReturn( "dtPath2" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath1 ) ) ).thenReturn( dtContent1 );
-        when( dtService.loadContent( eq( dtPath2 ) ) ).thenReturn( dtContent2 );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
-
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         eq( dtContent1 ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter1 );
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         eq( dtContent2 ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter2 );
-
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter1 );
-            add( dtPresenter2 );
-        }} );
-
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
-
-        presenter.saveDocumentGraphEntries();
-
-        verify( savePopUpPresenter,
-                times( 1 ) ).show( any( Path.class ),
-                                   commitMessageCommandCaptor.capture() );
-
-        final ParameterizedCommand<String> commitMessageCommand = commitMessageCommandCaptor.getValue();
-        assertNotNull( commitMessageCommand );
-        commitMessageCommand.execute( "message" );
-
-        verify( view,
-                times( 1 ) ).showSaving();
-        verify( saveInProgressEvent,
-                times( 2 ) ).fire( any( SaveInProgressEvent.class ) );
-        verify( dtGraphService,
-                times( 1 ) ).save( eq( dtGraphPath ),
-                                   any( GuidedDecisionTableEditorGraphModel.class ),
-                                   any( Metadata.class ),
-                                   eq( "message" ) );
-        verify( dtService,
-                times( 1 ) ).save( eq( dtPath2 ),
-                                   any( GuidedDecisionTable52.class ),
-                                   any( Metadata.class ),
-                                   eq( "message" ) );
-        verify( dtService,
-                times( 1 ) ).save( eq( dtPath2 ),
-                                   any( GuidedDecisionTable52.class ),
-                                   any( Metadata.class ),
-                                   eq( "message" ) );
-        verify( notificationEvent,
-                times( 1 ) ).fire( any( NotificationEvent.class ) );
-        verify( dtPresenter1,
-                times( 1 ) ).setConcurrentUpdateSessionInfo( eq( null ) );
-        verify( dtPresenter2,
-                times( 1 ) ).setConcurrentUpdateSessionInfo( eq( null ) );
-        assertNull( presenter.concurrentUpdateSessionInfo );
-    }
-
-    @Test
-    public void checkInitialiseVersionManager() {
-        doNothing().when( presenter ).reload();
-        when( versionRecordManager.isLatest( any( VersionRecord.class ) ) ).thenReturn( true );
-
-        presenter.initialiseVersionManager();
-
-        verify( versionRecordManager,
-                times( 1 ) ).init( eq( null ),
-                                   eq( presenter.editorPath ),
-                                   versionRecordCallbackCaptor.capture() );
-
-        final Callback<VersionRecord> versionRecordCallback = versionRecordCallbackCaptor.getValue();
-        assertNotNull( versionRecordCallback );
-        versionRecordCallback.callback( new PortableVersionRecord( "id",
-                                                                   "author",
-                                                                   "email",
-                                                                   "comment",
-                                                                   mock( Date.class ),
-                                                                   "uri" ) );
-
-        verify( versionRecordManager,
-                times( 1 ) ).setVersion( eq( "id" ) );
-        verify( registeredDocumentsMenuBuilder,
-                times( 1 ) ).setReadOnly( eq( false ) );
-        verify( presenter,
-                times( 1 ) ).reload();
-        assertFalse( presenter.access.isReadOnly() );
-    }
-
-    @Test
-    public void checkInitialiseKieEditorTabs() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( 0 );
-
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
-        when( versionRecordManager.getVersion() ).thenReturn( "version" );
-
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
-
-        verify( kieEditorWrapperView,
-                times( 1 ) ).clear();
-
-        final GuidedDecisionTableView.Presenter document = mock( GuidedDecisionTableView.Presenter.class );
-        final AsyncPackageDataModelOracle dmo = mock( AsyncPackageDataModelOracle.class );
-        final Imports imports = mock( Imports.class );
-        final boolean isReadOnly = true;
-
-        final ArgumentCaptor<com.google.gwt.user.client.Command> onFocusCommandCaptor = ArgumentCaptor.forClass( com.google.gwt.user.client.Command.class );
-
-        presenter.initialiseKieEditorTabs( document,
-                                           dtGraphContent.getOverview(),
-                                           dmo,
-                                           imports,
-                                           isReadOnly );
-
-        verify( kieEditorWrapperView,
-                times( 2 ) ).clear();
-        verify( kieEditorWrapperView,
-                times( 2 ) ).addMainEditorPage( view );
-        verify( kieEditorWrapperView,
-                times( 2 ) ).addOverviewPage( eq( overviewWidget ),
-                                              onFocusCommandCaptor.capture() );
-        verify( overviewWidget,
-                times( 2 ) ).setContent( eq( dtGraphContent.getOverview() ),
-                                         any( ObservablePath.class ) );
-
-        verify( kieEditorWrapperView,
-                times( 1 ) ).addSourcePage( any( ViewDRLSourceWidget.class ) );
-        verify( kieEditorWrapperView,
-                times( 1 ) ).addImportsTab( eq( importsWidget ) );
-        verify( importsWidget,
-                times( 1 ) ).setContent( eq( dmo ),
-                                         eq( imports ),
-                                         eq( isReadOnly ) );
-
-        final com.google.gwt.user.client.Command onFocusCommand = onFocusCommandCaptor.getValue();
-        assertNotNull( onFocusCommand );
-        onFocusCommand.execute();
-
-        verify( overviewWidget,
-                times( 1 ) ).refresh( eq( "version" ) );
-    }
-
-    @Test
-    public void checkOnDelete() {
-        final PlaceRequest placeRequest = mock( PlaceRequest.class );
-        presenter.editorPlaceRequest = placeRequest;
-
-        presenter.onDelete();
-
-        final ArgumentCaptor<Scheduler.ScheduledCommand> commandCaptor = ArgumentCaptor.forClass( Scheduler.ScheduledCommand.class );
-
-        verify( presenter,
-                times( 1 ) ).scheduleClosure( commandCaptor.capture() );
-
-        final Scheduler.ScheduledCommand command = commandCaptor.getValue();
-        assertNotNull( command );
-        command.execute();
-
-        verify( placeManager,
-                times( 1 ) ).forceClosePlace( eq( placeRequest ) );
-    }
-
-    @Test
-    public void checkOnRename() {
-        doNothing().when( presenter ).reload();
-        when( versionRecordManager.getCurrentPath() ).thenReturn( mock( ObservablePath.class ) );
-
-        presenter.onRename();
-
-        verify( presenter,
-                times( 1 ) ).reload();
-        verify( changeTitleEvent,
-                times( 1 ) ).fire( any( ChangeTitleWidgetEvent.class ) );
-    }
-
-    @Test
-    public void checkReload() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PathPlaceRequest dtGraphPlaceRequest = mock( PathPlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
-
-        final ObservablePath dtPath = mock( ObservablePath.class );
-        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent( 0 );
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( dtPath,
-                                                                                 dtPath,
-                                                                                 dtPlaceRequest,
-                                                                                 dtContent );
-
-        final GuidedDecisionTableGraphEntry dtGraphEntry = new GuidedDecisionTableGraphEntry( dtPath,
-                                                                                              dtPath );
-        dtGraphContent.getModel().getEntries().add( dtGraphEntry );
-
-        when( dtPath.toURI() ).thenReturn( "dtPath" );
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
-
-        when( modeller.addDecisionTable( any( ObservablePath.class ),
-                                         any( PlaceRequest.class ),
-                                         any( GuidedDecisionTableEditorContent.class ),
-                                         any( Boolean.class ),
-                                         any( Double.class ),
-                                         any( Double.class ) ) ).thenReturn( dtPresenter );
-        when( modeller.getAvailableDecisionTables() ).thenReturn( new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter );
-        }} );
-
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
-
-        verify( presenter,
-                times( 1 ) ).loadDocumentGraph( dtGraphPath );
-
-        presenter.reload();
-
-        verify( presenter,
-                times( 1 ) ).deregisterDocument( eq( dtPresenter ) );
-        verify( presenter,
-                times( 2 ) ).loadDocumentGraph( dtGraphPath );
-        verify( modeller,
-                times( 1 ) ).releaseDecisionTables();
-        verify( modellerView,
-                times( 1 ) ).clear();
-    }
-
-    @Test
-    public void checkOnRestore() {
-        final ObservablePath dtGraphPath = mock( ObservablePath.class );
-        final PathPlaceRequest dtGraphPlaceRequest = mock( PathPlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
-        final RestoreEvent event = new RestoreEvent( dtGraphPath );
-
-        when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
-        when( dtGraphPath.getFileName() ).thenReturn( "filename" );
-        when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
-        when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
-        when( versionRecordManager.getPathToLatest() ).thenReturn( dtGraphPath );
-
-        presenter.onStartup( dtGraphPath,
-                             dtGraphPlaceRequest );
-
-        verify( presenter,
-                times( 1 ) ).initialiseEditor( eq( dtGraphPath ),
-                                               eq( dtGraphPlaceRequest ) );
-
-        presenter.onRestore( event );
-
-        verify( presenter,
-                times( 2 ) ).initialiseEditor( eq( dtGraphPath ),
-                                               eq( dtGraphPlaceRequest ) );
-        verify( notification,
-                times( 1 ) ).fire( any( NotificationEvent.class ) );
-    }
-
-    @Test
-    public void checkOnUpdatedLockStatusEventWithNullPath() {
-        checkOnUpdatedLockStatusEvent( null,
-                                       false,
-                                       false,
-                                       () -> assertEquals( LockedBy.NOBODY,
-                                                           presenter.access.getLock() ) );
-    }
-
-    @Test
-    public void checkOnUpdatedLockStatusEventNotLocked() {
-        checkOnUpdatedLockStatusEvent( mock( ObservablePath.class ),
-                                       false,
-                                       false,
-                                       () -> assertEquals( LockedBy.NOBODY,
-                                                           presenter.access.getLock() ) );
-    }
-
-    @Test
-    public void checkOnUpdatedLockStatusEventLockedByOtherUser() {
-        checkOnUpdatedLockStatusEvent( mock( ObservablePath.class ),
-                                       true,
-                                       false,
-                                       () -> assertEquals( LockedBy.OTHER_USER,
-                                                           presenter.access.getLock() ) );
-    }
-
-    @Test
-    public void checkOnUpdatedLockStatusEventLockedByCurrentUser() {
-        checkOnUpdatedLockStatusEvent( mock( ObservablePath.class ),
-                                       true,
-                                       true,
-                                       () -> assertEquals( LockedBy.CURRENT_USER,
-                                                           presenter.access.getLock() ) );
-    }
-
-    private void checkOnUpdatedLockStatusEvent( final ObservablePath path,
-                                                final boolean locked,
-                                                final boolean lockedByCurrentUser,
-                                                final Command assertion ) {
-        presenter.editorPath = path;
-        presenter.access.setLock( LockedBy.NOBODY );
-
-        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( path,
-                                                                         locked,
-                                                                         lockedByCurrentUser );
-
-        presenter.onUpdatedLockStatusEvent( event );
-
-        assertion.execute();
-    }
-
-    protected GuidedDecisionTableEditorGraphContent makeDecisionTableGraphContent() {
-        return makeDecisionTableGraphContent( 0 );
-    }
-
-    protected GuidedDecisionTableEditorGraphContent makeDecisionTableGraphContent( final int hashCode ) {
-        final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel() {
-            @Override
-            public int hashCode() {
-                return hashCode;
-            }
-        };
-        return new GuidedDecisionTableEditorGraphContent( model,
-                                                          mock( Overview.class ) );
-    }
-
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2976

This PR changes the "can save" mechanism to only check "Overview" content for the Graph itself and not for each Decision Table document too. The "Overview" tab shows that for the whole Graph and does not change when individual tables are selected.