### PR TITLE
GUVNOR-3092: [Guided Decision Table Graph] Editor does not close when deleting file

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
@@ -24,6 +24,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.EditMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
@@ -55,42 +56,42 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.*;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.EDITOR_PROVIDED;
 
 /**
  * Guided Decision Table Editor Presenter
  */
 @Dependent
-@WorkbenchEditor(identifier = "GuidedDecisionTableEditor", supportedTypes = { GuidedDTableResourceType.class }, lockingStrategy = EDITOR_PROVIDED)
+@WorkbenchEditor(identifier = "GuidedDecisionTableEditor", supportedTypes = {GuidedDTableResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
 public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableEditorPresenter {
 
     @Inject
-    public GuidedDecisionTableEditorPresenter( final View view,
-                                               final Caller<GuidedDecisionTableEditorService> service,
-                                               final Event<NotificationEvent> notification,
-                                               final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
-                                               final ValidationPopup validationPopup,
-                                               final GuidedDTableResourceType resourceType,
-                                               final EditMenuBuilder editMenuBuilder,
-                                               final ViewMenuBuilder viewMenuBuilder,
-                                               final InsertMenuBuilder insertMenuBuilder,
-                                               final RadarMenuBuilder radarMenuBuilder,
-                                               final GuidedDecisionTableModellerView.Presenter modeller,
-                                               final SyncBeanManager beanManager,
-                                               final PlaceManager placeManager ) {
-        super( view,
-               service,
-               notification,
-               decisionTableSelectedEvent,
-               validationPopup,
-               resourceType,
-               editMenuBuilder,
-               viewMenuBuilder,
-               insertMenuBuilder,
-               radarMenuBuilder,
-               modeller,
-               beanManager,
-               placeManager );
+    public GuidedDecisionTableEditorPresenter(final View view,
+                                              final Caller<GuidedDecisionTableEditorService> service,
+                                              final Event<NotificationEvent> notification,
+                                              final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
+                                              final ValidationPopup validationPopup,
+                                              final GuidedDTableResourceType resourceType,
+                                              final EditMenuBuilder editMenuBuilder,
+                                              final ViewMenuBuilder viewMenuBuilder,
+                                              final InsertMenuBuilder insertMenuBuilder,
+                                              final RadarMenuBuilder radarMenuBuilder,
+                                              final GuidedDecisionTableModellerView.Presenter modeller,
+                                              final SyncBeanManager beanManager,
+                                              final PlaceManager placeManager) {
+        super(view,
+              service,
+              notification,
+              decisionTableSelectedEvent,
+              validationPopup,
+              resourceType,
+              editMenuBuilder,
+              viewMenuBuilder,
+              insertMenuBuilder,
+              radarMenuBuilder,
+              modeller,
+              beanManager,
+              placeManager);
     }
 
     @Override
@@ -101,13 +102,13 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
 
     @Override
     @OnStartup
-    public void onStartup( final ObservablePath path,
-                           final PlaceRequest placeRequest ) {
-        super.onStartup( path,
-                         placeRequest );
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest placeRequest) {
+        super.onStartup(path,
+                        placeRequest);
 
-        loadDocument( path,
-                      placeRequest );
+        loadDocument(path,
+                     placeRequest);
     }
 
     @Override
@@ -117,32 +118,33 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
     }
 
     @Override
-    public void loadDocument( final ObservablePath path,
-                              final PlaceRequest placeRequest ) {
+    public void loadDocument(final ObservablePath path,
+                             final PlaceRequest placeRequest) {
         view.showLoading();
-        service.call( getLoadContentSuccessCallback( path,
-                                                     placeRequest ),
-                      getNoSuchFileExceptionErrorCallback() ).loadContent( path );
+        service.call(getLoadContentSuccessCallback(path,
+                                                   placeRequest),
+                     getNoSuchFileExceptionErrorCallback()).loadContent(path);
     }
 
-    protected RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback( final ObservablePath path,
-                                                                                              final PlaceRequest placeRequest ) {
-        return ( content ) -> {
+    protected RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback(final ObservablePath path,
+                                                                                             final PlaceRequest placeRequest) {
+        return (content) -> {
             //Path is set to null when the Editor is closed (which can happen before async calls complete).
-            if ( path == null ) {
+            if (path == null) {
                 return;
             }
 
             //Add Decision Table to modeller
-            final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable( path,
-                                                                                             placeRequest,
-                                                                                             content,
-                                                                                             placeRequest.getParameter( "readOnly", null ) != null,
-                                                                                             null,
-                                                                                             null );
-            registerDocument( dtPresenter );
+            final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable(path,
+                                                                                            placeRequest,
+                                                                                            content,
+                                                                                            placeRequest.getParameter("readOnly",
+                                                                                                                      null) != null,
+                                                                                            null,
+                                                                                            null);
+            registerDocument(dtPresenter);
 
-            decisionTableSelectedEvent.fire( new DecisionTableSelectedEvent( dtPresenter ) );
+            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dtPresenter));
 
             view.hideBusyIndicator();
         };
@@ -179,35 +181,45 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
     }
 
     @Override
-    protected void onDecisionTableSelected( final @Observes DecisionTableSelectedEvent event ) {
-        super.onDecisionTableSelected( event );
+    protected void onDecisionTableSelected(final @Observes DecisionTableSelectedEvent event) {
+        super.onDecisionTableSelected(event);
     }
 
     @Override
     public void makeMenuBar() {
         this.menus = fileMenuBuilder
-                .addSave( getSaveMenuItem() )
-                .addCopy( () -> getActiveDocument().getCurrentPath(),
-                          fileNameValidator )
-                .addRename( () -> getActiveDocument().getLatestPath(),
-                            fileNameValidator )
-                .addDelete( () -> getActiveDocument().getLatestPath() )
-                .addValidate( () -> onValidate( getActiveDocument() ) )
-                .addNewTopLevelMenu( getEditMenuItem() )
-                .addNewTopLevelMenu( getViewMenuItem() )
-                .addNewTopLevelMenu( getInsertMenuItem() )
-                .addNewTopLevelMenu( getRadarMenuItem() )
-                .addNewTopLevelMenu( getVersionManagerMenuItem() )
+                .addSave(getSaveMenuItem())
+                .addCopy(() -> getActiveDocument().getCurrentPath(),
+                         fileNameValidator)
+                .addRename(() -> getActiveDocument().getLatestPath(),
+                           fileNameValidator)
+                .addDelete(() -> getActiveDocument().getLatestPath())
+                .addValidate(() -> onValidate(getActiveDocument()))
+                .addNewTopLevelMenu(getEditMenuItem())
+                .addNewTopLevelMenu(getViewMenuItem())
+                .addNewTopLevelMenu(getInsertMenuItem())
+                .addNewTopLevelMenu(getRadarMenuItem())
+                .addNewTopLevelMenu(getVersionManagerMenuItem())
                 .build();
     }
 
     @Override
-    public void onOpenDocumentsInEditor( final List<Path> selectedDocumentPaths ) {
+    public void onOpenDocumentsInEditor(final List<Path> selectedDocumentPaths) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void getAvailableDocumentPaths( final Callback<List<Path>> callback ) {
-        callback.callback( Collections.<Path>emptyList() );
+    public void getAvailableDocumentPaths(final Callback<List<Path>> callback) {
+        callback.callback(Collections.<Path>emptyList());
+    }
+
+    @Override
+    public void removeDocument(GuidedDecisionTableView.Presenter dtPresenter) {
+        super.removeDocument(dtPresenter);
+        scheduleClosure(() -> placeManager.forceClosePlace(editorPlaceRequest));
+    }
+
+    void scheduleClosure(final Scheduler.ScheduledCommand command) {
+        Scheduler.get().scheduleDeferred(command);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor;
 
 import java.util.Collections;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
@@ -25,6 +26,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
@@ -115,5 +117,26 @@ public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTa
     public void checkOnOpenDocumentsInEditor() {
         exception.expect(UnsupportedOperationException.class);
         presenter.onOpenDocumentsInEditor(Collections.<Path>emptyList());
+    }
+
+    @Test
+    public void checkRemoveDocumentClosesEditor() {
+        final PlaceRequest placeRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
+        presenter.editorPlaceRequest = placeRequest;
+
+        presenter.removeDocument(dtPresenter);
+
+        final ArgumentCaptor<Scheduler.ScheduledCommand> commandCaptor = ArgumentCaptor.forClass(Scheduler.ScheduledCommand.class);
+
+        verify(presenter,
+               times(1)).scheduleClosure(commandCaptor.capture());
+
+        final Scheduler.ScheduledCommand command = commandCaptor.getValue();
+        assertNotNull(command);
+        command.execute();
+
+        verify(placeManager,
+               times(1)).forceClosePlace(eq(placeRequest));
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3092

@jomarko This was caused by https://issues.jboss.org/browse/GUVNOR-3078

The old code used to close the editor when the last document was deregistered (which for a "graph" was undesirable; but for the single decision table editor deletion of the file deregistered the document which no longer lead to closure).