### PR TITLE
GUVNOR-3013: Guided Decision Table Graph: BRL fragments are not linked

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -485,7 +485,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                                                                       final int targetColumnIndex) -> {
                                                                          final GridData sourceUiModel = GuidedDecisionTablePresenter.this.getView().getModel();
                                                                          final GridData targetUiModel = e.getView().getModel();
-                                                                         sourceUiModel.getColumns().get(sourceColumnIndex).setLink(targetUiModel.getColumns().get(targetColumnIndex));
+                                                                         targetUiModel.getColumns().get(targetColumnIndex).setLink(sourceUiModel.getColumns().get(sourceColumnIndex));
                                                                      }));
     }
 
@@ -747,15 +747,15 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         if (isReadOnly()) {
             return;
         }
-        view.newAttributeOrMetaDataColumn( getReservedAttributeNames() );
+        view.newAttributeOrMetaDataColumn(getReservedAttributeNames());
     }
 
     @Override
     public Set<String> getReservedAttributeNames() {
         final Set<String> result = new HashSet<>();
 
-        result.addAll( getExistingAttributeNames() );
-        result.addAll( HitPolicyValidation.getReservedAttributes( model.getHitPolicy() ) );
+        result.addAll(getExistingAttributeNames());
+        result.addAll(HitPolicyValidation.getReservedAttributes(model.getHitPolicy()));
 
         return result;
     }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
@@ -82,6 +82,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.themes.Gui
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.EnumLoaderUtilities;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableLinkManager;
+import org.drools.workbench.screens.guided.dtable.shared.DefaultGuidedDecisionTableLinkManager;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
@@ -146,68 +147,67 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
     @Mock
     protected GuidedDecisionTableLockManager lockManager;
 
-    @Mock
     protected GuidedDecisionTableLinkManager linkManager;
 
-    protected Event<DecisionTableSelectedEvent> decisionTableSelectedEvent = spy( new EventSourceMock<DecisionTableSelectedEvent>() {
+    protected Event<DecisionTableSelectedEvent> decisionTableSelectedEvent = spy(new EventSourceMock<DecisionTableSelectedEvent>() {
         @Override
-        public void fire( final DecisionTableSelectedEvent event ) {
+        public void fire(final DecisionTableSelectedEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<DecisionTableColumnSelectedEvent> decisionTableColumnSelectedEvent = spy( new EventSourceMock<DecisionTableColumnSelectedEvent>() {
+    });
+    protected Event<DecisionTableColumnSelectedEvent> decisionTableColumnSelectedEvent = spy(new EventSourceMock<DecisionTableColumnSelectedEvent>() {
         @Override
-        public void fire( final DecisionTableColumnSelectedEvent event ) {
+        public void fire(final DecisionTableColumnSelectedEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<DecisionTableSelectionsChangedEvent> decisionTableSelectionsChangedEvent = spy( new EventSourceMock<DecisionTableSelectionsChangedEvent>() {
+    });
+    protected Event<DecisionTableSelectionsChangedEvent> decisionTableSelectionsChangedEvent = spy(new EventSourceMock<DecisionTableSelectionsChangedEvent>() {
         @Override
-        public void fire( final DecisionTableSelectionsChangedEvent event ) {
+        public void fire(final DecisionTableSelectionsChangedEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<RefreshAttributesPanelEvent> refreshAttributesPanelEvent = spy( new EventSourceMock<RefreshAttributesPanelEvent>() {
+    });
+    protected Event<RefreshAttributesPanelEvent> refreshAttributesPanelEvent = spy(new EventSourceMock<RefreshAttributesPanelEvent>() {
         @Override
-        public void fire( final RefreshAttributesPanelEvent event ) {
+        public void fire(final RefreshAttributesPanelEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<RefreshMetaDataPanelEvent> refreshMetaDataPanelEvent = spy( new EventSourceMock<RefreshMetaDataPanelEvent>() {
+    });
+    protected Event<RefreshMetaDataPanelEvent> refreshMetaDataPanelEvent = spy(new EventSourceMock<RefreshMetaDataPanelEvent>() {
         @Override
-        public void fire( final RefreshMetaDataPanelEvent event ) {
+        public void fire(final RefreshMetaDataPanelEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<RefreshConditionsPanelEvent> refreshConditionsPanelEvent = spy( new EventSourceMock<RefreshConditionsPanelEvent>() {
+    });
+    protected Event<RefreshConditionsPanelEvent> refreshConditionsPanelEvent = spy(new EventSourceMock<RefreshConditionsPanelEvent>() {
         @Override
-        public void fire( final RefreshConditionsPanelEvent event ) {
+        public void fire(final RefreshConditionsPanelEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<RefreshActionsPanelEvent> refreshActionsPanelEvent = spy( new EventSourceMock<RefreshActionsPanelEvent>() {
+    });
+    protected Event<RefreshActionsPanelEvent> refreshActionsPanelEvent = spy(new EventSourceMock<RefreshActionsPanelEvent>() {
         @Override
-        public void fire( final RefreshActionsPanelEvent event ) {
+        public void fire(final RefreshActionsPanelEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
-    protected Event<NotificationEvent> notificationEvent = spy( new EventSourceMock<NotificationEvent>() {
+    });
+    protected Event<NotificationEvent> notificationEvent = spy(new EventSourceMock<NotificationEvent>() {
         @Override
-        public void fire( final NotificationEvent event ) {
+        public void fire(final NotificationEvent event) {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
-    } );
+    });
     protected GridWidgetCellFactory gridWidgetCellFactory = new GridWidgetCellFactoryImpl();
     protected GridWidgetColumnFactory gridWidgetColumnFactory = new GridWidgetColumnFactoryImpl();
-    protected ModelSynchronizer synchronizer = spy( new ModelSynchronizerImpl() {
+    protected ModelSynchronizer synchronizer = spy(new ModelSynchronizerImpl() {
 
         @Override
-        protected void fireAfterColumnInsertedEvent( final BaseColumn column ) {
+        protected void fireAfterColumnInsertedEvent(final BaseColumn column) {
             //Do nothing; we're not testing V&V integration in these tests.
         }
 
         @Override
-        protected void fireAfterColumnDeletedEvent( final int columnIndex ) {
+        protected void fireAfterColumnDeletedEvent(final int columnIndex) {
             //Do nothing; we're not testing V&V integration in these tests.
         }
 
@@ -217,18 +217,18 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
         }
 
         @Override
-        protected void fireDeleteRowEvent( final int rowIndex ) {
+        protected void fireDeleteRowEvent(final int rowIndex) {
             //Do nothing; we're not testing V&V integration in these tests.
         }
 
         @Override
-        protected void fireInsertRowEvent( final int rowIndex ) {
+        protected void fireInsertRowEvent(final int rowIndex) {
             //Do nothing; we're not testing V&V integration in these tests.
         }
 
         @Override
-        protected void fireValidateEvent( final GridData.Range rowRange,
-                                          final Set<Integer> columnRange ) {
+        protected void fireValidateEvent(final GridData.Range rowRange,
+                                         final Set<Integer> columnRange) {
             //Do nothing; we're not testing V&V integration in these tests.
         }
 
@@ -236,8 +236,8 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
         protected void fireUpdateColumnDataEvent() {
             //Do nothing; we're not testing V&V integration in these tests.
         }
-    } );
-    protected Clipboard clipboard = spy( new DefaultClipboard() );
+    });
+    protected Clipboard clipboard = spy(new DefaultClipboard());
 
     @Mock
     protected GuidedDecisionTableRenderer renderer;
@@ -267,48 +267,49 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
     }
 
     private void setupProviders() {
-        when( decisionTableAnalyzerProvider.newAnalyzer( eq( dtPlaceRequest ),
-                                                         eq( oracle ),
-                                                         any( GuidedDecisionTable52.class ),
-                                                         any( EventBus.class ) ) ).thenReturn( analyzerController );
+        when(decisionTableAnalyzerProvider.newAnalyzer(eq(dtPlaceRequest),
+                                                       eq(oracle),
+                                                       any(GuidedDecisionTable52.class),
+                                                       any(EventBus.class))).thenReturn(analyzerController);
     }
 
     private void setupPreferences() {
         final Map<String, String> preferences = new HashMap<String, String>() {{
-            put( ApplicationPreferences.DATE_FORMAT,
-                 "dd/mm/yyyy" );
+            put(ApplicationPreferences.DATE_FORMAT,
+                "dd/mm/yyyy");
         }};
-        ApplicationPreferences.setUp( preferences );
+        ApplicationPreferences.setUp(preferences);
     }
 
     private void setupServices() {
-        ruleNameServiceCaller = new CallerMock<>( ruleNameService );
-        enumDropdownServiceCaller = new CallerMock<>( enumDropdownService );
-        enumLoaderUtilities = new EnumLoaderUtilities( enumDropdownServiceCaller );
+        ruleNameServiceCaller = new CallerMock<>(ruleNameService);
+        enumDropdownServiceCaller = new CallerMock<>(enumDropdownService);
+        enumLoaderUtilities = new EnumLoaderUtilities(enumDropdownServiceCaller);
+        linkManager = spy(new DefaultGuidedDecisionTableLinkManager());
     }
 
     private void setupPresenter() {
-        final GuidedDecisionTablePresenter wrapped = new GuidedDecisionTablePresenter( identity,
-                                                                                       resourceType,
-                                                                                       ruleNameServiceCaller,
-                                                                                       decisionTableSelectedEvent,
-                                                                                       decisionTableColumnSelectedEvent,
-                                                                                       decisionTableSelectionsChangedEvent,
-                                                                                       refreshAttributesPanelEvent,
-                                                                                       refreshMetaDataPanelEvent,
-                                                                                       refreshConditionsPanelEvent,
-                                                                                       refreshActionsPanelEvent,
-                                                                                       notificationEvent,
-                                                                                       gridWidgetCellFactory,
-                                                                                       gridWidgetColumnFactory,
-                                                                                       oracleFactory,
-                                                                                       synchronizer,
-                                                                                       beanManager,
-                                                                                       lockManager,
-                                                                                       linkManager,
-                                                                                       clipboard,
-                                                                                       decisionTableAnalyzerProvider,
-                                                                                       enumLoaderUtilities ) {
+        final GuidedDecisionTablePresenter wrapped = new GuidedDecisionTablePresenter(identity,
+                                                                                      resourceType,
+                                                                                      ruleNameServiceCaller,
+                                                                                      decisionTableSelectedEvent,
+                                                                                      decisionTableColumnSelectedEvent,
+                                                                                      decisionTableSelectionsChangedEvent,
+                                                                                      refreshAttributesPanelEvent,
+                                                                                      refreshMetaDataPanelEvent,
+                                                                                      refreshConditionsPanelEvent,
+                                                                                      refreshActionsPanelEvent,
+                                                                                      notificationEvent,
+                                                                                      gridWidgetCellFactory,
+                                                                                      gridWidgetColumnFactory,
+                                                                                      oracleFactory,
+                                                                                      synchronizer,
+                                                                                      beanManager,
+                                                                                      lockManager,
+                                                                                      linkManager,
+                                                                                      clipboard,
+                                                                                      decisionTableAnalyzerProvider,
+                                                                                      enumLoaderUtilities) {
             @Override
             void initialiseLockManager() {
                 //Do nothing for tests
@@ -320,7 +321,7 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
             }
 
             @Override
-            GuidedDecisionTableView makeView( final Set<PortableWorkDefinition> workItemDefinitions ) {
+            GuidedDecisionTableView makeView(final Set<PortableWorkDefinition> workItemDefinitions) {
                 return view;
             }
 
@@ -332,70 +333,69 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
             @Override
             List<BaseColumnConverter> getConverters() {
                 final List<BaseColumnConverter> converters = new ArrayList<BaseColumnConverter>();
-                converters.add( new ActionInsertFactColumnConverter() );
-                converters.add( new ActionRetractFactColumnConverter() );
-                converters.add( new ActionSetFieldColumnConverter() );
-                converters.add( new ActionWorkItemColumnConverter() );
-                converters.add( new ActionWorkItemInsertFactColumnConverter() );
-                converters.add( new ActionWorkItemSetFieldColumnConverter() );
-                converters.add( new AttributeColumnConverter() );
-                converters.add( new BRLActionVariableColumnConverter() );
-                converters.add( new BRLConditionVariableColumnConverter() );
-                converters.add( new ConditionColumnConverter() );
-                converters.add( new DescriptionColumnConverter() );
-                converters.add( new LimitedEntryColumnConverter() );
-                converters.add( new MetaDataColumnConverter() );
-                converters.add( new RowNumberColumnConverter() );
+                converters.add(new ActionInsertFactColumnConverter());
+                converters.add(new ActionRetractFactColumnConverter());
+                converters.add(new ActionSetFieldColumnConverter());
+                converters.add(new ActionWorkItemColumnConverter());
+                converters.add(new ActionWorkItemInsertFactColumnConverter());
+                converters.add(new ActionWorkItemSetFieldColumnConverter());
+                converters.add(new AttributeColumnConverter());
+                converters.add(new BRLActionVariableColumnConverter());
+                converters.add(new BRLConditionVariableColumnConverter());
+                converters.add(new ConditionColumnConverter());
+                converters.add(new DescriptionColumnConverter());
+                converters.add(new LimitedEntryColumnConverter());
+                converters.add(new MetaDataColumnConverter());
+                converters.add(new RowNumberColumnConverter());
                 return converters;
             }
 
             @Override
             List<Synchronizer<? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData>> getSynchronizers() {
                 final List<Synchronizer<? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData>> synchronizers = new ArrayList<>();
-                synchronizers.add( new ActionColumnSynchronizer() );
-                synchronizers.add( new ActionInsertFactColumnSynchronizer() );
-                synchronizers.add( new ActionRetractFactColumnSynchronizer() );
-                synchronizers.add( new ActionSetFieldColumnSynchronizer() );
-                synchronizers.add( new ActionWorkItemColumnSynchronizer() );
-                synchronizers.add( new ActionWorkItemInsertFactColumnSynchronizer() );
-                synchronizers.add( new ActionWorkItemSetFieldColumnSynchronizer() );
-                synchronizers.add( new AttributeColumnSynchronizer() );
-                synchronizers.add( new BRLActionColumnSynchronizer() );
-                synchronizers.add( new BRLConditionColumnSynchronizer() );
-                synchronizers.add( new ConditionColumnSynchronizer() );
-                synchronizers.add( new LimitedEntryBRLActionColumnSynchronizer() );
-                synchronizers.add( new LimitedEntryBRLConditionColumnSynchronizer() );
-                synchronizers.add( new MetaDataColumnSynchronizer() );
-                synchronizers.add( new RowSynchronizer() );
+                synchronizers.add(new ActionColumnSynchronizer());
+                synchronizers.add(new ActionInsertFactColumnSynchronizer());
+                synchronizers.add(new ActionRetractFactColumnSynchronizer());
+                synchronizers.add(new ActionSetFieldColumnSynchronizer());
+                synchronizers.add(new ActionWorkItemColumnSynchronizer());
+                synchronizers.add(new ActionWorkItemInsertFactColumnSynchronizer());
+                synchronizers.add(new ActionWorkItemSetFieldColumnSynchronizer());
+                synchronizers.add(new AttributeColumnSynchronizer());
+                synchronizers.add(new BRLActionColumnSynchronizer());
+                synchronizers.add(new BRLConditionColumnSynchronizer());
+                synchronizers.add(new ConditionColumnSynchronizer());
+                synchronizers.add(new LimitedEntryBRLActionColumnSynchronizer());
+                synchronizers.add(new LimitedEntryBRLConditionColumnSynchronizer());
+                synchronizers.add(new MetaDataColumnSynchronizer());
+                synchronizers.add(new RowSynchronizer());
                 return synchronizers;
             }
         };
-        dtPresenter = spy( wrapped );
+        dtPresenter = spy(wrapped);
 
         model = new GuidedDecisionTable52();
-        final PackageDataModelOracleBaselinePayload dmoBaseline = mock( PackageDataModelOracleBaselinePayload.class );
+        final PackageDataModelOracleBaselinePayload dmoBaseline = mock(PackageDataModelOracleBaselinePayload.class);
         final Set<PortableWorkDefinition> workItemDefinitions = Collections.emptySet();
-        final Overview overview = mock( Overview.class );
+        final Overview overview = mock(Overview.class);
 
-        dtContent = new GuidedDecisionTableEditorContent( model,
-                                                          workItemDefinitions,
-                                                          overview,
-                                                          dmoBaseline );
+        dtContent = new GuidedDecisionTableEditorContent(model,
+                                                         workItemDefinitions,
+                                                         overview,
+                                                         dmoBaseline);
 
-        when( oracleFactory.makeAsyncPackageDataModelOracle( any( Path.class ),
-                                                             any( GuidedDecisionTable52.class ),
-                                                             eq( dmoBaseline ) ) ).thenReturn( oracle );
+        when(oracleFactory.makeAsyncPackageDataModelOracle(any(Path.class),
+                                                           any(GuidedDecisionTable52.class),
+                                                           eq(dmoBaseline))).thenReturn(oracle);
 
-        when( view.getLayer() ).thenReturn( gridLayer );
-        when( modellerPresenter.getView() ).thenReturn( modellerView );
-        when( modellerView.getGridLayerView() ).thenReturn( gridLayer );
-        when( dtPresenter.getModellerPresenter() ).thenReturn( modellerPresenter );
+        when(view.getLayer()).thenReturn(gridLayer);
+        when(modellerPresenter.getView()).thenReturn(modellerView);
+        when(modellerView.getGridLayerView()).thenReturn(gridLayer);
+        when(dtPresenter.getModellerPresenter()).thenReturn(modellerPresenter);
 
-        dtPresenter.setContent( dtPath,
-                                dtPlaceRequest,
-                                dtContent,
-                                modellerPresenter,
-                                false );
+        dtPresenter.setContent(dtPath,
+                               dtPlaceRequest,
+                               dtContent,
+                               modellerPresenter,
+                               false);
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -39,7 +40,6 @@ import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
-import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.analysis.panel.IssueSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableColumnSelectedEvent;
@@ -47,7 +47,6 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableLinkManager.LinkFoundCallback;
@@ -67,10 +66,13 @@ import org.uberfire.client.mvp.UpdatedLockStatusEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.*;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.CURRENT_USER;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.NOBODY;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.OTHER_USER;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -91,141 +93,141 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
 
     @Test
     public void testOnUpdatedLockStatusEvent_LockedByCurrentUser() {
-        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
-        when( event.getFile() ).thenReturn( dtPath );
-        when( event.isLockedByCurrentUser() ).thenReturn( true );
-        when( event.isLocked() ).thenReturn( true );
+        final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
+        when(event.getFile()).thenReturn(dtPath);
+        when(event.isLockedByCurrentUser()).thenReturn(true);
+        when(event.isLocked()).thenReturn(true);
 
-        dtPresenter.onUpdatedLockStatusEvent( event );
+        dtPresenter.onUpdatedLockStatusEvent(event);
 
-        verify( modellerPresenter,
-                times( 1 ) ).onLockStatusUpdated( eq( dtPresenter ) );
-        assertEquals( CURRENT_USER,
-                      dtPresenter.getAccess().getLock() );
+        verify(modellerPresenter,
+               times(1)).onLockStatusUpdated(eq(dtPresenter));
+        assertEquals(CURRENT_USER,
+                     dtPresenter.getAccess().getLock());
     }
 
     @Test
     public void testOnUpdatedLockStatusEvent_LockedByOtherUser() {
-        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
-        when( event.getFile() ).thenReturn( dtPath );
-        when( event.isLockedByCurrentUser() ).thenReturn( false );
-        when( event.isLocked() ).thenReturn( true );
+        final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
+        when(event.getFile()).thenReturn(dtPath);
+        when(event.isLockedByCurrentUser()).thenReturn(false);
+        when(event.isLocked()).thenReturn(true);
 
-        dtPresenter.onUpdatedLockStatusEvent( event );
+        dtPresenter.onUpdatedLockStatusEvent(event);
 
-        verify( modellerPresenter,
-                times( 1 ) ).onLockStatusUpdated( eq( dtPresenter ) );
-        assertEquals( OTHER_USER,
-                      dtPresenter.getAccess().getLock() );
+        verify(modellerPresenter,
+               times(1)).onLockStatusUpdated(eq(dtPresenter));
+        assertEquals(OTHER_USER,
+                     dtPresenter.getAccess().getLock());
     }
 
     @Test
     public void testOnUpdatedLockStatusEvent_NotLocked() {
-        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
-        when( event.getFile() ).thenReturn( dtPath );
-        dtPresenter.onUpdatedLockStatusEvent( event );
+        final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
+        when(event.getFile()).thenReturn(dtPath);
+        dtPresenter.onUpdatedLockStatusEvent(event);
 
-        verify( modellerPresenter,
-                times( 1 ) ).onLockStatusUpdated( eq( dtPresenter ) );
-        assertEquals( NOBODY,
-                      dtPresenter.getAccess().getLock() );
+        verify(modellerPresenter,
+               times(1)).onLockStatusUpdated(eq(dtPresenter));
+        assertEquals(NOBODY,
+                     dtPresenter.getAccess().getLock());
     }
 
     @Test
     public void testOnUpdatedLockStatusEvent_NullFile() {
-        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
-        dtPresenter.onUpdatedLockStatusEvent( event );
+        final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
+        dtPresenter.onUpdatedLockStatusEvent(event);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testOnIssueSelectedEvent_NullEvent() {
-        dtPresenter.onIssueSelectedEvent( null );
+        dtPresenter.onIssueSelectedEvent(null);
 
-        verify( renderer,
-                never() ).clearHighlights();
-        verify( renderer,
-                never() ).highlightRows( any( Severity.class ),
-                                         any( Set.class ) );
+        verify(renderer,
+               never()).clearHighlights();
+        verify(renderer,
+               never()).highlightRows(any(Severity.class),
+                                      any(Set.class));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testOnIssueSelectedEvent_ClearHighlightsWithDifferentTable() {
-        dtPresenter.onIssueSelectedEvent( new IssueSelectedEvent( mock( PlaceRequest.class ),
-                                                                  mock( Issue.class ) ) );
+        dtPresenter.onIssueSelectedEvent(new IssueSelectedEvent(mock(PlaceRequest.class),
+                                                                mock(Issue.class)));
 
-        verify( renderer,
-                times( 1 ) ).clearHighlights();
-        verify( renderer,
-                never() ).highlightRows( any( Severity.class ),
-                                         any( Set.class ) );
-        verify( view,
-                times( 1 ) ).draw();
+        verify(renderer,
+               times(1)).clearHighlights();
+        verify(renderer,
+               never()).highlightRows(any(Severity.class),
+                                      any(Set.class));
+        verify(view,
+               times(1)).draw();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testOnIssueSelectedEvent_HighlightsRows() {
-        dtPresenter.onIssueSelectedEvent( new IssueSelectedEvent( dtPlaceRequest,
-                                                                  mock( Issue.class ) ) );
+        dtPresenter.onIssueSelectedEvent(new IssueSelectedEvent(dtPlaceRequest,
+                                                                mock(Issue.class)));
 
-        verify( renderer,
-                never() ).clearHighlights();
-        verify( renderer,
-                times( 1 ) ).highlightRows( any( Severity.class ),
-                                            any( Set.class ) );
-        verify( view,
-                times( 1 ) ).draw();
+        verify(renderer,
+               never()).clearHighlights();
+        verify(renderer,
+               times(1)).highlightRows(any(Severity.class),
+                                       any(Set.class));
+        verify(view,
+               times(1)).draw();
     }
 
     @Test
     public void testActivate() {
         dtPresenter.activate();
-        verify( lockManager,
-                times( 1 ) ).fireChangeTitleEvent();
+        verify(lockManager,
+               times(1)).fireChangeTitleEvent();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void setContent() {
         //dtPresenter.setContent(...) is called by the base tests @Before method
-        verify( dtPresenter,
-                times( 1 ) ).initialiseContent( eq( dtPath ),
-                                                eq( dtPlaceRequest ),
-                                                eq( dtContent ),
-                                                eq( false ) );
-        verify( oracleFactory,
-                times( 1 ) ).makeAsyncPackageDataModelOracle( eq( dtPath ),
-                                                              any( GuidedDecisionTable52.class ),
-                                                              any( PackageDataModelOracleBaselinePayload.class ) );
-        verify( dtPresenter,
-                times( 1 ) ).makeUiModel();
-        verify( dtPresenter,
-                times( 1 ) ).makeView( any( Set.class ) );
-        verify( dtPresenter,
-                times( 1 ) ).initialiseLockManager();
-        verify( dtPresenter,
-                times( 1 ) ).initialiseUtilities();
-        verify( dtPresenter,
-                times( 1 ) ).initialiseModels();
-        verify( dtPresenter,
-                times( 1 ) ).initialiseValidationAndVerification();
-        verify( dtPresenter,
-                times( 1 ) ).initialiseAuditLog();
+        verify(dtPresenter,
+               times(1)).initialiseContent(eq(dtPath),
+                                           eq(dtPlaceRequest),
+                                           eq(dtContent),
+                                           eq(false));
+        verify(oracleFactory,
+               times(1)).makeAsyncPackageDataModelOracle(eq(dtPath),
+                                                         any(GuidedDecisionTable52.class),
+                                                         any(PackageDataModelOracleBaselinePayload.class));
+        verify(dtPresenter,
+               times(1)).makeUiModel();
+        verify(dtPresenter,
+               times(1)).makeView(any(Set.class));
+        verify(dtPresenter,
+               times(1)).initialiseLockManager();
+        verify(dtPresenter,
+               times(1)).initialiseUtilities();
+        verify(dtPresenter,
+               times(1)).initialiseModels();
+        verify(dtPresenter,
+               times(1)).initialiseValidationAndVerification();
+        verify(dtPresenter,
+               times(1)).initialiseAuditLog();
 
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      dtPresenter.getUiModel().getRow( 0 ).getHeight(),
-                      0.0 );
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      dtPresenter.getUiModel().getRow( 1 ).getHeight(),
-                      0.0 );
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      dtPresenter.getUiModel().getRow( 2 ).getHeight(),
-                      0.0 );
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     dtPresenter.getUiModel().getRow(0).getHeight(),
+                     0.0);
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     dtPresenter.getUiModel().getRow(1).getHeight(),
+                     0.0);
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     dtPresenter.getUiModel().getRow(2).getHeight(),
+                     0.0);
 
-        assertEquals( dtContent.getModel().hashCode(),
-                      (int) dtPresenter.getOriginalHashCode() );
+        assertEquals(dtContent.getModel().hashCode(),
+                     (int) dtPresenter.getOriginalHashCode());
     }
 
     @Test
@@ -234,45 +236,45 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         // dtPresenter.setContent(...) is called by the base tests @Before method so
         // expect some invocations to have occurred twice: once for setContent(...)
         // and again for refreshContent(...)
-        dtPresenter.refreshContent( dtPath,
-                                    dtPlaceRequest,
-                                    dtContent,
-                                    false );
+        dtPresenter.refreshContent(dtPath,
+                                   dtPlaceRequest,
+                                   dtContent,
+                                   false);
 
-        verify( dtPresenter,
-                times( 2 ) ).initialiseContent( eq( dtPath ),
-                                                eq( dtPlaceRequest ),
-                                                eq( dtContent ),
-                                                eq( false ) );
-        verify( oracleFactory,
-                times( 2 ) ).makeAsyncPackageDataModelOracle( eq( dtPath ),
-                                                              any( GuidedDecisionTable52.class ),
-                                                              any( PackageDataModelOracleBaselinePayload.class ) );
-        verify( dtPresenter,
-                times( 2 ) ).makeUiModel();
-        verify( dtPresenter,
-                times( 2 ) ).makeView( any( Set.class ) );
-        verify( dtPresenter,
-                times( 2 ) ).initialiseLockManager();
-        verify( dtPresenter,
-                times( 2 ) ).initialiseUtilities();
-        verify( dtPresenter,
-                times( 2 ) ).initialiseModels();
-        verify( dtPresenter,
-                times( 2 ) ).initialiseValidationAndVerification();
-        verify( dtPresenter,
-                times( 2 ) ).initialiseAuditLog();
+        verify(dtPresenter,
+               times(2)).initialiseContent(eq(dtPath),
+                                           eq(dtPlaceRequest),
+                                           eq(dtContent),
+                                           eq(false));
+        verify(oracleFactory,
+               times(2)).makeAsyncPackageDataModelOracle(eq(dtPath),
+                                                         any(GuidedDecisionTable52.class),
+                                                         any(PackageDataModelOracleBaselinePayload.class));
+        verify(dtPresenter,
+               times(2)).makeUiModel();
+        verify(dtPresenter,
+               times(2)).makeView(any(Set.class));
+        verify(dtPresenter,
+               times(2)).initialiseLockManager();
+        verify(dtPresenter,
+               times(2)).initialiseUtilities();
+        verify(dtPresenter,
+               times(2)).initialiseModels();
+        verify(dtPresenter,
+               times(2)).initialiseValidationAndVerification();
+        verify(dtPresenter,
+               times(2)).initialiseAuditLog();
 
-        assertEquals( dtContent.getModel().hashCode(),
-                      (int) dtPresenter.getOriginalHashCode() );
+        assertEquals(dtContent.getModel().hashCode(),
+                     (int) dtPresenter.getOriginalHashCode());
 
         //These invocations are as a result of the previous Presenter being destroyed
-        verify( dtPresenter,
-                times( 1 ) ).terminateAnalysis();
-        verify( lockManager,
-                times( 1 ) ).releaseLock();
-        verify( oracleFactory,
-                times( 1 ) ).destroy( eq( oracle ) );
+        verify(dtPresenter,
+               times(1)).terminateAnalysis();
+        verify(lockManager,
+               times(1)).releaseLock();
+        verify(oracleFactory,
+               times(1)).destroy(eq(oracle));
     }
 
     @Test
@@ -281,982 +283,1072 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         final GuidedDecisionTable52 model1 = new GuidedDecisionTable52();
         final GuidedDecisionTable52 model2 = new GuidedDecisionTable52();
         final GuidedDecisionTable52 model3 = new GuidedDecisionTable52();
-        final GuidedDecisionTableView.Presenter dtPresenter2 = mock( GuidedDecisionTableView.Presenter.class );
-        final GuidedDecisionTableView.Presenter dtPresenter3 = mock( GuidedDecisionTableView.Presenter.class );
+        final GuidedDecisionTableView.Presenter dtPresenter2 = mock(GuidedDecisionTableView.Presenter.class);
+        final GuidedDecisionTableView.Presenter dtPresenter3 = mock(GuidedDecisionTableView.Presenter.class);
         final Set<GuidedDecisionTableView.Presenter> dtPresenters = new HashSet<GuidedDecisionTableView.Presenter>() {{
-            add( dtPresenter );
-            add( dtPresenter2 );
-            add( dtPresenter3 );
+            add(dtPresenter);
+            add(dtPresenter2);
+            add(dtPresenter3);
         }};
-        when( dtPresenter.getModel() ).thenReturn( model1 );
-        when( dtPresenter2.getModel() ).thenReturn( model2 );
-        when( dtPresenter3.getModel() ).thenReturn( model3 );
+        when(dtPresenter.getModel()).thenReturn(model1);
+        when(dtPresenter2.getModel()).thenReturn(model2);
+        when(dtPresenter3.getModel()).thenReturn(model3);
 
-        dtPresenter.link( dtPresenters );
+        dtPresenter.link(dtPresenters);
 
-        verify( linkManager,
-                times( 1 ) ).link( eq( model1 ),
-                                   eq( model2 ),
-                                   any( LinkFoundCallback.class ) );
-        verify( linkManager,
-                times( 1 ) ).link( eq( model1 ),
-                                   eq( model3 ),
-                                   any( LinkFoundCallback.class ) );
+        verify(linkManager,
+               times(1)).link(eq(model1),
+                              eq(model2),
+                              any(LinkFoundCallback.class));
+        verify(linkManager,
+               times(1)).link(eq(model1),
+                              eq(model3),
+                              any(LinkFoundCallback.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void linkMultipleRelatedTables() {
+        final GuidedDecisionTable52 model1 = new GuidedDecisionTable52();
+        final GuidedDecisionTable52 model2 = new GuidedDecisionTable52();
+        final GuidedDecisionTable52 model3 = new GuidedDecisionTable52();
+
+        final GridData uiModel1 = spy(new BaseGridData());
+        final GridData uiModel2 = spy(new BaseGridData());
+        final GridData uiModel3 = spy(new BaseGridData());
+        final List uiModel1Columns = mock(List.class);
+        final List uiModel2Columns = mock(List.class);
+        final List uiModel3Columns = mock(List.class);
+        final GridColumn uiModel1MockColumn = mock(GridColumn.class);
+        final GridColumn uiModel2MockColumn = mock(GridColumn.class);
+        final GridColumn uiModel3MockColumn = mock(GridColumn.class);
+
+        final GuidedDecisionTableView dtView2 = mock(GuidedDecisionTableView.class);
+        final GuidedDecisionTableView dtView3 = mock(GuidedDecisionTableView.class);
+        final GuidedDecisionTableView.Presenter dtPresenter2 = mock(GuidedDecisionTableView.Presenter.class);
+        final GuidedDecisionTableView.Presenter dtPresenter3 = mock(GuidedDecisionTableView.Presenter.class);
+        final Set<GuidedDecisionTableView.Presenter> dtPresenters = new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+            add(dtPresenter2);
+            add(dtPresenter3);
+        }};
+
+        addActionInsertFactToModel(model1,
+                                   "Applicant",
+                                   "name");
+        addConstraintToModel(model2,
+                             "Applicant",
+                             "name");
+        addConstraintToModel(model3,
+                             "Applicant",
+                             "name");
+
+        when(dtPresenter.getModel()).thenReturn(model1);
+        when(dtPresenter2.getModel()).thenReturn(model2);
+        when(dtPresenter3.getModel()).thenReturn(model3);
+
+        when(dtPresenter2.getView()).thenReturn(dtView2);
+        when(dtPresenter3.getView()).thenReturn(dtView3);
+        when(view.getModel()).thenReturn(uiModel1);
+        when(dtView2.getModel()).thenReturn(uiModel2);
+        when(dtView3.getModel()).thenReturn(uiModel3);
+        when(uiModel1.getColumns()).thenReturn(uiModel1Columns);
+        when(uiModel2.getColumns()).thenReturn(uiModel2Columns);
+        when(uiModel3.getColumns()).thenReturn(uiModel3Columns);
+        when(uiModel1Columns.get(anyInt())).thenReturn(uiModel1MockColumn);
+        when(uiModel2Columns.get(anyInt())).thenReturn(uiModel2MockColumn);
+        when(uiModel3Columns.get(anyInt())).thenReturn(uiModel3MockColumn);
+
+        dtPresenter.link(dtPresenters);
+
+        verify(uiModel1Columns,
+               atLeast(1)).get(eq(2));
+        verify(uiModel2Columns,
+               atLeast(1)).get(eq(2));
+        verify(uiModel3Columns,
+               atLeast(1)).get(eq(2));
+
+        verify(uiModel2MockColumn).setLink(eq(uiModel1MockColumn));
+        verify(uiModel3MockColumn).setLink(eq(uiModel1MockColumn));
+    }
+
+    private void addConstraintToModel(final GuidedDecisionTable52 model,
+                                      final String factType,
+                                      final String fieldName) {
+        final Pattern52 p = new Pattern52();
+        p.setFactType(factType);
+        final ConditionCol52 c = new ConditionCol52();
+        c.setOperator("==");
+        c.setFactField(fieldName);
+        c.setFieldType(DataType.TYPE_STRING);
+        p.getChildColumns().add(c);
+        model.getConditions().add(p);
+    }
+
+    private void addActionInsertFactToModel(final GuidedDecisionTable52 model,
+                                            final String factType,
+                                            final String fieldName) {
+        final ActionInsertFactCol52 aif = new ActionInsertFactCol52();
+        aif.setFactType(factType);
+        aif.setFactField(fieldName);
+        model.getActionCols().add(aif);
     }
 
     @Test
     public void onClose() {
         // Reset the mocks to check for interactions caused by explicit invocation of onClose(). onClose()
         // is implicitly called by setContent(...) which is called by the base tests @Before method.
-        reset( dtPresenter,
-               lockManager );
+        reset(dtPresenter,
+              lockManager);
 
         dtPresenter.onClose();
 
-        verify( dtPresenter,
-                times( 1 ) ).terminateAnalysis();
-        verify( lockManager,
-                times( 1 ) ).releaseLock();
-        verify( oracleFactory,
-                times( 1 ) ).destroy( eq( oracle ) );
+        verify(dtPresenter,
+               times(1)).terminateAnalysis();
+        verify(lockManager,
+               times(1)).releaseLock();
+        verify(oracleFactory,
+               times(1)).destroy(eq(oracle));
     }
 
     @Test
     public void select() {
-        dtPresenter.select( dtPresenter.getView() );
+        dtPresenter.select(dtPresenter.getView());
 
-        verify( decisionTableSelectedEvent,
-                times( 1 ) ).fire( any( DecisionTableSelectedEvent.class ) );
-        verify( lockManager,
-                times( 1 ) ).acquireLock();
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(any(DecisionTableSelectedEvent.class));
+        verify(lockManager,
+               times(1)).acquireLock();
     }
 
     @Test
     public void selectLinkedColumn() {
-        final GridColumn uiColumn = mock( GridColumn.class );
+        final GridColumn uiColumn = mock(GridColumn.class);
 
-        dtPresenter.selectLinkedColumn( uiColumn );
+        dtPresenter.selectLinkedColumn(uiColumn);
 
-        verify( decisionTableColumnSelectedEvent,
-                times( 1 ) ).fire( any( DecisionTableColumnSelectedEvent.class ) );
+        verify(decisionTableColumnSelectedEvent,
+               times(1)).fire(any(DecisionTableColumnSelectedEvent.class));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void getPackageParentRuleNames() {
         final Set<String> parentRuleNames = new HashSet<>();
-        parentRuleNames.add( "parentRule1" );
-        parentRuleNames.add( "parentRule2" );
+        parentRuleNames.add("parentRule1");
+        parentRuleNames.add("parentRule2");
 
-        final ParameterizedCommand<Collection<String>> parentRuleNamesCommand = mock( ParameterizedCommand.class );
+        final ParameterizedCommand<Collection<String>> parentRuleNamesCommand = mock(ParameterizedCommand.class);
 
-        when( ruleNameService.getRuleNames( any( ObservablePath.class ),
-                                            any( String.class ) ) ).thenReturn( parentRuleNames );
+        when(ruleNameService.getRuleNames(any(ObservablePath.class),
+                                          any(String.class))).thenReturn(parentRuleNames);
 
-        dtPresenter.getPackageParentRuleNames( parentRuleNamesCommand );
+        dtPresenter.getPackageParentRuleNames(parentRuleNamesCommand);
 
-        verify( parentRuleNamesCommand,
-                times( 1 ) ).execute( eq( parentRuleNames ) );
+        verify(parentRuleNamesCommand,
+               times(1)).execute(eq(parentRuleNames));
     }
 
     @Test
     public void hasColumnDefinitionsEmptyModel() {
-        assertFalse( dtPresenter.hasColumnDefinitions() );
+        assertFalse(dtPresenter.hasColumnDefinitions());
     }
 
     @Test
     public void hasColumnDefinitionsWithAttributeColumn() {
         final AttributeCol52 attribute = new AttributeCol52();
-        attribute.setAttribute( "attribute" );
+        attribute.setAttribute("attribute");
 
-        dtPresenter.getModel().getAttributeCols().add( attribute );
+        dtPresenter.getModel().getAttributeCols().add(attribute);
 
-        assertTrue( dtPresenter.hasColumnDefinitions() );
+        assertTrue(dtPresenter.hasColumnDefinitions());
     }
 
     @Test
     public void hasColumnDefinitionsWithConditionColumn() {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType" );
+        pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        pattern.getChildColumns().add( condition );
+        condition.setFactField("field");
+        pattern.getChildColumns().add(condition);
 
-        dtPresenter.getModel().getConditions().add( pattern );
+        dtPresenter.getModel().getConditions().add(pattern);
 
-        assertTrue( dtPresenter.hasColumnDefinitions() );
+        assertTrue(dtPresenter.hasColumnDefinitions());
     }
 
     @Test
     public void hasColumnDefinitionsWithActionColumn() {
         final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType( "FactType" );
-        action.setFactField( "field" );
+        action.setFactType("FactType");
+        action.setFactField("field");
 
-        dtPresenter.getModel().getActionCols().add( action );
+        dtPresenter.getModel().getActionCols().add(action);
 
-        assertTrue( dtPresenter.hasColumnDefinitions() );
+        assertTrue(dtPresenter.hasColumnDefinitions());
     }
 
     @Test
     public void getBindingsWithSimpleClassName() {
         final Pattern52 pattern1 = new Pattern52();
-        pattern1.setFactType( "FactType1" );
-        pattern1.setBoundName( "$fact1" );
+        pattern1.setFactType("FactType1");
+        pattern1.setBoundName("$fact1");
         final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField( "field" );
-        condition1.setBinding( "$field1" );
-        pattern1.getChildColumns().add( condition1 );
+        condition1.setFactField("field");
+        condition1.setBinding("$field1");
+        pattern1.getChildColumns().add(condition1);
 
         final Pattern52 pattern2 = new Pattern52();
-        pattern2.setFactType( "FactType1" );
+        pattern2.setFactType("FactType1");
         final ConditionCol52 condition2 = new ConditionCol52();
-        condition2.setFactField( "field" );
-        pattern2.getChildColumns().add( condition2 );
+        condition2.setFactField("field");
+        pattern2.getChildColumns().add(condition2);
 
-        when( oracle.getFieldClassName( eq( "FactType1" ),
-                                        eq( "field" ) ) ).thenReturn( "FactType1" );
+        when(oracle.getFieldClassName(eq("FactType1"),
+                                      eq("field"))).thenReturn("FactType1");
 
-        dtPresenter.getModel().getConditions().add( pattern1 );
-        dtPresenter.getModel().getConditions().add( pattern2 );
+        dtPresenter.getModel().getConditions().add(pattern1);
+        dtPresenter.getModel().getConditions().add(pattern2);
 
-        final Set<String> bindings = dtPresenter.getBindings( "FactType1" );
+        final Set<String> bindings = dtPresenter.getBindings("FactType1");
 
-        assertNotNull( bindings );
-        assertEquals( 2,
-                      bindings.size() );
-        assertTrue( bindings.contains( "$fact1" ) );
-        assertTrue( bindings.contains( "$field1" ) );
+        assertNotNull(bindings);
+        assertEquals(2,
+                     bindings.size());
+        assertTrue(bindings.contains("$fact1"));
+        assertTrue(bindings.contains("$field1"));
     }
 
     @Test
     public void getBindingsWithFullyQualifiedClassName() {
         final Pattern52 pattern1 = new Pattern52();
-        pattern1.setFactType( "FactType1" );
-        pattern1.setBoundName( "$fact1" );
+        pattern1.setFactType("FactType1");
+        pattern1.setBoundName("$fact1");
         final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField( "field" );
-        condition1.setBinding( "$field1" );
-        pattern1.getChildColumns().add( condition1 );
+        condition1.setFactField("field");
+        condition1.setBinding("$field1");
+        pattern1.getChildColumns().add(condition1);
 
         final Pattern52 pattern2 = new Pattern52();
-        pattern2.setFactType( "FactType1" );
+        pattern2.setFactType("FactType1");
         final ConditionCol52 condition2 = new ConditionCol52();
-        condition2.setFactField( "field" );
-        pattern2.getChildColumns().add( condition2 );
+        condition2.setFactField("field");
+        pattern2.getChildColumns().add(condition2);
 
-        when( oracle.getFieldClassName( eq( "FactType1" ),
-                                        eq( "field" ) ) ).thenReturn( "FactType1" );
+        when(oracle.getFieldClassName(eq("FactType1"),
+                                      eq("field"))).thenReturn("FactType1");
 
-        dtPresenter.getModel().getConditions().add( pattern1 );
-        dtPresenter.getModel().getConditions().add( pattern2 );
+        dtPresenter.getModel().getConditions().add(pattern1);
+        dtPresenter.getModel().getConditions().add(pattern2);
 
-        final Set<String> bindings = dtPresenter.getBindings( "org.drools.workbench.screens.guided.dtable.client.widget.table.FactType1" );
+        final Set<String> bindings = dtPresenter.getBindings("org.drools.workbench.screens.guided.dtable.client.widget.table.FactType1");
 
-        assertNotNull( bindings );
-        assertEquals( 1,
-                      bindings.size() );
-        assertTrue( bindings.contains( "$fact1" ) );
+        assertNotNull(bindings);
+        assertEquals(1,
+                     bindings.size());
+        assertTrue(bindings.contains("$fact1"));
     }
 
     @Test
     public void canConditionBeDeletedWithSingleChildColumnWithAction() {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType1" );
-        pattern.setBoundName( "$fact" );
+        pattern.setFactType("FactType1");
+        pattern.setBoundName("$fact");
         final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField( "field1" );
-        pattern.getChildColumns().add( condition1 );
+        condition1.setFactField("field1");
+        pattern.getChildColumns().add(condition1);
 
-        dtPresenter.getModel().getConditions().add( pattern );
+        dtPresenter.getModel().getConditions().add(pattern);
 
         final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType( "FactType1" );
-        action.setBoundName( "$fact" );
-        action.setFactField( "field" );
+        action.setFactType("FactType1");
+        action.setBoundName("$fact");
+        action.setFactField("field");
 
-        dtPresenter.getModel().getActionCols().add( action );
+        dtPresenter.getModel().getActionCols().add(action);
 
-        assertFalse( dtPresenter.canConditionBeDeleted( condition1 ) );
+        assertFalse(dtPresenter.canConditionBeDeleted(condition1));
     }
 
     @Test
     public void canConditionBeDeletedWithSingleChildColumnWithNoAction() {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType1" );
+        pattern.setFactType("FactType1");
         final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField( "field1" );
-        pattern.getChildColumns().add( condition1 );
+        condition1.setFactField("field1");
+        pattern.getChildColumns().add(condition1);
 
-        dtPresenter.getModel().getConditions().add( pattern );
+        dtPresenter.getModel().getConditions().add(pattern);
 
-        assertTrue( dtPresenter.canConditionBeDeleted( condition1 ) );
+        assertTrue(dtPresenter.canConditionBeDeleted(condition1));
     }
 
     @Test
     public void canConditionBeDeletedWithMultipleChildColumns() {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType1" );
+        pattern.setFactType("FactType1");
         final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField( "field1" );
-        pattern.getChildColumns().add( condition1 );
+        condition1.setFactField("field1");
+        pattern.getChildColumns().add(condition1);
         final ConditionCol52 condition2 = new ConditionCol52();
-        condition2.setFactField( "field2" );
-        pattern.getChildColumns().add( condition2 );
+        condition2.setFactField("field2");
+        pattern.getChildColumns().add(condition2);
 
-        dtPresenter.getModel().getConditions().add( pattern );
+        dtPresenter.getModel().getConditions().add(pattern);
 
-        assertTrue( dtPresenter.canConditionBeDeleted( condition1 ) );
+        assertTrue(dtPresenter.canConditionBeDeleted(condition1));
     }
 
     @Test
     public void canBRLFragmentConditionBeDeletedWithAction() {
-        final FactPattern fp = new FactPattern( "FactType1" );
-        fp.setBoundName( "$fact" );
+        final FactPattern fp = new FactPattern("FactType1");
+        fp.setBoundName("$fact");
         final BRLConditionColumn column = new BRLConditionColumn();
-        column.getDefinition().add( fp );
+        column.getDefinition().add(fp);
 
-        dtPresenter.getModel().getConditions().add( column );
+        dtPresenter.getModel().getConditions().add(column);
 
         final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType( "FactType1" );
-        action.setBoundName( "$fact" );
-        action.setFactField( "field" );
+        action.setFactType("FactType1");
+        action.setBoundName("$fact");
+        action.setFactField("field");
 
-        dtPresenter.getModel().getActionCols().add( action );
+        dtPresenter.getModel().getActionCols().add(action);
 
-        assertFalse( dtPresenter.canConditionBeDeleted( column ) );
+        assertFalse(dtPresenter.canConditionBeDeleted(column));
     }
 
     @Test
     public void canBRLFragmentConditionBeDeletedWithNoAction() {
-        final FactPattern fp = new FactPattern( "FactType1" );
-        fp.setBoundName( "$fact" );
+        final FactPattern fp = new FactPattern("FactType1");
+        fp.setBoundName("$fact");
         final BRLConditionColumn column = new BRLConditionColumn();
-        column.getDefinition().add( fp );
+        column.getDefinition().add(fp);
 
-        dtPresenter.getModel().getConditions().add( column );
+        dtPresenter.getModel().getConditions().add(column);
 
-        assertTrue( dtPresenter.canConditionBeDeleted( column ) );
+        assertTrue(dtPresenter.canConditionBeDeleted(column));
     }
 
     @Test
     public void getValueListLookups() {
         final AttributeCol52 attribute = new AttributeCol52();
-        attribute.setAttribute( RuleAttributeWidget.ENABLED_ATTR );
+        attribute.setAttribute(RuleAttributeWidget.ENABLED_ATTR);
 
-        final Map<String, String> valueList = dtPresenter.getValueListLookups( attribute );
+        final Map<String, String> valueList = dtPresenter.getValueListLookups(attribute);
 
-        assertNotNull( valueList );
-        assertEquals( 2,
-                      valueList.size() );
-        assertTrue( valueList.containsKey( "true" ) );
-        assertTrue( valueList.containsKey( "false" ) );
+        assertNotNull(valueList);
+        assertEquals(2,
+                     valueList.size());
+        assertTrue(valueList.containsKey("true"));
+        assertTrue(valueList.containsKey("false"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void getEnumLookupsWithNoEnumsDefined() {
-        final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
-        final Callback<Map<String, String>> callback = mock( Callback.class );
+        final DependentEnumsUtilities.Context context = mock(DependentEnumsUtilities.Context.class);
+        final Callback<Map<String, String>> callback = mock(Callback.class);
 
-        dtPresenter.getEnumLookups( "FactType",
-                                    "field",
-                                    context,
-                                    callback );
+        dtPresenter.getEnumLookups("FactType",
+                                   "field",
+                                   context,
+                                   callback);
 
-        verify( callback,
-                times( 1 ) ).callback( callbackValueCaptor.capture() );
+        verify(callback,
+               times(1)).callback(callbackValueCaptor.capture());
 
         final Map<String, String> callbackValue = callbackValueCaptor.getValue();
-        assertNotNull( callbackValue );
-        assertTrue( callbackValue.isEmpty() );
+        assertNotNull(callbackValue);
+        assertTrue(callbackValue.isEmpty());
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void getEnumLookupsWithFixedListDefinition() {
-        final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
-        final Callback<Map<String, String>> callback = mock( Callback.class );
-        final DropDownData dd = DropDownData.create( new String[]{ "one", "two" } );
+        final DependentEnumsUtilities.Context context = mock(DependentEnumsUtilities.Context.class);
+        final Callback<Map<String, String>> callback = mock(Callback.class);
+        final DropDownData dd = DropDownData.create(new String[]{"one", "two"});
 
-        when( oracle.getEnums( eq( "FactType" ),
-                               eq( "field" ),
-                               any( Map.class ) ) ).thenReturn( dd );
+        when(oracle.getEnums(eq("FactType"),
+                             eq("field"),
+                             any(Map.class))).thenReturn(dd);
 
-        dtPresenter.getEnumLookups( "FactType",
-                                    "field",
-                                    context,
-                                    callback );
+        dtPresenter.getEnumLookups("FactType",
+                                   "field",
+                                   context,
+                                   callback);
 
-        verify( callback,
-                times( 1 ) ).callback( callbackValueCaptor.capture() );
+        verify(callback,
+               times(1)).callback(callbackValueCaptor.capture());
 
         final Map<String, String> callbackValue = callbackValueCaptor.getValue();
-        assertNotNull( callbackValue );
-        assertFalse( callbackValue.isEmpty() );
-        assertTrue( callbackValue.containsKey( "one" ) );
-        assertTrue( callbackValue.containsKey( "two" ) );
+        assertNotNull(callbackValue);
+        assertFalse(callbackValue.isEmpty());
+        assertTrue(callbackValue.containsKey("one"));
+        assertTrue(callbackValue.containsKey("two"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void getEnumLookupsWithFixedListDefinitionWithSplitter() {
-        final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
-        final Callback<Map<String, String>> callback = mock( Callback.class );
-        final DropDownData dd = DropDownData.create( new String[]{ "1=one", "2=two" } );
+        final DependentEnumsUtilities.Context context = mock(DependentEnumsUtilities.Context.class);
+        final Callback<Map<String, String>> callback = mock(Callback.class);
+        final DropDownData dd = DropDownData.create(new String[]{"1=one", "2=two"});
 
-        when( oracle.getEnums( eq( "FactType" ),
-                               eq( "field" ),
-                               any( Map.class ) ) ).thenReturn( dd );
+        when(oracle.getEnums(eq("FactType"),
+                             eq("field"),
+                             any(Map.class))).thenReturn(dd);
 
-        dtPresenter.getEnumLookups( "FactType",
-                                    "field",
-                                    context,
-                                    callback );
+        dtPresenter.getEnumLookups("FactType",
+                                   "field",
+                                   context,
+                                   callback);
 
-        verify( callback,
-                times( 1 ) ).callback( callbackValueCaptor.capture() );
+        verify(callback,
+               times(1)).callback(callbackValueCaptor.capture());
 
         final Map<String, String> callbackValue = callbackValueCaptor.getValue();
-        assertNotNull( callbackValue );
-        assertFalse( callbackValue.isEmpty() );
-        assertTrue( callbackValue.containsKey( "1" ) );
-        assertTrue( callbackValue.containsKey( "2" ) );
-        assertEquals( "one",
-                      callbackValue.get( "1" ) );
-        assertEquals( "two",
-                      callbackValue.get( "2" ) );
+        assertNotNull(callbackValue);
+        assertFalse(callbackValue.isEmpty());
+        assertTrue(callbackValue.containsKey("1"));
+        assertTrue(callbackValue.containsKey("2"));
+        assertEquals("one",
+                     callbackValue.get("1"));
+        assertEquals("two",
+                     callbackValue.get("2"));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void getEnumLookupsWithQueryExpressionDefinition() {
-        final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
-        final Callback<Map<String, String>> callback = mock( Callback.class );
-        final DropDownData dd = DropDownData.create( "query",
-                                                     new String[]{ "one", "two" } );
+        final DependentEnumsUtilities.Context context = mock(DependentEnumsUtilities.Context.class);
+        final Callback<Map<String, String>> callback = mock(Callback.class);
+        final DropDownData dd = DropDownData.create("query",
+                                                    new String[]{"one", "two"});
 
-        when( oracle.getEnums( eq( "FactType" ),
-                               eq( "field" ),
-                               any( Map.class ) ) ).thenReturn( dd );
-        when( enumDropdownService.loadDropDownExpression( any( Path.class ),
-                                                          any( String[].class ),
-                                                          any( String.class ) ) ).thenReturn( new String[]{ "three", "four" } );
+        when(oracle.getEnums(eq("FactType"),
+                             eq("field"),
+                             any(Map.class))).thenReturn(dd);
+        when(enumDropdownService.loadDropDownExpression(any(Path.class),
+                                                        any(String[].class),
+                                                        any(String.class))).thenReturn(new String[]{"three", "four"});
 
-        dtPresenter.getEnumLookups( "FactType",
-                                    "field",
-                                    context,
-                                    callback );
+        dtPresenter.getEnumLookups("FactType",
+                                   "field",
+                                   context,
+                                   callback);
 
-        verify( callback,
-                times( 1 ) ).callback( callbackValueCaptor.capture() );
+        verify(callback,
+               times(1)).callback(callbackValueCaptor.capture());
 
         final Map<String, String> callbackValue = callbackValueCaptor.getValue();
-        assertNotNull( callbackValue );
-        assertFalse( callbackValue.isEmpty() );
-        assertTrue( callbackValue.containsKey( "three" ) );
-        assertTrue( callbackValue.containsKey( "four" ) );
+        assertNotNull(callbackValue);
+        assertFalse(callbackValue.isEmpty());
+        assertTrue(callbackValue.containsKey("three"));
+        assertTrue(callbackValue.containsKey("four"));
     }
 
     @Test
     public void newConditionColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newConditionColumn();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryConditionColumn();
-        verify( view,
-                never() ).newLimitedEntryConditionColumn();
+        verify(view,
+               times(1)).newExtendedEntryConditionColumn();
+        verify(view,
+               never()).newLimitedEntryConditionColumn();
     }
 
     @Test
     public void newLimitedEntryConditionColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newConditionColumn();
 
-        verify( view,
-                never() ).newExtendedEntryConditionColumn();
-        verify( view,
-                times( 1 ) ).newLimitedEntryConditionColumn();
+        verify(view,
+               never()).newExtendedEntryConditionColumn();
+        verify(view,
+               times(1)).newLimitedEntryConditionColumn();
     }
 
     @Test
     public void newConditionBRLFragment() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newConditionBRLFragment();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryConditionBRLFragment();
-        verify( view,
-                never() ).newLimitedEntryConditionBRLFragment();
+        verify(view,
+               times(1)).newExtendedEntryConditionBRLFragment();
+        verify(view,
+               never()).newLimitedEntryConditionBRLFragment();
     }
 
     @Test
     public void newLimitedEntryConditionBRLFragment() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newConditionBRLFragment();
 
-        verify( view,
-                never() ).newExtendedEntryConditionBRLFragment();
-        verify( view,
-                times( 1 ) ).newLimitedEntryConditionBRLFragment();
+        verify(view,
+               never()).newExtendedEntryConditionBRLFragment();
+        verify(view,
+               times(1)).newLimitedEntryConditionBRLFragment();
     }
 
     @Test
     public void newActionInsertColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newActionInsertColumn();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryActionInsertColumn();
-        verify( view,
-                never() ).newLimitedEntryActionInsertColumn();
+        verify(view,
+               times(1)).newExtendedEntryActionInsertColumn();
+        verify(view,
+               never()).newLimitedEntryActionInsertColumn();
     }
 
     @Test
     public void newLimitedEntryActionInsertColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newActionInsertColumn();
 
-        verify( view,
-                never() ).newExtendedEntryActionInsertColumn();
-        verify( view,
-                times( 1 ) ).newLimitedEntryActionInsertColumn();
+        verify(view,
+               never()).newExtendedEntryActionInsertColumn();
+        verify(view,
+               times(1)).newLimitedEntryActionInsertColumn();
     }
 
     @Test
     public void newActionSetColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newActionSetColumn();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryActionSetColumn();
-        verify( view,
-                never() ).newLimitedEntryActionSetColumn();
+        verify(view,
+               times(1)).newExtendedEntryActionSetColumn();
+        verify(view,
+               never()).newLimitedEntryActionSetColumn();
     }
 
     @Test
     public void newLimitedEntryActionSetColumn() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newActionSetColumn();
 
-        verify( view,
-                never() ).newExtendedEntryActionSetColumn();
-        verify( view,
-                times( 1 ) ).newLimitedEntryActionSetColumn();
+        verify(view,
+               never()).newExtendedEntryActionSetColumn();
+        verify(view,
+               times(1)).newLimitedEntryActionSetColumn();
     }
 
     @Test
     public void newActionRetractFact() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newActionRetractFact();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryActionRetractFact();
-        verify( view,
-                never() ).newLimitedEntryActionRetractFact();
+        verify(view,
+               times(1)).newExtendedEntryActionRetractFact();
+        verify(view,
+               never()).newLimitedEntryActionRetractFact();
     }
 
     @Test
     public void newLimitedEntryActionRetractFact() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newActionRetractFact();
 
-        verify( view,
-                never() ).newExtendedEntryActionRetractFact();
-        verify( view,
-                times( 1 ) ).newLimitedEntryActionRetractFact();
+        verify(view,
+               never()).newExtendedEntryActionRetractFact();
+        verify(view,
+               times(1)).newLimitedEntryActionRetractFact();
     }
 
     @Test
     public void newActionWorkItem() {
         dtPresenter.newActionWorkItem();
 
-        verify( view,
-                times( 1 ) ).newActionWorkItem();
+        verify(view,
+               times(1)).newActionWorkItem();
     }
 
     @Test
     public void newActionWorkItemSetField() {
         dtPresenter.newActionWorkItemSetField();
 
-        verify( view,
-                times( 1 ) ).newActionWorkItemSetField();
+        verify(view,
+               times(1)).newActionWorkItemSetField();
     }
 
     @Test
     public void newActionWorkItemInsertFact() {
         dtPresenter.newActionWorkItemInsertFact();
 
-        verify( view,
-                times( 1 ) ).newActionWorkItemInsertFact();
+        verify(view,
+               times(1)).newActionWorkItemInsertFact();
     }
 
     @Test
     public void newActionBRLFragment() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
 
         dtPresenter.newActionBRLFragment();
 
-        verify( view,
-                times( 1 ) ).newExtendedEntryActionBRLFragment();
-        verify( view,
-                never() ).newLimitedEntryActionBRLFragment();
+        verify(view,
+               times(1)).newExtendedEntryActionBRLFragment();
+        verify(view,
+               never()).newLimitedEntryActionBRLFragment();
     }
 
     @Test
     public void newLimitedEntryActionBRLFragment() {
-        dtPresenter.getModel().setTableFormat( GuidedDecisionTable52.TableFormat.LIMITED_ENTRY );
+        dtPresenter.getModel().setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
 
         dtPresenter.newActionBRLFragment();
 
-        verify( view,
-                never() ).newExtendedEntryActionBRLFragment();
-        verify( view,
-                times( 1 ) ).newLimitedEntryActionBRLFragment();
+        verify(view,
+               never()).newExtendedEntryActionBRLFragment();
+        verify(view,
+               times(1)).newLimitedEntryActionBRLFragment();
     }
 
     @Test
     public void editConditionWithPatternAndCondition() {
-        dtPresenter.editCondition( mock( Pattern52.class ),
-                                   mock( ConditionCol52.class ) );
+        dtPresenter.editCondition(mock(Pattern52.class),
+                                  mock(ConditionCol52.class));
 
-        verify( view,
-                times( 1 ) ).editCondition( any( Pattern52.class ),
-                                            any( ConditionCol52.class ) );
+        verify(view,
+               times(1)).editCondition(any(Pattern52.class),
+                                       any(ConditionCol52.class));
     }
 
     @Test
     public void editConditionWithBRLCondition() {
-        dtPresenter.editCondition( mock( BRLConditionColumn.class ) );
+        dtPresenter.editCondition(mock(BRLConditionColumn.class));
 
-        verify( view,
-                times( 1 ) ).editExtendedEntryConditionBRLFragment( any( BRLConditionColumn.class ) );
-        verify( view,
-                never() ).editLimitedEntryConditionBRLFragment( any( LimitedEntryBRLConditionColumn.class ) );
+        verify(view,
+               times(1)).editExtendedEntryConditionBRLFragment(any(BRLConditionColumn.class));
+        verify(view,
+               never()).editLimitedEntryConditionBRLFragment(any(LimitedEntryBRLConditionColumn.class));
     }
 
     @Test
     public void editLimitedEntryConditionWithBRLCondition() {
-        dtPresenter.editCondition( mock( LimitedEntryBRLConditionColumn.class ) );
+        dtPresenter.editCondition(mock(LimitedEntryBRLConditionColumn.class));
 
-        verify( view,
-                never() ).editExtendedEntryConditionBRLFragment( any( BRLConditionColumn.class ) );
-        verify( view,
-                times( 1 ) ).editLimitedEntryConditionBRLFragment( any( LimitedEntryBRLConditionColumn.class ) );
+        verify(view,
+               never()).editExtendedEntryConditionBRLFragment(any(BRLConditionColumn.class));
+        verify(view,
+               times(1)).editLimitedEntryConditionBRLFragment(any(LimitedEntryBRLConditionColumn.class));
     }
 
     @Test
     public void editActionWorkItemSetFieldColumn() {
-        dtPresenter.editAction( mock( ActionWorkItemSetFieldCol52.class ) );
+        dtPresenter.editAction(mock(ActionWorkItemSetFieldCol52.class));
 
-        verify( view,
-                times( 1 ) ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               times(1)).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editActionSetFieldColumn() {
-        dtPresenter.editAction( mock( ActionSetFieldCol52.class ) );
+        dtPresenter.editAction(mock(ActionSetFieldCol52.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                times( 1 ) ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               times(1)).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editActionWorkItemInsertFactColumn() {
-        dtPresenter.editAction( mock( ActionWorkItemInsertFactCol52.class ) );
+        dtPresenter.editAction(mock(ActionWorkItemInsertFactCol52.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                times( 1 ) ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               times(1)).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editActionInsertFactColumn() {
-        dtPresenter.editAction( mock( ActionInsertFactCol52.class ) );
+        dtPresenter.editAction(mock(ActionInsertFactCol52.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                times( 1 ) ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               times(1)).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editActionRetractFactColumn() {
-        dtPresenter.editAction( mock( ActionRetractFactCol52.class ) );
+        dtPresenter.editAction(mock(ActionRetractFactCol52.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                times( 1 ) ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               times(1)).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editActionWorkItemColumn() {
-        dtPresenter.editAction( mock( ActionWorkItemCol52.class ) );
+        dtPresenter.editAction(mock(ActionWorkItemCol52.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                times( 1 ) ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               times(1)).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editLimitedEntryBRLActionColumn() {
-        dtPresenter.editAction( mock( LimitedEntryBRLActionColumn.class ) );
+        dtPresenter.editAction(mock(LimitedEntryBRLActionColumn.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                times( 1 ) ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                never() ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               times(1)).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               never()).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void editBRLActionColumn() {
-        dtPresenter.editAction( mock( BRLActionColumn.class ) );
+        dtPresenter.editAction(mock(BRLActionColumn.class));
 
-        verify( view,
-                never() ).editActionWorkItemSetField( any( ActionWorkItemSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionSetField( any( ActionSetFieldCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItemInsertFact( any( ActionWorkItemInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionInsertFact( any( ActionInsertFactCol52.class ) );
-        verify( view,
-                never() ).editActionRetractFact( any( ActionRetractFactCol52.class ) );
-        verify( view,
-                never() ).editActionWorkItem( any( ActionWorkItemCol52.class ) );
-        verify( view,
-                never() ).editLimitedEntryActionBRLFragment( any( LimitedEntryBRLActionColumn.class ) );
-        verify( view,
-                times( 1 ) ).editExtendedEntryActionBRLFragment( any( BRLActionColumn.class ) );
+        verify(view,
+               never()).editActionWorkItemSetField(any(ActionWorkItemSetFieldCol52.class));
+        verify(view,
+               never()).editActionSetField(any(ActionSetFieldCol52.class));
+        verify(view,
+               never()).editActionWorkItemInsertFact(any(ActionWorkItemInsertFactCol52.class));
+        verify(view,
+               never()).editActionInsertFact(any(ActionInsertFactCol52.class));
+        verify(view,
+               never()).editActionRetractFact(any(ActionRetractFactCol52.class));
+        verify(view,
+               never()).editActionWorkItem(any(ActionWorkItemCol52.class));
+        verify(view,
+               never()).editLimitedEntryActionBRLFragment(any(LimitedEntryBRLActionColumn.class));
+        verify(view,
+               times(1)).editExtendedEntryActionBRLFragment(any(BRLActionColumn.class));
     }
 
     @Test
     public void appendPatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
-        reset( modellerPresenter );
+        reset(modellerPresenter);
 
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType" );
+        pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        condition.setHeader( "header" );
+        condition.setFactField("field");
+        condition.setHeader("header");
 
-        dtPresenter.appendColumn( pattern,
-                                  condition );
+        dtPresenter.appendColumn(pattern,
+                                 condition);
 
-        verify( synchronizer,
-                times( 1 ) ).appendColumn( eq( pattern ),
-                                           eq( condition ) );
-        verify( refreshConditionsPanelEvent,
-                times( 1 ) ).fire( any( RefreshConditionsPanelEvent.class ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).appendColumn(eq(pattern),
+                                      eq(condition));
+        verify(refreshConditionsPanelEvent,
+               times(1)).fire(any(RefreshConditionsPanelEvent.class));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void appendConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
-        reset( modellerPresenter );
+        reset(modellerPresenter);
 
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        condition.setHeader( "header" );
+        condition.setFactField("field");
+        condition.setHeader("header");
 
-        dtPresenter.appendColumn( condition );
+        dtPresenter.appendColumn(condition);
 
-        verify( synchronizer,
-                times( 1 ) ).appendColumn( eq( condition ) );
-        verify( refreshConditionsPanelEvent,
-                times( 1 ) ).fire( any( RefreshConditionsPanelEvent.class ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).appendColumn(eq(condition));
+        verify(refreshConditionsPanelEvent,
+               times(1)).fire(any(RefreshConditionsPanelEvent.class));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void appendActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
-        reset( modellerPresenter );
+        reset(modellerPresenter);
 
         final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType( "FactType" );
-        action.setFactField( "field" );
-        action.setHeader( "header" );
-        when( oracle.getFieldType( eq( "FactType" ),
-                                   eq( "field" ) ) ).thenReturn( DataType.TYPE_STRING );
+        action.setFactType("FactType");
+        action.setFactField("field");
+        action.setHeader("header");
+        when(oracle.getFieldType(eq("FactType"),
+                                 eq("field"))).thenReturn(DataType.TYPE_STRING);
 
-        dtPresenter.appendColumn( action );
+        dtPresenter.appendColumn(action);
 
-        verify( synchronizer,
-                times( 1 ) ).appendColumn( eq( action ) );
-        verify( refreshActionsPanelEvent,
-                times( 1 ) ).fire( any( RefreshActionsPanelEvent.class ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).appendColumn(eq(action));
+        verify(refreshActionsPanelEvent,
+               times(1)).fire(any(RefreshActionsPanelEvent.class));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void appendRow() throws ModelSynchronizer.MoveColumnVetoException {
-        reset( synchronizer,
-               modellerPresenter );
+        reset(synchronizer,
+              modellerPresenter);
 
         dtPresenter.onAppendRow();
 
-        verify( synchronizer,
-                times( 1 ) ).appendRow();
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).appendRow();
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void deleteConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType" );
+        pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        condition.setHeader( "header" );
-        dtPresenter.appendColumn( pattern,
-                                  condition );
-        reset( modellerPresenter );
+        condition.setFactField("field");
+        condition.setHeader("header");
+        dtPresenter.appendColumn(pattern,
+                                 condition);
+        reset(modellerPresenter);
 
-        dtPresenter.deleteColumn( condition );
+        dtPresenter.deleteColumn(condition);
 
-        verify( synchronizer,
-                times( 1 ) ).deleteColumn( eq( condition ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).deleteColumn(eq(condition));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void deleteActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
-        column.setFactType( "FactType" );
-        column.setFactField( "field" );
-        column.setHeader( "header" );
-        when( oracle.getFieldType( eq( "FactType" ),
-                                   eq( "field" ) ) ).thenReturn( DataType.TYPE_STRING );
-        dtPresenter.appendColumn( column );
-        reset( modellerPresenter );
+        column.setFactType("FactType");
+        column.setFactField("field");
+        column.setHeader("header");
+        when(oracle.getFieldType(eq("FactType"),
+                                 eq("field"))).thenReturn(DataType.TYPE_STRING);
+        dtPresenter.appendColumn(column);
+        reset(modellerPresenter);
 
-        dtPresenter.deleteColumn( column );
+        dtPresenter.deleteColumn(column);
 
-        verify( synchronizer,
-                times( 1 ) ).deleteColumn( eq( column ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).deleteColumn(eq(column));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void deleteAttributeColumn() throws Exception {
         final AttributeCol52 column = new AttributeCol52();
         column.setAttribute("salience");
-        dtPresenter.appendColumn( column );
-        reset( modellerPresenter );
+        dtPresenter.appendColumn(column);
+        reset(modellerPresenter);
 
-        dtPresenter.deleteColumn( column );
+        dtPresenter.deleteColumn(column);
 
-        verify( synchronizer,
-                times( 1 ) ).deleteColumn( eq( column ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).deleteColumn(eq(column));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
 
-        verify( refreshAttributesPanelEvent, times(2) ).fire( any( RefreshAttributesPanelEvent.class ) );
+        verify(refreshAttributesPanelEvent,
+               times(2)).fire(any(RefreshAttributesPanelEvent.class));
     }
 
     @Test
     public void updatePatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType" );
-        pattern.setBoundName( "$f" );
+        pattern.setFactType("FactType");
+        pattern.setBoundName("$f");
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        condition.setHeader( "header" );
-        dtPresenter.appendColumn( pattern,
-                                  condition );
-        reset( modellerPresenter );
+        condition.setFactField("field");
+        condition.setHeader("header");
+        dtPresenter.appendColumn(pattern,
+                                 condition);
+        reset(modellerPresenter);
 
         final Pattern52 updatePattern = new Pattern52();
-        updatePattern.setFactType( "NewType" );
-        updatePattern.setBoundName( "$f" );
+        updatePattern.setFactType("NewType");
+        updatePattern.setBoundName("$f");
         final ConditionCol52 updateCondition = new ConditionCol52();
-        updateCondition.setFactField( "newField" );
-        updateCondition.setHeader( "newHeader" );
+        updateCondition.setFactField("newField");
+        updateCondition.setHeader("newHeader");
 
-        dtPresenter.updateColumn( pattern,
-                                  condition,
-                                  updatePattern,
-                                  updateCondition );
+        dtPresenter.updateColumn(pattern,
+                                 condition,
+                                 updatePattern,
+                                 updateCondition);
 
-        verify( synchronizer,
-                times( 1 ) ).updateColumn( eq( pattern ),
-                                           eq( condition ),
-                                           eq( updatePattern ),
-                                           eq( updateCondition ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).updateColumn(eq(pattern),
+                                      eq(condition),
+                                      eq(updatePattern),
+                                      eq(updateCondition));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void updateConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
         final Pattern52 pattern = new Pattern52();
-        pattern.setFactType( "FactType" );
+        pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
-        condition.setFactField( "field" );
-        condition.setHeader( "header" );
-        dtPresenter.appendColumn( pattern,
-                                  condition );
-        reset( modellerPresenter );
+        condition.setFactField("field");
+        condition.setHeader("header");
+        dtPresenter.appendColumn(pattern,
+                                 condition);
+        reset(modellerPresenter);
 
         final ConditionCol52 updateCondition = new ConditionCol52();
-        updateCondition.setFactField( "newField" );
-        updateCondition.setHeader( "newHeader" );
+        updateCondition.setFactField("newField");
+        updateCondition.setHeader("newHeader");
 
-        dtPresenter.updateColumn( condition,
-                                  updateCondition );
+        dtPresenter.updateColumn(condition,
+                                 updateCondition);
 
-        verify( synchronizer,
-                times( 1 ) ).updateColumn( eq( condition ),
-                                           eq( updateCondition ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).updateColumn(eq(condition),
+                                      eq(updateCondition));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     public void updateActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
-        column.setFactType( "FactType" );
-        column.setFactField( "field" );
-        column.setHeader( "header" );
-        when( oracle.getFieldType( eq( "FactType" ),
-                                   eq( "field" ) ) ).thenReturn( DataType.TYPE_STRING );
-        dtPresenter.appendColumn( column );
-        reset( modellerPresenter );
+        column.setFactType("FactType");
+        column.setFactField("field");
+        column.setHeader("header");
+        when(oracle.getFieldType(eq("FactType"),
+                                 eq("field"))).thenReturn(DataType.TYPE_STRING);
+        dtPresenter.appendColumn(column);
+        reset(modellerPresenter);
 
         final ActionInsertFactCol52 update = new ActionInsertFactCol52();
-        update.setFactType( "NewType" );
-        update.setFactField( "newField" );
-        update.setHeader( "newHeader" );
-        when( oracle.getFieldType( eq( "NewType" ),
-                                   eq( "newField" ) ) ).thenReturn( DataType.TYPE_STRING );
+        update.setFactType("NewType");
+        update.setFactField("newField");
+        update.setHeader("newHeader");
+        when(oracle.getFieldType(eq("NewType"),
+                                 eq("newField"))).thenReturn(DataType.TYPE_STRING);
 
-        dtPresenter.updateColumn( column,
-                                  update );
+        dtPresenter.updateColumn(column,
+                                 update);
 
-        verify( synchronizer,
-                times( 1 ) ).updateColumn( eq( column ),
-                                           eq( update ) );
-        verify( modellerPresenter,
-                times( 1 ) ).updateLinks();
+        verify(synchronizer,
+               times(1)).updateColumn(eq(column),
+                                      eq(update));
+        verify(modellerPresenter,
+               times(1)).updateLinks();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void onCutWithSelection() {
-        dtPresenter.getUiModel().selectCell( 0, 0 );
+        dtPresenter.getUiModel().selectCell(0,
+                                            0);
 
         dtPresenter.onCut();
 
-        verify( clipboard,
-                times( 1 ) ).setData( any( Set.class ) );
+        verify(clipboard,
+               times(1)).setData(any(Set.class));
     }
 
     @Test
@@ -1264,19 +1356,20 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     public void onCutWithoutSelection() {
         dtPresenter.onCut();
 
-        verify( clipboard,
-                never() ).setData( any( Set.class ) );
+        verify(clipboard,
+               never()).setData(any(Set.class));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void onCopyWithSelection() {
-        dtPresenter.getUiModel().selectCell( 0, 0 );
+        dtPresenter.getUiModel().selectCell(0,
+                                            0);
 
         dtPresenter.onCopy();
 
-        verify( clipboard,
-                times( 1 ) ).setData( any( Set.class ) );
+        verify(clipboard,
+               times(1)).setData(any(Set.class));
     }
 
     @Test
@@ -1284,296 +1377,297 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     public void onCopyWithoutSelection() {
         dtPresenter.onCopy();
 
-        verify( clipboard,
-                never() ).setData( any( Set.class ) );
+        verify(clipboard,
+               never()).setData(any(Set.class));
     }
 
     @Test
     public void onPasteWithClipboardDataWithSelection() {
-        dtPresenter.getUiModel().selectCell( 0, 0 );
+        dtPresenter.getUiModel().selectCell(0,
+                                            0);
         dtPresenter.onCopy();
 
-        dtPresenter.getUiModel().selectCell( 1, 0 );
+        dtPresenter.getUiModel().selectCell(1,
+                                            0);
         dtPresenter.onPaste();
 
-        verify( clipboard,
-                times( 1 ) ).getData();
+        verify(clipboard,
+               times(1)).getData();
     }
 
     @Test
     public void onPasteWithClipboardDataWithoutSelection() {
         dtPresenter.onPaste();
 
-        verify( clipboard,
-                never() ).getData();
+        verify(clipboard,
+               never()).getData();
     }
 
     @Test
     public void onDeleteSelectedCellsWithSelection() {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            1 );
+        uiModel.selectCell(0,
+                           1);
 
-        final ArgumentCaptor<Integer> columnIndexCaptor = ArgumentCaptor.forClass( Integer.class );
-        final ArgumentCaptor<GridData.Range> rowRangeCaptor = ArgumentCaptor.forClass( GridData.Range.class );
+        final ArgumentCaptor<Integer> columnIndexCaptor = ArgumentCaptor.forClass(Integer.class);
+        final ArgumentCaptor<GridData.Range> rowRangeCaptor = ArgumentCaptor.forClass(GridData.Range.class);
 
         dtPresenter.onDeleteSelectedCells();
 
-        verify( synchronizer,
-                times( 1 ) ).deleteCell( rowRangeCaptor.capture(),
-                                         columnIndexCaptor.capture() );
+        verify(synchronizer,
+               times(1)).deleteCell(rowRangeCaptor.capture(),
+                                    columnIndexCaptor.capture());
 
         final Integer columnIndex = columnIndexCaptor.getValue();
         final GridData.Range rowRange = rowRangeCaptor.getValue();
-        assertEquals( 0,
-                      rowRange.getMinRowIndex() );
-        assertEquals( 0,
-                      rowRange.getMaxRowIndex() );
-        assertEquals( 1,
-                      columnIndex.intValue() );
+        assertEquals(0,
+                     rowRange.getMinRowIndex());
+        assertEquals(0,
+                     rowRange.getMaxRowIndex());
+        assertEquals(1,
+                     columnIndex.intValue());
     }
 
     @Test
     public void onDeleteSelectedCellsWithSelectionWithBooleanColumn() {
         final AttributeCol52 column = new AttributeCol52() {{
-            setAttribute( RuleAttributeWidget.ENABLED_ATTR );
+            setAttribute(RuleAttributeWidget.ENABLED_ATTR);
         }};
-        dtPresenter.appendColumn( column );
+        dtPresenter.appendColumn(column);
 
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            2 );
+        uiModel.selectCell(0,
+                           2);
 
         dtPresenter.onDeleteSelectedCells();
 
-        verify( synchronizer,
-                never() ).deleteCell( any( GridData.Range.class ),
-                                      any( Integer.class ) );
+        verify(synchronizer,
+               never()).deleteCell(any(GridData.Range.class),
+                                   any(Integer.class));
     }
 
     @Test
     public void onDeleteSelectedCellsWithSelectionsWithBooleanColumn() {
         final AttributeCol52 column = new AttributeCol52() {{
-            setAttribute( RuleAttributeWidget.ENABLED_ATTR );
+            setAttribute(RuleAttributeWidget.ENABLED_ATTR);
         }};
-        dtPresenter.appendColumn( column );
+        dtPresenter.appendColumn(column);
 
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            1 );
-        uiModel.selectCell( 0,
-                            2 );
+        uiModel.selectCell(0,
+                           1);
+        uiModel.selectCell(0,
+                           2);
 
-        final ArgumentCaptor<Integer> columnIndexCaptor = ArgumentCaptor.forClass( Integer.class );
-        final ArgumentCaptor<GridData.Range> rowRangeCaptor = ArgumentCaptor.forClass( GridData.Range.class );
+        final ArgumentCaptor<Integer> columnIndexCaptor = ArgumentCaptor.forClass(Integer.class);
+        final ArgumentCaptor<GridData.Range> rowRangeCaptor = ArgumentCaptor.forClass(GridData.Range.class);
 
         dtPresenter.onDeleteSelectedCells();
 
-        verify( synchronizer,
-                times( 1 ) ).deleteCell( rowRangeCaptor.capture(),
-                                         columnIndexCaptor.capture() );
-        verify( synchronizer,
-                never() ).deleteCell( any( GridData.Range.class ),
-                                      eq( 2 ) );
-        final GridCell<?> booleanCell = uiModel.getCell( 0,
-                                                         2 );
-        assertNotNull( booleanCell );
-        assertFalse( (Boolean) booleanCell.getValue().getValue() );
+        verify(synchronizer,
+               times(1)).deleteCell(rowRangeCaptor.capture(),
+                                    columnIndexCaptor.capture());
+        verify(synchronizer,
+               never()).deleteCell(any(GridData.Range.class),
+                                   eq(2));
+        final GridCell<?> booleanCell = uiModel.getCell(0,
+                                                        2);
+        assertNotNull(booleanCell);
+        assertFalse((Boolean) booleanCell.getValue().getValue());
 
         final Integer columnIndex = columnIndexCaptor.getValue();
         final GridData.Range rowRange = rowRangeCaptor.getValue();
-        assertEquals( 0,
-                      rowRange.getMinRowIndex() );
-        assertEquals( 0,
-                      rowRange.getMaxRowIndex() );
-        assertEquals( 1,
-                      columnIndex.intValue() );
+        assertEquals(0,
+                     rowRange.getMinRowIndex());
+        assertEquals(0,
+                     rowRange.getMaxRowIndex());
+        assertEquals(1,
+                     columnIndex.intValue());
     }
 
     @Test
     public void onDeleteSelectedCellsWithoutSelections() {
         dtPresenter.onDeleteSelectedCells();
 
-        verify( synchronizer,
-                never() ).deleteCell( any( GridData.Range.class ),
-                                      any( Integer.class ) );
+        verify(synchronizer,
+               never()).deleteCell(any(GridData.Range.class),
+                                   any(Integer.class));
     }
 
     @Test
     public void onDeleteSelectedColumnsWithSelections() throws ModelSynchronizer.MoveColumnVetoException {
         final AttributeCol52 column = new AttributeCol52() {{
-            setAttribute( "attribute1" );
+            setAttribute("attribute1");
         }};
-        dtPresenter.appendColumn( column );
+        dtPresenter.appendColumn(column);
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            2 );
+        uiModel.selectCell(0,
+                           2);
 
         dtPresenter.onDeleteSelectedColumns();
 
-        verify( synchronizer,
-                times( 1 ) ).deleteColumn( eq( column ) );
+        verify(synchronizer,
+               times(1)).deleteColumn(eq(column));
     }
 
     @Test
     public void onDeleteSelectedColumnsWithoutSelections() throws ModelSynchronizer.MoveColumnVetoException {
         dtPresenter.onDeleteSelectedColumns();
 
-        verify( synchronizer,
-                never() ).deleteColumn( any( BaseColumn.class ) );
+        verify(synchronizer,
+               never()).deleteColumn(any(BaseColumn.class));
     }
 
     @Test
     public void onDeleteSelectedRowsWithSelections() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
-        uiModel.selectCell( 2,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
+        uiModel.selectCell(2,
+                           0);
 
         dtPresenter.onDeleteSelectedRows();
 
-        verify( synchronizer,
-                times( 1 ) ).deleteRow( eq( 0 ) );
-        verify( synchronizer,
-                times( 1 ) ).deleteRow( eq( 1 ) );
+        verify(synchronizer,
+               times(1)).deleteRow(eq(0));
+        verify(synchronizer,
+               times(1)).deleteRow(eq(1));
     }
 
     @Test
     public void onDeleteSelectedRowsWithNoSelections() throws ModelSynchronizer.MoveColumnVetoException {
         dtPresenter.onDeleteSelectedRows();
 
-        verify( synchronizer,
-                never() ).deleteRow( any( Integer.class ) );
+        verify(synchronizer,
+               never()).deleteRow(any(Integer.class));
     }
 
     @Test
     public void onInsertRowAboveNoRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
         dtPresenter.onInsertRowAbove();
 
-        verify( synchronizer,
-                never() ).insertRow( any( Integer.class ) );
+        verify(synchronizer,
+               never()).insertRow(any(Integer.class));
     }
 
     @Test
     public void onInsertRowAboveSingleRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
 
         dtPresenter.onInsertRowAbove();
 
-        verify( synchronizer,
-                times( 1 ) ).insertRow( eq( 0 ) );
+        verify(synchronizer,
+               times(1)).insertRow(eq(0));
     }
 
     @Test
     public void onInsertRowAboveMultipleRowsSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
-        uiModel.selectCell( 1,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
+        uiModel.selectCell(1,
+                           0);
 
         dtPresenter.onInsertRowAbove();
 
-        verify( synchronizer,
-                never() ).insertRow( any( Integer.class ) );
+        verify(synchronizer,
+               never()).insertRow(any(Integer.class));
     }
 
     @Test
     public void onInsertRowBelowNoRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
         dtPresenter.onInsertRowBelow();
 
-        verify( synchronizer,
-                never() ).insertRow( any( Integer.class ) );
+        verify(synchronizer,
+               never()).insertRow(any(Integer.class));
     }
 
     @Test
     public void onInsertRowBelowSingleRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
 
         dtPresenter.onInsertRowBelow();
 
-        verify( synchronizer,
-                times( 1 ) ).insertRow( eq( 1 ) );
+        verify(synchronizer,
+               times(1)).insertRow(eq(1));
     }
 
     @Test
     public void onInsertRowBelowMultipleRowsSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
-        uiModel.selectCell( 1,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
+        uiModel.selectCell(1,
+                           0);
 
         dtPresenter.onInsertRowBelow();
 
-        verify( synchronizer,
-                never() ).insertRow( any( Integer.class ) );
+        verify(synchronizer,
+               never()).insertRow(any(Integer.class));
     }
 
     @Test
     public void onOtherwiseCellNoCellSelected() throws ModelSynchronizer.MoveColumnVetoException {
         dtPresenter.onOtherwiseCell();
 
-        verify( synchronizer,
-                never() ).setCellOtherwiseState( any( Integer.class ),
-                                                 any( Integer.class ) );
+        verify(synchronizer,
+               never()).setCellOtherwiseState(any(Integer.class),
+                                              any(Integer.class));
     }
 
     @Test
     public void onOtherwiseCellSingleCellSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
 
         dtPresenter.onOtherwiseCell();
 
-        verify( synchronizer,
-                times( 1 ) ).setCellOtherwiseState( eq( 0 ),
-                                                    eq( 0 ) );
+        verify(synchronizer,
+               times(1)).setCellOtherwiseState(eq(0),
+                                               eq(0));
     }
 
     @Test
     public void onOtherwiseCellMultipleCellsSelected() throws ModelSynchronizer.MoveColumnVetoException {
         final GridData uiModel = dtPresenter.getUiModel();
-        uiModel.selectCell( 0,
-                            0 );
-        uiModel.selectCell( 1,
-                            0 );
+        uiModel.selectCell(0,
+                           0);
+        uiModel.selectCell(1,
+                           0);
 
         dtPresenter.onOtherwiseCell();
 
-        verify( synchronizer,
-                never() ).setCellOtherwiseState( any( Integer.class ),
-                                                 any( Integer.class ) );
+        verify(synchronizer,
+               never()).setCellOtherwiseState(any(Integer.class),
+                                              any(Integer.class));
     }
 
     @Test
     public void setMergedTrue() {
-        reset( gridLayer );
+        reset(gridLayer);
 
-        dtPresenter.setMerged( true );
+        dtPresenter.setMerged(true);
 
-        assertTrue( dtPresenter.isMerged() );
+        assertTrue(dtPresenter.isMerged());
 
-        verify( gridLayer,
-                times( 1 ) ).draw();
+        verify(gridLayer,
+               times(1)).draw();
     }
 
     @Test
     public void setMergedFalse() {
-        reset( gridLayer );
+        reset(gridLayer);
 
-        dtPresenter.setMerged( false );
+        dtPresenter.setMerged(false);
 
-        assertFalse( dtPresenter.isMerged() );
+        assertFalse(dtPresenter.isMerged());
 
-        verify( gridLayer,
-                times( 1 ) ).draw();
+        verify(gridLayer,
+               times(1)).draw();
     }
-
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3013

The link was being created in the wrong "direction"; so link from A1.setLink(C1) was overwritten when we linked A1.setLink(C2). This PR fixes with C1.setLink(A1) and C2.setLink(A1). The UI was therefore only showing the "latest" link giving the impression the BRL-table was unlinked.