### PR TITLE
[7.3.x] GUVNOR-3198: [Guided Decision Table] Visual indication where the current view of Decision Table is located

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilder.java
@@ -146,5 +146,6 @@ public class RadarMenuBuilder implements MenuFactory.CustomMenuBuilder,
 
         modeller.getView().getGridLayerView().getViewport().setTransform(newTransform);
         modeller.getView().getGridLayerView().batch();
+        modeller.getView().refreshScrollPosition();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -337,6 +337,16 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     }
 
     @Override
+    public void addOnEnterPinnedModeCommand(final Command command) {
+        view.getGridLayerView().addOnEnterPinnedModeCommand(command);
+    }
+
+    @Override
+    public void addOnExitPinnedModeCommand(final Command command) {
+        view.getGridLayerView().addOnExitPinnedModeCommand(command);
+    }
+
+    @Override
     public void onDecisionTableSelected(final @Observes DecisionTableSelectedEvent event) {
         final Optional<GuidedDecisionTableView.Presenter> dtPresenter = event.getPresenter();
         if (!dtPresenter.isPresent()) {
@@ -458,6 +468,11 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     public void onViewPinned(final boolean isPinned) {
         pinnedEvent.fire(new DecisionTablePinnedEvent(this,
                                                       isPinned));
+    }
+
+    @Override
+    public void refreshScrollPosition() {
+        view.refreshScrollPosition();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -70,6 +70,8 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
     void refreshRuleInheritance(final String selectedParentRuleName,
                                 final Collection<String> availableParentRuleNames);
 
+    void refreshScrollPosition();
+
     void refreshAttributeWidget(final List<AttributeCol52> attributeColumns);
 
     void refreshMetaDataWidget(final List<MetadataCol52> metaDataColumns);
@@ -138,6 +140,8 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
         void updateRadar();
 
         void onViewPinned(final boolean isPinned);
+
+        void refreshScrollPosition();
 
         void updateLinks();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -19,6 +19,7 @@ import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.ContextMenuHandler;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.MouseDownHandler;
+import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -89,14 +90,8 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
             Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
                 @Override
                 public void execute() {
-                    final int width = getParent().getOffsetWidth();
-                    final int height = getParent().getOffsetHeight();
-                    if ((width != 0) && (height != 0)) {
-                        domElementContainer.setPixelSize(width,
-                                                         height);
-                        lienzoPanel.setPixelSize(width,
-                                                 height);
-                    }
+                    updatePanelSize();
+                    refreshScrollPosition();
 
                     final TransformMediator restriction = mousePanMediator.getTransformMediator();
                     final Transform transform = restriction.adjust(gridLayer.getViewport().getTransform(),
@@ -203,6 +198,10 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         mousePanMediator.setTransformMediator(defaultTransformMediator);
         gridPanel.getViewport().getMediators().push(mousePanMediator);
         mousePanMediator.setBatchDraw(true);
+
+        gridPanel.setBounds(getBounds());
+        gridPanel.getMainPanel().addDomHandler(scrollEvent -> getPresenter().updateRadar(),
+                                               ScrollEvent.getType());
 
         //Wire-up widgets
         gridPanel.add(gridLayer);
@@ -364,6 +363,11 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
                                        final Collection<String> availableParentRuleNames) {
         ruleSelector.setRuleName(selectedParentRuleName);
         ruleSelector.setRuleNames(availableParentRuleNames);
+    }
+
+    @Override
+    public void refreshScrollPosition() {
+        gridPanel.refreshScrollPosition();
     }
 
     private VerticalPanel makeDefaultPanel() {
@@ -709,6 +713,7 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
                                                           gridLayer.getVisibleBounds());
         gridPanel.getViewport().setTransform(newTransform);
         gridPanel.getViewport().batch();
+        gridPanel.refreshScrollPosition();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -642,6 +642,20 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
     }
 
     @Override
+    public void addOnEnterPinnedModeCommand(final Command command) {
+        getParent().addOnEnterPinnedModeCommand(command);
+    }
+
+    @Override
+    public void addOnExitPinnedModeCommand(final Command command) {
+        getParent().addOnExitPinnedModeCommand(command);
+    }
+
+    GuidedDecisionTableModellerView.Presenter getParent() {
+        return parent;
+    }
+
+    @Override
     public void getPackageParentRuleNames(final ParameterizedCommand<Collection<String>> command) {
         ruleNameService.call(new RemoteCallback<Collection<String>>() {
             @Override
@@ -847,9 +861,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         try {
             append.execute();
 
-            parent.updateLinks();
-
-            view.getLayer().draw();
+            refreshView();
 
             //Log addition of column
             model.getAuditLog().add(new InsertColumnAuditLogEntry(identity.getIdentifier(),
@@ -868,9 +880,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         try {
             synchronizer.appendRow();
 
-            parent.updateLinks();
-
-            view.getLayer().draw();
+            refreshView();
 
             //Log insertion of row
             model.getAuditLog().add(new InsertRowAuditLogEntry(identity.getIdentifier(),
@@ -878,6 +888,13 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         } catch (ModelSynchronizer.MoveColumnVetoException e) {
             //Swallow
         }
+    }
+
+    void refreshView() {
+        getParent().updateLinks();
+        getParent().refreshScrollPosition();
+
+        view.getLayer().draw();
     }
 
     @Override
@@ -916,9 +933,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         try {
             synchronizer.deleteColumn(column);
 
-            parent.updateLinks();
-
-            view.getLayer().draw();
+            refreshView();
 
             //Log deletion of column
             model.getAuditLog().add(new DeleteColumnAuditLogEntry(identity.getIdentifier(),
@@ -1252,9 +1267,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         try {
             synchronizer.deleteRow(rowIndex);
 
-            parent.updateLinks();
-
-            view.getLayer().draw();
+            refreshView();
 
             //Log deletion of column
             model.getAuditLog().add(new DeleteRowAuditLogEntry(identity.getIdentifier(),
@@ -1313,9 +1326,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         try {
             synchronizer.insertRow(rowIndex);
 
-            parent.updateLinks();
-
-            view.getLayer().draw();
+            refreshView();
 
             //Log insertion of row
             model.getAuditLog().add(new InsertRowAuditLogEntry(identity.getIdentifier(),

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilderTest.java
@@ -151,6 +151,8 @@ public class RadarMenuBuilderTest {
 
         verify(modellerLayer,
                times(1)).batch();
+
+        verify(modellerView).refreshScrollPosition();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -39,7 +39,6 @@ import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuBuilder;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.accordion.GuidedDecisionTableAccordion;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableColumnSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTablePinnedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
@@ -52,7 +51,6 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuided
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -715,6 +713,32 @@ public class GuidedDecisionTableModellerPresenterTest {
         assertEquals(presenter,
                      pinnedEvent.getPresenter());
         assertFalse(pinnedEvent.isPinned());
+    }
+
+    @Test
+    public void testAddOnEnterPinnedModeCommand() {
+
+        final Command command = mock(Command.class);
+        final GridLayer gridLayer = mock(GridLayer.class);
+
+        doReturn(gridLayer).when(view).getGridLayerView();
+
+        presenter.addOnEnterPinnedModeCommand(command);
+
+        verify(gridLayer).addOnEnterPinnedModeCommand(command);
+    }
+
+    @Test
+    public void testAddOnExitPinnedModeCommand() {
+
+        final Command command = mock(Command.class);
+        final GridLayer gridLayer = mock(GridLayer.class);
+
+        doReturn(gridLayer).when(view).getGridLayerView();
+
+        presenter.addOnExitPinnedModeCommand(command);
+
+        verify(gridLayer).addOnExitPinnedModeCommand(command);
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
@@ -321,6 +321,13 @@ public class GuidedDecisionTableModellerViewImplTest {
         verify(gridLayer).select(gridWidget);
     }
 
+    @Test
+    public void testRefreshScrollPosition() {
+        view.refreshScrollPosition();
+
+        verify(mockGridPanel).refreshScrollPosition();
+    }
+
     private AttributeCol52 attributeColumn() {
         final AttributeCol52 attributeCol52 = mock(AttributeCol52.class);
         final DTCellValue52 defaultValue = mock(DTCellValue52.class);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -26,6 +26,7 @@ import com.ait.lienzo.client.core.event.NodeDragMoveEvent;
 import com.ait.lienzo.client.core.event.NodeDragMoveHandler;
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickEvent;
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
+import com.ait.lienzo.client.core.shape.Layer;
 import com.google.gwt.user.client.Command;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.datamodel.oracle.DataType;
@@ -1598,5 +1599,46 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
 
         verify(gridLayer,
                times(1)).draw();
+    }
+
+    @Test
+    public void testAddOnEnterPinnedModeCommand() {
+
+        final GuidedDecisionTableModellerView.Presenter parent = mock(GuidedDecisionTableModellerView.Presenter.class);
+        final Command command = mock(Command.class);
+
+        doReturn(parent).when(dtPresenter).getParent();
+
+        dtPresenter.addOnEnterPinnedModeCommand(command);
+
+        verify(parent).addOnEnterPinnedModeCommand(command);
+    }
+
+    @Test
+    public void testAddOnExitPinnedModeCommand() {
+
+        final GuidedDecisionTableModellerView.Presenter parent = mock(GuidedDecisionTableModellerView.Presenter.class);
+        final Command command = mock(Command.class);
+
+        doReturn(parent).when(dtPresenter).getParent();
+
+        dtPresenter.addOnExitPinnedModeCommand(command);
+
+        verify(parent).addOnExitPinnedModeCommand(command);
+    }
+
+    @Test
+    public void testRefreshView() {
+        final GuidedDecisionTableModellerView.Presenter parent = mock(GuidedDecisionTableModellerView.Presenter.class);
+        final Layer layer = mock(Layer.class);
+
+        doReturn(parent).when(dtPresenter).getParent();
+        doReturn(layer).when(view).getLayer();
+
+        dtPresenter.refreshView();
+
+        verify(parent).updateLinks();
+        verify(parent).refreshScrollPosition();
+        verify(layer).draw();
     }
 }


### PR DESCRIPTION
Cherry picked from https://github.com/kiegroup/drools-wb/pull/583

---

Part of an ensemble:
- https://github.com/kiegroup/drools-wb/pull/594
- https://github.com/AppFormer/uberfire/pull/819

---

PS: We don't need to update `kie-wb-common` on `7.3.x`.