### PR TITLE
[7.2.x] PLANNER-823: ScoreHolder support does not work in Guided Decision Tables

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/pom.xml
@@ -23,6 +23,10 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-workbench-models-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-datamodel-api</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableSourceService.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableSourceService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -29,6 +30,7 @@ import org.drools.compiler.lang.Expander;
 import org.drools.compiler.lang.dsl.DSLMappingFile;
 import org.drools.compiler.lang.dsl.DSLTokenizedMappingFile;
 import org.drools.compiler.lang.dsl.DefaultExpander;
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTDRLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
@@ -48,25 +50,37 @@ import org.uberfire.java.nio.file.Path;
 public class GuidedDecisionTableSourceService
         extends BaseSourceService<GuidedDecisionTable52> {
 
-    private static final Logger logger = LoggerFactory.getLogger( GuidedDecisionTableSourceService.class );
+    private static final Logger logger = LoggerFactory.getLogger(GuidedDecisionTableSourceService.class);
 
     private static final DSLFileFilter FILTER_DSLS = new DSLFileFilter();
 
-    @Inject
     private GuidedDTableResourceTypeDefinition resourceType;
 
-    @Inject
     private GuidedDecisionTableEditorService guidedDecisionTableEditorService;
 
-    @Inject
-    @Named("ioStrategy")
     private IOService ioService;
 
-    @Inject
     private FileDiscoveryService fileDiscoveryService;
 
-    @Inject
     private KieProjectService projectService;
+
+    private Collection<RuleModelIActionPersistenceExtension> persistenceExtensions = new ArrayList<>();
+
+    @Inject
+    public GuidedDecisionTableSourceService(final GuidedDTableResourceTypeDefinition resourceType,
+                                            final GuidedDecisionTableEditorService guidedDecisionTableEditorService,
+                                            final @Named("ioStrategy") IOService ioService,
+                                            final FileDiscoveryService fileDiscoveryService,
+                                            final KieProjectService projectService,
+                                            final Instance<RuleModelIActionPersistenceExtension> persistenceExtensionInstance) {
+        this.resourceType = resourceType;
+        this.guidedDecisionTableEditorService = guidedDecisionTableEditorService;
+        this.ioService = ioService;
+        this.fileDiscoveryService = fileDiscoveryService;
+        this.projectService = projectService;
+
+        persistenceExtensionInstance.iterator().forEachRemaining(persistenceExtensions::add);
+    }
 
     @Override
     public String getPattern() {
@@ -74,59 +88,58 @@ public class GuidedDecisionTableSourceService
     }
 
     @Override
-    public String getSource( final Path path,
-                             final GuidedDecisionTable52 model ) throws SourceGenerationFailedException {
+    public String getSource(final Path path,
+                            final GuidedDecisionTable52 model) throws SourceGenerationFailedException {
 
         try {
-            final String dslr = GuidedDTDRLPersistence.getInstance().marshal( model );
-            final Expander expander = getDSLExpander( path );
-            final String drl = expander.expand( dslr );
+            final String dslr = GuidedDTDRLPersistence.getInstance().marshal(model,
+                                                                             persistenceExtensions);
+            final Expander expander = getDSLExpander(path);
+            final String drl = expander.expand(dslr);
             return drl;
-
-        } catch ( Exception e ) {
-            throw new SourceGenerationFailedException( e.getMessage() );
+        } catch (Exception e) {
+            throw new SourceGenerationFailedException(e.getMessage());
         }
     }
 
     @Override
-    public String getSource( final Path path ) throws SourceGenerationFailedException {
-        return getSource( path,
-                          guidedDecisionTableEditorService.load( Paths.convert( path ) ) );
+    public String getSource(final Path path) throws SourceGenerationFailedException {
+        return getSource(path,
+                         guidedDecisionTableEditorService.load(Paths.convert(path)));
     }
 
     /**
      * Returns an expander for DSLs (only if there is a DSL configured for this package).
      */
-    private Expander getDSLExpander( final Path path ) {
+    private Expander getDSLExpander(final Path path) {
         final Expander expander = new DefaultExpander();
-        final List<DSLMappingFile> dsls = getDSLMappingFiles( path );
-        for ( DSLMappingFile dsl : dsls ) {
-            expander.addDSLMapping( dsl.getMapping() );
+        final List<DSLMappingFile> dsls = getDSLMappingFiles(path);
+        for (DSLMappingFile dsl : dsls) {
+            expander.addDSLMapping(dsl.getMapping());
         }
         return expander;
     }
 
-    private List<DSLMappingFile> getDSLMappingFiles( final Path path ) {
+    private List<DSLMappingFile> getDSLMappingFiles(final Path path) {
         final List<DSLMappingFile> dsls = new ArrayList<DSLMappingFile>();
-        final org.uberfire.backend.vfs.Path vfsPath = Paths.convert( path );
-        final org.uberfire.backend.vfs.Path packagePath = projectService.resolvePackage( vfsPath ).getPackageMainResourcesPath();
-        final org.uberfire.java.nio.file.Path nioPackagePath = Paths.convert( packagePath );
-        final Collection<Path> dslPaths = fileDiscoveryService.discoverFiles( nioPackagePath,
-                                                                              FILTER_DSLS );
-        for ( final org.uberfire.java.nio.file.Path dslPath : dslPaths ) {
-            final String dslDefinition = ioService.readAllString( dslPath );
+        final org.uberfire.backend.vfs.Path vfsPath = Paths.convert(path);
+        final org.uberfire.backend.vfs.Path packagePath = projectService.resolvePackage(vfsPath).getPackageMainResourcesPath();
+        final org.uberfire.java.nio.file.Path nioPackagePath = Paths.convert(packagePath);
+        final Collection<Path> dslPaths = fileDiscoveryService.discoverFiles(nioPackagePath,
+                                                                             FILTER_DSLS);
+        for (final org.uberfire.java.nio.file.Path dslPath : dslPaths) {
+            final String dslDefinition = ioService.readAllString(dslPath);
             final DSLTokenizedMappingFile dslFile = new DSLTokenizedMappingFile();
             try {
-                if ( dslFile.parseAndLoad( new StringReader( dslDefinition ) ) ) {
-                    dsls.add( dslFile );
+                if (dslFile.parseAndLoad(new StringReader(dslDefinition))) {
+                    dsls.add(dslFile);
                 } else {
-                    logger.error( "Unable to parse DSL definition: " + dslDefinition );
+                    logger.error("Unable to parse DSL definition: " + dslDefinition);
                 }
-            } catch ( IOException ioe ) {
-                logger.error( ioe.getMessage() );
+            } catch (IOException ioe) {
+                logger.error(ioe.getMessage());
             }
         }
         return dsls;
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFileIndexer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFileIndexer.java
@@ -15,9 +15,14 @@
  */
 package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
 import org.drools.workbench.models.datamodel.oracle.ProjectDataModelOracle;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTDRLPersistence;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
@@ -38,6 +43,16 @@ public class GuidedDecisionTableFileIndexer extends AbstractDrlFileIndexer {
     @Inject
     protected DataModelService dataModelService;
 
+    @Inject
+    protected Instance<RuleModelIActionPersistenceExtension> persistenceExtensionInstance;
+
+    private List<RuleModelIActionPersistenceExtension> persistenceExtensions = new ArrayList<>();
+
+    @PostConstruct
+    private void init() {
+        persistenceExtensionInstance.forEach(persistenceExtensions::add);
+    }
+
     @Override
     public boolean supportsPath(final Path path) {
         return type.accept(Paths.convert(path));
@@ -47,7 +62,8 @@ public class GuidedDecisionTableFileIndexer extends AbstractDrlFileIndexer {
     public DefaultIndexBuilder fillIndexBuilder(final Path path) throws Exception {
         final String content = ioService.readAllString(path);
         final GuidedDecisionTable52 model = GuidedDTXMLPersistence.getInstance().unmarshal(content);
-        final String drl = GuidedDTDRLPersistence.getInstance().marshal(model);
+        final String drl = GuidedDTDRLPersistence.getInstance().marshal(model,
+                                                                        persistenceExtensions);
 
         return fillDrlIndexBuilder(path,
                                    drl);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableSourceServiceTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableSourceServiceTest.java
@@ -22,6 +22,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import javax.enterprise.inject.Instance;
+
+import org.drools.workbench.models.commons.backend.rule.RuleModelIActionPersistenceExtension;
 import org.drools.workbench.models.datamodel.imports.Import;
 import org.drools.workbench.models.datamodel.imports.Imports;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
@@ -31,6 +34,8 @@ import org.drools.workbench.models.guided.dtable.shared.model.DescriptionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.models.guided.dtable.shared.model.RowNumberCol52;
+import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
+import org.drools.workbench.screens.guided.dtable.type.GuidedDTableResourceTypeDefinition;
 import org.guvnor.common.services.backend.file.FileDiscoveryService;
 import org.guvnor.common.services.project.model.Package;
 import org.junit.Before;
@@ -40,11 +45,13 @@ import org.kie.workbench.common.services.shared.project.KieProjectService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -65,9 +72,23 @@ public class GuidedDecisionTableSourceServiceTest {
     @Mock
     FileDiscoveryService discoveryService;
 
+    @Mock
+    GuidedDTableResourceTypeDefinition resourceTypeDefinition;
+
+    @Mock
+    GuidedDecisionTableEditorService guidedDecisionTableEditorService;
+
+    @Mock
+    IOService ioService;
+
+    @Mock
+    FileDiscoveryService fileDiscoveryService;
+
+    @Mock
+    Instance<RuleModelIActionPersistenceExtension> persistenceExtensionInstance;
+
     GuidedDecisionTable52 model;
 
-    @InjectMocks
     GuidedDecisionTableSourceService service;
 
     Pattern52 pattern;
@@ -78,6 +99,17 @@ public class GuidedDecisionTableSourceServiceTest {
 
     @Before
     public void setUp() throws Exception {
+        Instance<RuleModelIActionPersistenceExtension> persistenceExtensionInstance = mock(Instance.class);
+        when(persistenceExtensionInstance.iterator()).thenReturn(new ArrayList<RuleModelIActionPersistenceExtension>().iterator());
+
+        service = new GuidedDecisionTableSourceService(resourceTypeDefinition,
+                                                       guidedDecisionTableEditorService,
+                                                       ioService,
+                                                       fileDiscoveryService,
+                                                       projectService,
+                                                       persistenceExtensionInstance);
+
+
         // Simulates that no DSL files are present
         when(projectService.resolvePackage(any())).thenReturn(packageMock);
         when(discoveryService.discoverFiles(any(),

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasRuleModellerPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasRuleModellerPage.java
@@ -16,13 +16,18 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.commons;
 
+import java.util.Collection;
+
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 
 public interface HasRuleModellerPage {
 
     RuleModel getRuleModel();
+
+    Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins();
 
     RuleModellerConfiguration getRuleModellerConfiguration();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPage.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages;
 
+import java.util.Collection;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -30,6 +31,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.c
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerWidgetFactory;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.template.client.editor.TemplateModellerWidgetFactory;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
@@ -88,6 +90,7 @@ public class RuleModellerPage<T extends HasRuleModellerPage & DecisionTableColum
 
     private RuleModeller newRuleModeller() {
         final RuleModeller ruleModeller = new RuleModeller(ruleModel(),
+                                                           actionPlugins(),
                                                            oracle(),
                                                            widgetFactory(),
                                                            configuration(),
@@ -115,6 +118,10 @@ public class RuleModellerPage<T extends HasRuleModellerPage & DecisionTableColum
         return plugin().getRuleModel();
     }
 
+    private Collection<RuleModellerActionPlugin> actionPlugins() {
+        return plugin().getRuleModellerActionPlugins();
+    }
+
     RuleModellerConfiguration configuration() {
         return plugin().getRuleModellerConfiguration();
     }
@@ -124,7 +131,7 @@ public class RuleModellerPage<T extends HasRuleModellerPage & DecisionTableColum
 
         switch (tableFormat) {
             case EXTENDED_ENTRY:
-                return new TemplateModellerWidgetFactory();
+                return new TemplateModellerWidgetFactory(actionPlugins());
             case LIMITED_ENTRY:
                 return new RuleModellerWidgetFactory();
             default:

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -50,6 +52,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.c
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.BaseDecisionTableColumnPlugin;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
@@ -60,6 +63,8 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
                                                                                     TemplateVariablesChangedEvent.Handler {
 
     private RuleModellerPage ruleModellerPage;
+
+    private Collection<RuleModellerActionPlugin> actionPlugins = new ArrayList<>();
 
     private AdditionalInfoPage<BRLActionColumnPlugin> additionalInfoPage;
 
@@ -73,6 +78,7 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
 
     @Inject
     public BRLActionColumnPlugin(final RuleModellerPage ruleModellerPage,
+                                 final Instance<RuleModellerActionPlugin> actionPluginInstance,
                                  final AdditionalInfoPage<BRLActionColumnPlugin> additionalInfoPage,
                                  final Event<WizardPageStatusChangeEvent> changeEvent,
                                  final TranslationService translationService) {
@@ -80,6 +86,7 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
               translationService);
 
         this.ruleModellerPage = ruleModellerPage;
+        actionPluginInstance.iterator().forEachRemaining(actionPlugins::add);
         this.additionalInfoPage = additionalInfoPage;
     }
 
@@ -260,6 +267,11 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
         ruleModel = Optional.ofNullable(ruleModel).orElse(newRuleModel());
 
         return ruleModel;
+    }
+
+    @Override
+    public Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins() {
+        return actionPlugins;
     }
 
     private RuleModel newRuleModel() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,6 +58,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.c
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.BaseDecisionTableColumnPlugin;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
@@ -265,6 +267,11 @@ public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin impl
         ruleModel = Optional.ofNullable(ruleModel).orElse(newRuleModel());
 
         return ruleModel;
+    }
+
+    @Override
+    public Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins() {
+        return Collections.emptyList();
     }
 
     private RuleModel newRuleModel() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table;
 
+import java.util.ArrayList;
+
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -32,6 +34,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.popovers.MockInstanceImpl;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.CalculationTypePage;
@@ -52,6 +55,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.B
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ConditionColumnPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.BaseDecisionTableColumnPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.DecisionTableColumnPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
@@ -272,6 +276,7 @@ public class PluginHandlerTest {
         final LimitedEntryBRLActionColumn originalColumn = mock(LimitedEntryBRLActionColumn.class);
 
         final BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
+                                                                           new MockInstanceImpl<>(new ArrayList<>()),
                                                                            additionalInfoPage,
                                                                            event,
                                                                            translationService));
@@ -285,6 +290,7 @@ public class PluginHandlerTest {
         final BRLActionColumn originalColumn = mock(BRLActionColumn.class);
 
         final BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
+                                                                           new MockInstanceImpl<>(new ArrayList<>()),
                                                                            additionalInfoPage,
                                                                            event,
                                                                            translationService));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPluginTest.java
@@ -31,6 +31,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BRLRuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.popovers.MockInstanceImpl;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.RuleModellerPage;
@@ -79,6 +80,7 @@ public class BRLActionColumnPluginTest {
 
     @InjectMocks
     private BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
+                                                                         new MockInstanceImpl<>(new ArrayList<>()),
                                                                          additionalInfoPage,
                                                                          changeEvent,
                                                                          translationService));

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
@@ -101,12 +101,12 @@ public class RuleModeller extends Composite
                         final boolean isReadOnly,
                         final boolean isDSLEnabled) {
         this(model,
+             actionPlugins,
              oracle,
              widgetFactory,
              RuleModellerConfiguration.getDefault(),
              eventBus,
              isReadOnly);
-        this.actionPlugins = actionPlugins;
         this.isDSLEnabled = isDSLEnabled;
     }
 
@@ -127,12 +127,14 @@ public class RuleModeller extends Composite
 
     //used by Guided Decision BRL Fragments
     public RuleModeller(final RuleModel model,
+                        final Collection<RuleModellerActionPlugin> actionPlugins,
                         final AsyncPackageDataModelOracle oracle,
                         final ModellerWidgetFactory widgetFactory,
                         final RuleModellerConfiguration configuration,
                         final EventBus eventBus,
                         final boolean isReadOnly) {
         this.model = model;
+        this.actionPlugins = actionPlugins;
         this.oracle = oracle;
         this.widgetFactory = widgetFactory;
         this.configuration = configuration;
@@ -785,6 +787,10 @@ public class RuleModeller extends Composite
 
     public RuleModel getModel() {
         return model;
+    }
+
+    public Collection<RuleModellerActionPlugin> getActionPlugins() {
+        return actionPlugins;
     }
 
     /**

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateModellerWidgetFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateModellerWidgetFactory.java
@@ -16,10 +16,20 @@
 
 package org.drools.workbench.screens.guided.template.client.editor;
 
+import java.util.Collection;
+
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerWidgetFactory;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 
 public class TemplateModellerWidgetFactory
         extends RuleModellerWidgetFactory {
+
+    public TemplateModellerWidgetFactory() {
+    }
+
+    public TemplateModellerWidgetFactory(Collection<RuleModellerActionPlugin> actionPlugins) {
+        super(actionPlugins);
+    }
 
     @Override
     public boolean isTemplate() {


### PR DESCRIPTION
Just a backport of the master fix (https://github.com/kiegroup/drools-wb/pull/550) to 7.2.x branch.

Part of:
- https://github.com/kiegroup/drools-wb/pull/565
- https://github.com/kiegroup/drools/pull/1401
- https://github.com/kiegroup/optaplanner-wb/pull/194