### PR TITLE
GUVNOR-2998: GDT Editor - New column (wizard) - Error on 'Set the value of a field' plugin

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPlugin.java
@@ -127,7 +127,7 @@ public class ActionSetFactPlugin extends BaseDecisionTableColumnPlugin implement
     boolean isValid(final ActionWrapper editingWrapper) {
         final ActionCol52 actionCol52 = editingWrapper.getActionCol52();
 
-        if (nil(getFactType())) {
+        if (nil(getFactField())) {
             Window.alert(translate(GuidedDecisionTableErraiConstants.ActionInsertFactPlugin_YouMustEnterAColumnPattern));
             return false;
         }
@@ -313,7 +313,7 @@ public class ActionSetFactPlugin extends BaseDecisionTableColumnPlugin implement
 
     @Override
     public String getBinding() {
-        return editingWrapper().getBoundName();
+        return patternWrapper().getBoundName();
     }
 
     @Override
@@ -392,11 +392,9 @@ public class ActionSetFactPlugin extends BaseDecisionTableColumnPlugin implement
     }
 
     private void resetField() {
-        final PatternWrapper defaultPattern = new PatternWrapper();
-
         editingWrapper().setFactField("");
-        editingWrapper().setFactType(defaultPattern.getFactType());
-        editingWrapper().setBoundName(defaultPattern.getBoundName());
+        editingWrapper().setFactType(patternWrapper().getFactType());
+        editingWrapper().setBoundName(patternWrapper().getBoundName());
         editingWrapper().setType("");
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPluginTest.java
@@ -154,23 +154,6 @@ public class ActionSetFactPluginTest {
     }
 
     @Test
-    public void testIsValidWhenFactFieldIsBlank() {
-        final ActionCol52 actionCol52 = mock(ActionCol52.class);
-        final ActionWrapper actionWrapper = mock(ActionWrapper.class);
-        final String errorKey = GuidedDecisionTableErraiConstants.ActionInsertFactPlugin_YouMustEnterAColumnField;
-
-        when(actionWrapper.getFactField()).thenReturn("");
-        when(actionWrapper.getFactType()).thenReturn("factType");
-        when(actionWrapper.getActionCol52()).thenReturn(actionCol52);
-        when(plugin.editingWrapper()).thenReturn(actionWrapper);
-
-        final boolean valid = plugin.isValid(actionWrapper);
-
-        assertFalse(valid);
-        verify(translationService).format(errorKey);
-    }
-
-    @Test
     public void testIsValidWhenHeaderIsBlank() {
         final ActionCol52 actionCol52 = mock(ActionCol52.class);
         final ActionWrapper actionWrapper = mock(ActionWrapper.class);
@@ -225,7 +208,7 @@ public class ActionSetFactPluginTest {
         when(presenter.getModel()).thenReturn(model);
         when(actionCol52.getHeader()).thenReturn("header");
         when(actionWrapper.getFactField()).thenReturn("factField");
-        when(actionWrapper.getFactType()).thenReturn("factType");
+        when(actionWrapper.getFactType()).thenReturn("");
         when(actionWrapper.getActionCol52()).thenReturn(actionCol52);
         when(plugin.editingWrapper()).thenReturn(actionWrapper);
 
@@ -264,12 +247,14 @@ public class ActionSetFactPluginTest {
         final PatternWrapper patternWrapper = mock(PatternWrapper.class);
 
         when(plugin.editingWrapper()).thenReturn(actionWrapper);
+        when(patternWrapper.getFactType()).thenReturn("factType");
+        when(patternWrapper.getBoundName()).thenReturn("boundName");
 
         plugin.setEditingPattern(patternWrapper);
 
         verify(actionWrapper).setFactField("");
-        verify(actionWrapper).setFactType("");
-        verify(actionWrapper).setBoundName("");
+        verify(actionWrapper).setFactType("factType");
+        verify(actionWrapper).setBoundName("boundName");
         verify(actionWrapper).setType("");
 
         verify(plugin).fireChangeEvent(patternPage);
@@ -555,13 +540,13 @@ public class ActionSetFactPluginTest {
 
     @Test
     public void testGetBinding() {
-        final ActionWrapper actionWrapper = mock(ActionWrapper.class);
+        final PatternWrapper patternWrapper = mock(PatternWrapper.class);
 
-        doReturn(actionWrapper).when(plugin).editingWrapper();
+        doReturn(patternWrapper).when(plugin).patternWrapper();
 
         plugin.getBinding();
 
-        verify(actionWrapper).getBoundName();
+        verify(patternWrapper).getBoundName();
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2998

- Before:
![before](https://cloud.githubusercontent.com/assets/1079279/25022853/d5e0b2f2-206d-11e7-8ac5-daa14781c6cf.gif)

- After:
![after](https://cloud.githubusercontent.com/assets/1079279/25022848/d3a3e036-206d-11e7-9dc2-7340bb93b224.gif)
