### PR TITLE
GUVNOR-3037: Lucene Index: DSL files that are created into default package should be indexed

### DIFF
--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDefaultPackageDslEntriesTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDefaultPackageDslEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss, by Red Hat, Inc
+ * Copyright 2017 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,53 +36,52 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.java.nio.file.Path;
 
-public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinition> {
+public class IndexDefaultPackageDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinition> {
 
     @Test
-    public void testIndexDslEntries() throws IOException, InterruptedException {
+    public void testDefaultPackageIndexDslEntries() throws IOException, InterruptedException {
         //Add test files
-        final Path path1 = basePath.resolve( "dsl1.dsl" );
-        final String dsl1 = loadText( "dsl1.dsl" );
-        ioService().write( path1,
-                           dsl1 );
-        final Path path2 = basePath.resolve( "dsl2.dsl" );
-        final String dsl2 = loadText( "dsl2.dsl" );
-        ioService().write( path2,
-                           dsl2 );
+        final Path path1 = basePath.resolve("dsl1.dsl");
+        final String dsl1 = loadText("dsl1.dsl");
+        ioService().write(path1,
+                          dsl1);
 
-        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
 
-        final Index index = getConfig().getIndexManager().get( org.uberfire.ext.metadata.io.KObjectUtil.toKCluster( basePath.getFileSystem() ) );
+        final Index index = getConfig().getIndexManager().get(org.uberfire.ext.metadata.io.KObjectUtil.toKCluster(basePath.getFileSystem()));
 
         {
-            final Query query = new SingleTermQueryBuilder( new ValueResourceIndexTerm( "*", ResourceType.RULE, TermSearchType.WILDCARD ) )
+            final Query query = new SingleTermQueryBuilder(new ValueResourceIndexTerm("*",
+                                                                                      ResourceType.RULE,
+                                                                                      TermSearchType.WILDCARD))
                     .build();
-            searchFor(index, query, 0);
+            searchFor(index,
+                      query,
+                      0);
         }
 
         {
-            final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant", ResourceType.JAVA ) )
+            final Query query = new SingleTermQueryBuilder(new ValueReferenceIndexTerm("org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant",
+                                                                                       ResourceType.JAVA))
                     .build();
-            searchFor(index, query, 2, path1, path2);
-        }
-
-        {
-            final Query query = new SingleTermQueryBuilder( new ValueReferenceIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Mortgage", ResourceType.JAVA ) )
-                    .build();
-            searchFor(index, query, 1, path2);
+            searchFor(index,
+                      query,
+                      1,
+                      path1);
         }
     }
 
     @Override
     protected TestIndexer getIndexer() {
-        return new TestDslFileIndexer("org.drools.workbench.screens.dsltext.backend.server.indexing.classes");
+        return new TestDslFileIndexer("");
     }
 
     @Override
     public Map<String, Analyzer> getAnalyzers() {
         return new HashMap<String, Analyzer>() {
             {
-                put( ProjectRootPathIndexTerm.TERM, new FilenameAnalyzer() );
+                put(ProjectRootPathIndexTerm.TERM,
+                    new FilenameAnalyzer());
             }
         };
     }
@@ -96,5 +95,4 @@ public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinit
     protected String getRepositoryName() {
         return this.getClass().getSimpleName();
     }
-
 }

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
@@ -79,7 +79,7 @@ public class IndexDslInvalidDrlTest extends BaseIndexingTest<DSLResourceTypeDefi
 
     @Override
     protected TestIndexer getIndexer() {
-        return new TestDslFileIndexer();
+        return new TestDslFileIndexer("org.drools.workbench.screens.dsltext.backend.server.indexing.classes");
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/TestDslFileIndexer.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/TestDslFileIndexer.java
@@ -33,8 +33,13 @@ import org.uberfire.java.nio.file.Path;
 /**
  * Test indexer
  */
-@ApplicationScoped
 public class TestDslFileIndexer extends DslFileIndexer implements TestIndexer<DSLResourceTypeDefinition> {
+
+    private final String packageName;
+
+    public TestDslFileIndexer(final String packageName) {
+        this.packageName=packageName;
+    }
 
     @Override
     public void setIOService( final IOService ioService ) {
@@ -53,7 +58,7 @@ public class TestDslFileIndexer extends DslFileIndexer implements TestIndexer<DS
 
     @Override
     protected String getPackageName( final Path path ) {
-        return "org.drools.workbench.screens.dsltext.backend.server.indexing.classes";
+        return packageName;
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3037

The issue was that when the file was in the default package; the package name is an empty ```String``` and the ```DRL``` generated from the ```DSL``` (to extract class and field references etc) was of the form ```package rule "test" when... ``` and failed ```DRL``` compilation. The resulting error was logged as a warning (but not listed with the default log level). 