### PR TITLE
GUVNOR-3078: Save of empty graph never ends

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
@@ -459,10 +459,14 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                                     editorView.showSaving();
                                     saveGraphLatch = new SaveGraphLatch(allDecisionTables.size(),
                                                                         commitMessage);
-                                    allDecisionTables.stream().forEach((dtPresenter) -> {
-                                        saveGraphLatch.saveDocumentGraphEntry(dtPresenter);
-                                        saveInProgressEvent.fire(new SaveInProgressEvent(dtPresenter.getLatestPath()));
-                                    });
+                                    if(allDecisionTables.isEmpty()) {
+                                        saveGraphLatch.saveDocumentGraph();
+                                    } else {
+                                        allDecisionTables.stream().forEach((dtPresenter) -> {
+                                            saveGraphLatch.saveDocumentGraphEntry(dtPresenter);
+                                            saveInProgressEvent.fire(new SaveInProgressEvent(dtPresenter.getLatestPath()));
+                                        });
+                                    }
                                 });
     }
 


### PR DESCRIPTION
The save operation on graph that doesn't inlcude decision tables was causing never
ending saving. In practise, the saving progress popup was never hidden.

@manstis please take a look when you have a while. I forgot to check this yesterday. Sorry for inconvenience.