### PR TITLE
GUVNOR-3146: Attach Modeller's KeyDownHandler to editor not RootPanel

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -17,7 +17,6 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.ContextMenuHandler;
-import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -31,7 +30,6 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -243,8 +241,7 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
 
     @Override
     public HandlerRegistration addKeyDownHandler(final KeyDownHandler handler) {
-        return RootPanel.get().addDomHandler(handler,
-                                             KeyDownEvent.getType());
+        return gridPanel.addKeyDownHandler(handler);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
@@ -151,8 +151,8 @@ public class GuidedDecisionTableViewImpl extends BaseGridWidget implements Guide
         //Clip Caption Group
         final BoundingBox bb = new BoundingBox(0,
                                                0,
-                                               captionWidth,
-                                               HEADER_CAPTION_HEIGHT);
+                                               captionWidth + border.getStrokeWidth(),
+                                               HEADER_CAPTION_HEIGHT + 0.5);
         final IPathClipper clipper = getPathClipper(bb);
         g.setPathClipper(clipper);
         clipper.setActive(true);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/keyboard/KeyDownHandlerCommon.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/keyboard/KeyDownHandlerCommon.java
@@ -57,6 +57,7 @@ public class KeyDownHandlerCommon implements KeyDownHandler {
                 gridCell.flush();
                 moveSelection(keyCode,
                               isShiftKeyDown);
+                e.preventDefault();
 
             case KeyCodes.KEY_ESCAPE:
                 gridCell.destroyResources();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.dev.util.collect.HashMap;
+import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -55,7 +56,7 @@ public class GuidedDecisionTableModellerViewImplTest {
     FlowPanel flowPanel;
 
     @Mock
-    GridLienzoPanel gridPanel;
+    GridLienzoPanel mockGridPanel;
 
     @Mock
     DefaultGridLayer gridLayer;
@@ -261,6 +262,17 @@ public class GuidedDecisionTableModellerViewImplTest {
         verify(attributeConfigWidget).add(any(AttributeColumnConfigRowView.class));
     }
 
+    @Test
+    public void testAddKeyDownHandlerAttachesToEditor() {
+        //Ensure nobody thinks its a good idea to attach to the RootPanel at some time in the future!
+        //See https://issues.jboss.org/browse/GUVNOR-3146
+        final KeyDownHandler handler = mock(KeyDownHandler.class);
+
+        view.addKeyDownHandler(handler);
+
+        verify(mockGridPanel).addKeyDownHandler(eq(handler));
+    }
+
     private AttributeCol52 attributeColumn() {
         final AttributeCol52 attributeCol52 = mock(AttributeCol52.class);
         final DTCellValue52 defaultValue = mock(DTCellValue52.class);
@@ -274,7 +286,7 @@ public class GuidedDecisionTableModellerViewImplTest {
     class GuidedDecisionTableModellerViewImplFake extends GuidedDecisionTableModellerViewImpl {
 
         public GuidedDecisionTableModellerViewImplFake() {
-            /* do nothing */
+            this.gridPanel = mockGridPanel;
         }
 
         DefaultGridLayer defaultGridLayer() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/keyboard/KeyDownHandlerCommonTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/keyboard/KeyDownHandlerCommonTest.java
@@ -44,6 +44,7 @@ public class KeyDownHandlerCommonTest extends BaseKeyDownHandlerTest {
         handler.onKeyDown(e);
 
         verify(gridCell).flush();
+        verify(e).preventDefault();
         verifyCommonActions();
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3146

@jomarko I've tested with Chrome and FF and keyboard navigation still works OK (remember the "tab" issue on FF, when ```Shift```-tabbing out of ```TextBox``` would "disable" keyboard interaction?  

I also took the liberty of fixing a small rendering [issue](https://github.com/kiegroup/drools-wb/pull/526/files#diff-e380c5924f6e5d1bd9b7ee1800b10de4R154) evident in "graphs" when it's possible to see a de-selected table. The ```IPathClipper``` was clipping the right border from the header.