### PR TITLE
GUVNOR-3134: Test scenarios fail after upgrade to 7.1 because rule expectation in 6.x doesn't use FQN

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioWidgetComponentCreator.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioWidgetComponentCreator.java
@@ -82,10 +82,10 @@ public class ScenarioWidgetComponentCreator {
                         scenario.getPackageName());
     }
 
-    Option makeRuleNameOption(final String text) {
+    Option makeRuleNameOption(final String simpleRuleName) {
         final Option o = GWT.create(Option.class);
-        o.setText(text);
-        o.setValue(text);
+        o.setText(simpleRuleName);
+        o.setValue(simpleRuleName);
         return o;
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3134

This PR effectively reverts https://github.com/kiegroup/droolswb/commit/a12cd9b352322df1e9ea75b93ce455f95192a8a5 made for https://issues.jboss.org/browse/GUVNOR-2980 that attempted to switch to use of 'Fully Qualified Rule Names' for Test Scenarios. However this causes problems with backwards compatibility and an alternative solution has been added for GUVNOR-3134 keeping use of 'Simple Rule Names'.