### PR TITLE
GUVNOR-2782 : [Guided Decision Table] Row with Impossible Match throws Exception

### DIFF
--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/pom.xml
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/pom.xml
@@ -27,6 +27,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.errai</groupId>
+            <artifactId>errai-marshalling</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>
             <artifactId>gwtmockito</artifactId>
             <scope>test</scope>

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ImpossibleMatchIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ImpossibleMatchIssue.java
@@ -70,4 +70,14 @@ public class ImpossibleMatchIssue
     public String getRuleId() {
         return ruleId;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/MultipleValuesForOneActionIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/MultipleValuesForOneActionIssue.java
@@ -49,4 +49,14 @@ public class MultipleValuesForOneActionIssue
     public String getConflictingItem() {
         return conflictingItem;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/resources/ErraiApp.properties
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/resources/ErraiApp.properties
@@ -1,0 +1,16 @@
+#
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/MarshallingTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/MarshallingTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.services.verifier.api.client;
+
+import java.util.Collections;
+
+import org.drools.workbench.services.verifier.api.client.reporting.CheckType;
+import org.drools.workbench.services.verifier.api.client.reporting.ImpossibleMatchIssue;
+import org.drools.workbench.services.verifier.api.client.reporting.Issue;
+import org.drools.workbench.services.verifier.api.client.reporting.MultipleValuesForOneActionIssue;
+import org.drools.workbench.services.verifier.api.client.reporting.RedundantConditionsIssue;
+import org.drools.workbench.services.verifier.api.client.reporting.Severity;
+import org.drools.workbench.services.verifier.api.client.reporting.SingleHitLostIssue;
+import org.drools.workbench.services.verifier.api.client.reporting.ValueForActionIsSetTwiceIssue;
+import org.drools.workbench.services.verifier.api.client.reporting.ValueForFactFieldIsSetTwiceIssue;
+import org.jboss.errai.marshalling.server.MappingContextSingleton;
+import org.jboss.errai.marshalling.server.ServerMarshalling;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MarshallingTest {
+
+    @Before
+    public void prepare() throws Exception {
+        MappingContextSingleton.get();
+    }
+
+    @Test
+    public void testImpossibleMatchIssue() throws Exception {
+        check(new ImpossibleMatchIssue(Severity.WARNING,
+                                       CheckType.IMPOSSIBLE_MATCH,
+                                       "1",
+                                       "Person",
+                                       "name",
+                                       "1",
+                                       "2"),
+              new ImpossibleMatchIssue(Severity.ERROR,
+                                       CheckType.IMPOSSIBLE_MATCH,
+                                       "1",
+                                       "Person",
+                                       "name",
+                                       "1",
+                                       "2"));
+    }
+
+    @Test
+    public void testMultipleValuesForOneActionIssue() throws Exception {
+        check(new MultipleValuesForOneActionIssue(Severity.ERROR,
+                                                  CheckType.IMPOSSIBLE_MATCH,
+                                                  "1",
+                                                  "2",
+                                                  Collections.emptySet()),
+              new MultipleValuesForOneActionIssue(Severity.WARNING,
+                                                  CheckType.IMPOSSIBLE_MATCH,
+                                                  "1",
+                                                  "2",
+                                                  Collections.emptySet()));
+    }
+
+    @Test
+    public void testRedundantConditionsIssue() throws Exception {
+        check(new RedundantConditionsIssue(Severity.ERROR,
+                                           CheckType.IMPOSSIBLE_MATCH,
+                                           "Person",
+                                           "name",
+                                           "1",
+                                           "2",
+                                           Collections.emptySet()),
+              new RedundantConditionsIssue(Severity.WARNING,
+                                           CheckType.IMPOSSIBLE_MATCH,
+                                           "Person",
+                                           "name",
+                                           "1",
+                                           "2",
+                                           Collections.emptySet()));
+    }
+
+    @Test
+    public void testSingleHitLostIssue() throws Exception {
+        check(new SingleHitLostIssue(Severity.ERROR,
+                                     CheckType.IMPOSSIBLE_MATCH,
+                                     "1",
+                                     "2"),
+              new SingleHitLostIssue(Severity.ERROR,
+                                     CheckType.IMPOSSIBLE_MATCH,
+                                     "2",
+                                     "3"));
+    }
+
+    @Test
+    public void testValueForActionIsSetTwiceIssue() throws Exception {
+        check(new ValueForActionIsSetTwiceIssue(Severity.ERROR,
+                                                CheckType.IMPOSSIBLE_MATCH,
+                                                "1",
+                                                "2",
+                                                Collections.emptySet()),
+              new ValueForActionIsSetTwiceIssue(Severity.WARNING,
+                                                CheckType.IMPOSSIBLE_MATCH,
+                                                "1",
+                                                "2",
+                                                Collections.emptySet()));
+    }
+
+    @Test
+    public void testValueForFactFieldIsSetTwiceIssue() throws Exception {
+        check(new ValueForFactFieldIsSetTwiceIssue(Severity.ERROR,
+                                                   CheckType.IMPOSSIBLE_MATCH,
+                                                   "boundName",
+                                                   "name",
+                                                   "1",
+                                                   "2",
+                                                   Collections.emptySet()),
+              new ValueForFactFieldIsSetTwiceIssue(Severity.WARNING,
+                                                   CheckType.IMPOSSIBLE_MATCH,
+                                                   "boundName",
+                                                   "name",
+                                                   "1",
+                                                   "2",
+                                                   Collections.emptySet()));
+    }
+
+    private void check(final Issue original,
+                       final Issue secondOne) {
+
+        final String json = ServerMarshalling.toJSON(original);
+
+        final Issue newVersion = (Issue) ServerMarshalling.fromJSON(json);
+
+        assertEquals(original.hashCode(),
+                     newVersion.hashCode());
+        assertNotEquals(secondOne.hashCode(),
+                        newVersion.hashCode());
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-2782

@jomarko Hey, this was my take on the fix for #442, but while this picks up several of the bugs that I ran into previously it does not pick up of fix the bug you found. Still a good addition to our test coverage and this can be extended from this simple hashcode comparison.

To really test the actual cause we would have to compile to GWT. I tried with GWT Test Case. It is slow and hard to setup. I think a better bet is to make a selenium test since:
a. We already test with Selenium
b. No need to compile any code to JavaScript

Made a ticket for it. https://issues.jboss.org/browse/GUVNOR-3071