### PR TITLE
[7.0.x] GUVNOR-2787: [Library] Use Lucene to list assets in the project page

### DIFF
--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/indexing/DslFileIndexer.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/indexing/DslFileIndexer.java
@@ -110,8 +110,7 @@ public class DslFileIndexer extends AbstractDrlFileIndexer {
         }
 
         // responsible for basic index info: project name, branch, etc
-        return new DefaultIndexBuilder(project,
-                                       pkg) {
+        return new DefaultIndexBuilder( Paths.convert(path).getFileName(), project, pkg ) {
             @Override
             public DefaultIndexBuilder addGenerator(final IndexElementsGenerator generator) {
                 // Don't include the rule created to parse DSL

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/indexing/TestScenarioFileIndexer.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/indexing/TestScenarioFileIndexer.java
@@ -57,7 +57,8 @@ public class TestScenarioFileIndexer extends AbstractFileIndexer {
         final Project project = projectService.resolveProject( Paths.convert( path ) );
         final Package pkg = projectService.resolvePackage( Paths.convert( path ) );
 
-        final DefaultIndexBuilder builder = new DefaultIndexBuilder( project,
+        final DefaultIndexBuilder builder = new DefaultIndexBuilder( Paths.convert(path).getFileName(),
+                                                                     project,
                                                                      pkg );
         final TestScenarioIndexVisitor visitor = new TestScenarioIndexVisitor( dmo,
                                                                                builder,


### PR DESCRIPTION
This is the corollary of https://github.com/kiegroup/drools-wb/pull/465 for 7.0.x

(cherry picked from commit 7ac22656f128ecc121eebea9bffa846f8aca463b)