### PR TITLE
[7.0.x] Fix Dash Builder dependencies

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -928,6 +928,20 @@
       <classifier>sources</classifier>
     </dependency>
 
+    <!-- DashBuilder -->
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-navigation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-json</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.owasp.encoder</groupId>
       <artifactId>encoder</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.dashbuilder</groupId>
+        <artifactId>dashbuilder-bom</artifactId>
+        <version>${version.org.dashbuilder}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This is the corollary of https://github.com/kiegroup/drools-wb/pull/471 for 7.0.x

(cherry picked from commit 24e27dcb05ed504e7503c103d5b2f5565eae0535)