### PR TITLE
[7.0.x] GUVNOR-3050: Guided Decision Table Graph: Missing Indexer

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableGraphFileIndexer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableGraphFileIndexer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.guided.dtable.backend.server.GuidedDTGraphXMLPersistence;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
+import org.drools.workbench.screens.guided.dtable.type.GuidedDTableGraphResourceTypeDefinition;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.AbstractFileIndexer;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.java.nio.file.Path;
+
+@ApplicationScoped
+public class GuidedDecisionTableGraphFileIndexer extends AbstractFileIndexer {
+
+    GuidedDTableGraphResourceTypeDefinition type;
+
+    GuidedDecisionTableGraphFileIndexer() {
+        //WELD proxies
+    }
+
+    @Inject
+    public GuidedDecisionTableGraphFileIndexer(final GuidedDTableGraphResourceTypeDefinition type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean supportsPath(final Path path) {
+        return type.accept(Paths.convert(path));
+    }
+
+    @Override
+    public DefaultIndexBuilder fillIndexBuilder(final Path path) throws Exception {
+        final String content = ioService.readAllString(path);
+        final GuidedDecisionTableEditorGraphModel model = GuidedDTGraphXMLPersistence.getInstance().unmarshal(content);
+
+        final DefaultIndexBuilder builder = getIndexBuilder(path);
+        if (builder == null) {
+            return null;
+        }
+
+        final GuidedDecisionTableGraphModelIndexVisitor visitor = new GuidedDecisionTableGraphModelIndexVisitor(builder,
+                                                                                                                model);
+        visitor.visit();
+        addReferencedResourcesToIndexBuilder(builder,
+                                             visitor);
+
+        return builder;
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableGraphModelIndexVisitor.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableGraphModelIndexVisitor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
+import org.kie.workbench.common.services.refactoring.backend.server.impact.ResourceReferenceCollector;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
+import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.uberfire.commons.data.Pair;
+import org.uberfire.commons.validation.PortablePreconditions;
+
+/**
+ * Visitor to extract index information from a Guided Decision Table Graph
+ */
+public class GuidedDecisionTableGraphModelIndexVisitor extends ResourceReferenceCollector {
+
+    private final DefaultIndexBuilder builder;
+    private final GuidedDecisionTableEditorGraphModel model;
+    private final Set<Pair<String, String>> results = new HashSet<Pair<String, String>>();
+
+    public GuidedDecisionTableGraphModelIndexVisitor(final DefaultIndexBuilder builder,
+                                                     final GuidedDecisionTableEditorGraphModel model) {
+        this.builder = PortablePreconditions.checkNotNull("builder",
+                                                          builder);
+        this.model = PortablePreconditions.checkNotNull("model",
+                                                        model);
+    }
+
+    public Set<Pair<String, String>> visit() {
+        model.getEntries().stream().forEach(e -> addSharedReference(e.getPathHead().toURI(),
+                                                                    PartType.PATH));
+
+        results.addAll(builder.build());
+        return results;
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableGraphFileTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableGraphFileTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
+
+import java.io.IOException;
+
+import org.apache.lucene.search.Query;
+import org.drools.workbench.screens.guided.dtable.backend.server.GuidedDTGraphXMLPersistence;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
+import org.drools.workbench.screens.guided.dtable.type.GuidedDTableGraphResourceTypeDefinition;
+import org.junit.Test;
+import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
+import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.SingleTermQueryBuilder;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueSharedPartIndexTerm;
+import org.kie.workbench.common.services.refactoring.service.PartType;
+import org.uberfire.backend.server.util.Paths;
+import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.java.nio.file.Path;
+
+public class IndexGuidedDecisionTableGraphFileTest extends BaseIndexingTest<GuidedDTableGraphResourceTypeDefinition> {
+
+    @Test
+    public void testIndexGuidedDecisionTableGraphEntries() throws IOException, InterruptedException {
+        //Add test files
+        final Path path = basePath.resolve("dtable-graph1.gdst-set");
+        final Path dtable1Path = basePath.resolve("dtable1.gdst");
+        final Path dtable2Path = basePath.resolve("dtable2.gdst");
+        final org.uberfire.backend.vfs.Path vfsDtable1Path = Paths.convert(dtable1Path);
+        final org.uberfire.backend.vfs.Path vfsDtable2Path = Paths.convert(dtable2Path);
+
+        final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel();
+        model.getEntries().add(new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry(vfsDtable1Path,
+                                                                                                     vfsDtable1Path));
+        model.getEntries().add(new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry(vfsDtable2Path,
+                                                                                                     vfsDtable2Path));
+        final String xml = GuidedDTGraphXMLPersistence.getInstance().marshal(model);
+        ioService().write(path,
+                          xml);
+
+        Thread.sleep(5000); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        final Index index = getConfig().getIndexManager().get(org.uberfire.ext.metadata.io.KObjectUtil.toKCluster(basePath.getFileSystem()));
+
+        {
+            final Query query = new SingleTermQueryBuilder(new ValueSharedPartIndexTerm(vfsDtable1Path.toURI(),
+                                                                                        PartType.PATH))
+                    .build();
+            searchFor(index,
+                      query,
+                      1,
+                      path);
+        }
+
+        {
+            final Query query = new SingleTermQueryBuilder(new ValueSharedPartIndexTerm(vfsDtable2Path.toURI(),
+                                                                                        PartType.PATH))
+                    .build();
+            searchFor(index,
+                      query,
+                      1,
+                      path);
+        }
+    }
+
+    @Override
+    protected TestIndexer<GuidedDTableGraphResourceTypeDefinition> getIndexer() {
+        return new TestGuidedDecisionTableGraphFileIndexer();
+    }
+
+    @Override
+    protected GuidedDTableGraphResourceTypeDefinition getResourceTypeDefinition() {
+        return new GuidedDTableGraphResourceTypeDefinition();
+    }
+
+    @Override
+    protected String getRepositoryName() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/TestGuidedDecisionTableGraphFileIndexer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/TestGuidedDecisionTableGraphFileIndexer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.workbench.screens.guided.dtable.type.GuidedDTableGraphResourceTypeDefinition;
+import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
+import org.kie.workbench.common.services.shared.project.KieProjectService;
+import org.uberfire.io.IOService;
+
+/**
+ * Test graph indexer
+ */
+@ApplicationScoped
+public class TestGuidedDecisionTableGraphFileIndexer extends GuidedDecisionTableGraphFileIndexer implements TestIndexer<GuidedDTableGraphResourceTypeDefinition> {
+
+    @Override
+    public void setIOService(final IOService ioService) {
+        this.ioService = ioService;
+    }
+
+    @Override
+    public void setProjectService(final KieProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @Override
+    public void setResourceTypeDefinition(final GuidedDTableGraphResourceTypeDefinition type) {
+        this.type = type;
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3050

This is the corollary of https://github.com/kiegroup/drools-wb/pull/480 for 7.0.x

(cherry picked from commit 1cc3f4591804907067900a61405589bde4a993f5)