### PR TITLE
GUVNOR-3062: [Guided Decision Table] Just one pattern can be setup in the wizard

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionInsertFactFieldsPageViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionInsertFactFieldsPageViewImpl.java
@@ -242,7 +242,7 @@ public class ActionInsertFactFieldsPageViewImpl extends Composite
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         chosenPatternsWidget.setEmptyListWidget( lstEmpty );
 
-        final MultiSelectionModel<ActionInsertFactFieldsPattern> selectionModel = new MultiSelectionModel<ActionInsertFactFieldsPattern>();
+        final MultiSelectionModel<ActionInsertFactFieldsPattern> selectionModel = new MultiSelectionModel<ActionInsertFactFieldsPattern>(System::identityHashCode);
         chosenPatternsWidget.setSelectionModel( selectionModel );
 
         selectionModel.addSelectionChangeHandler( new SelectionChangeEvent.Handler() {
@@ -317,7 +317,7 @@ public class ActionInsertFactFieldsPageViewImpl extends Composite
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         chosenFieldsWidget.setEmptyListWidget( lstEmpty );
 
-        final MultiSelectionModel<ActionInsertFactCol52> selectionModel = new MultiSelectionModel<ActionInsertFactCol52>();
+        final MultiSelectionModel<ActionInsertFactCol52> selectionModel = new MultiSelectionModel<ActionInsertFactCol52>(System::identityHashCode);
         chosenFieldsWidget.setSelectionModel( selectionModel );
 
         selectionModel.addSelectionChangeHandler( new SelectionChangeEvent.Handler() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImpl.java
@@ -234,7 +234,7 @@ public class ActionSetFieldsPageViewImpl extends Composite
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         chosenFieldsWidget.setEmptyListWidget( lstEmpty );
 
-        final MultiSelectionModel<ActionSetFieldCol52> selectionModel = new MultiSelectionModel<ActionSetFieldCol52>();
+        final MultiSelectionModel<ActionSetFieldCol52> selectionModel = new MultiSelectionModel<ActionSetFieldCol52>(System::identityHashCode);
         chosenFieldsWidget.setSelectionModel( selectionModel );
 
         selectionModel.addSelectionChangeHandler( new SelectionChangeEvent.Handler() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageViewImpl.java
@@ -287,7 +287,7 @@ public class FactPatternConstraintsPageViewImpl extends Composite
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         chosenConditionsWidget.setEmptyListWidget( lstEmpty );
 
-        final MultiSelectionModel<ConditionCol52> selectionModel = new MultiSelectionModel<ConditionCol52>();
+        final MultiSelectionModel<ConditionCol52> selectionModel = new MultiSelectionModel<ConditionCol52>(System::identityHashCode);
         chosenConditionsWidget.setSelectionModel( selectionModel );
 
         selectionModel.addSelectionChangeHandler( new SelectionChangeEvent.Handler() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternsPageViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternsPageViewImpl.java
@@ -186,7 +186,7 @@ public class FactPatternsPageViewImpl extends Composite
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         chosenPatternWidget.setEmptyListWidget( lstEmpty );
 
-        final MultiSelectionModel<Pattern52> selectionModel = new MultiSelectionModel<Pattern52>();
+        final MultiSelectionModel<Pattern52> selectionModel = new MultiSelectionModel<Pattern52>(System::identityHashCode);
         chosenPatternWidget.setSelectionModel( selectionModel );
 
         selectionModel.addSelectionChangeHandler( new SelectionChangeEvent.Handler() {


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3062

@jomarko I'm open to ideas about how this could be tested before merge!?!

GWT's ```MultiSelectionModel``` uses a ```HashMap``` for it's "keys" (see [here](https://github.com/gwtproject/gwt/blob/master/user/src/com/google/gwt/view/client/MultiSelectionModel.java#L78)) which, following GUVNOR-2900, produces different values for a (for example) ```Pattern52``` when it's binding is set vs unset. This leads to the "selected" and "unselected" items in the tables to be unidentifiable.. Using ```System::identityHashCode``` as the "key provider" means the original behaviour is maintained by using the Object's identity.