### PR TITLE
GUVNOR-3472: [Guided Decision Table] GDT Graph creation causes Error Popup

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
@@ -16,6 +16,20 @@
 
 package org.drools.workbench.screens.guided.dtable.shared;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.drools.workbench.models.datamodel.rule.ActionFieldList;
+import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
+import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
+import org.drools.workbench.models.datamodel.rule.ActionSetField;
+import org.drools.workbench.models.datamodel.rule.IAction;
+import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.models.datamodel.rule.visitors.RuleModelVisitor;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
@@ -33,86 +47,151 @@ import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableLin
 
 public class DefaultGuidedDecisionTableLinkManager implements GuidedDecisionTableLinkManager {
 
+    static class RHSTypeFieldsExtractor {
+
+        private Map<String, List<String>> typeFields = new HashMap<>();
+
+        public Map<String, List<String>> extract(final GuidedDecisionTable52 dtable,
+                                                 final List<IAction> fragment) {
+            final BRLRuleModel rm = new BRLRuleModel(dtable);
+
+            fragment.stream()
+                    .filter(iAction -> iAction instanceof ActionFieldList)
+                    .map(iAction -> (ActionFieldList) iAction)
+                    .forEach(iAction -> extract(rm,
+                                                iAction));
+            return typeFields;
+        }
+
+        private void extract(final RuleModel rm,
+                             final ActionFieldList afl) {
+            final Optional<String> type = getType(rm,
+                                                  afl);
+            type.ifPresent(t -> {
+                final ActionFieldValue[] afvs = afl.getFieldValues();
+                for (ActionFieldValue afv : afvs) {
+                    List<String> fields = typeFields.get(t);
+                    if (fields == null) {
+                        fields = new ArrayList<>();
+                        typeFields.put(t,
+                                       fields);
+                    }
+                    fields.add(afv.getField());
+                }
+            });
+        }
+
+        private Optional<String> getType(final RuleModel rm,
+                                         final ActionFieldList afl) {
+            if (afl instanceof ActionInsertFact) {
+                return Optional.of(((ActionInsertFact) afl).getFactType());
+            } else if (afl instanceof ActionSetField) {
+                final String var = ((ActionSetField) afl).getVariable();
+                return Optional.ofNullable(rm.getLHSBindingType(var));
+            }
+            return Optional.empty();
+        }
+    }
+
+    private final RHSTypeFieldsExtractor rhsTypeFieldsExtractor = new RHSTypeFieldsExtractor();
+
     @Override
-    public void link( final GuidedDecisionTable52 model,
-                      final GuidedDecisionTable52 otherModel,
-                      final LinkFoundCallback callback ) {
-        if ( model == null ) {
+    public void link(final GuidedDecisionTable52 model,
+                     final GuidedDecisionTable52 otherModel,
+                     final LinkFoundCallback callback) {
+        if (model == null) {
             return;
         }
-        if ( otherModel == null ) {
+        if (otherModel == null) {
             return;
         }
-        if ( callback == null ) {
+        if (callback == null) {
             return;
         }
-        final BRLRuleModel helper = new BRLRuleModel( model );
+        final BRLRuleModel helper = new BRLRuleModel(model);
 
         //Re-create links to other Decision Tables
-        for ( CompositeColumn<? extends BaseColumn> otherDecisionTableConditions : otherModel.getConditions() ) {
-            if ( otherDecisionTableConditions instanceof Pattern52 ) {
+        for (CompositeColumn<? extends BaseColumn> otherDecisionTableConditions : otherModel.getConditions()) {
+            if (otherDecisionTableConditions instanceof Pattern52) {
                 final Pattern52 otherDecisionTablePattern = (Pattern52) otherDecisionTableConditions;
-                for ( ConditionCol52 otherDecisionTableCondition : otherDecisionTablePattern.getChildColumns() ) {
+                for (ConditionCol52 otherDecisionTableCondition : otherDecisionTablePattern.getChildColumns()) {
                     final String factType = otherDecisionTablePattern.getFactType();
                     final String fieldName = otherDecisionTableCondition.getFactField();
-                    final ActionCol52 linkedActionColumn = getLinkedActionColumn( factType,
-                                                                                  fieldName,
-                                                                                  model,
-                                                                                  helper );
-                    if ( linkedActionColumn != null ) {
-                        final int sourceColumnIndex = model.getExpandedColumns().indexOf( linkedActionColumn );
-                        final int targetColumnIndex = otherModel.getExpandedColumns().indexOf( otherDecisionTableCondition );
-                        callback.link( sourceColumnIndex,
-                                       targetColumnIndex );
+                    final ActionCol52 linkedActionColumn = getLinkedActionColumn(factType,
+                                                                                 fieldName,
+                                                                                 model,
+                                                                                 helper);
+                    if (linkedActionColumn != null) {
+                        final int sourceColumnIndex = model.getExpandedColumns().indexOf(linkedActionColumn);
+                        final int targetColumnIndex = otherModel.getExpandedColumns().indexOf(otherDecisionTableCondition);
+                        callback.link(sourceColumnIndex,
+                                      targetColumnIndex);
                     }
                 }
-
-            } else if ( otherDecisionTableConditions instanceof BRLConditionColumn ) {
+            } else if (otherDecisionTableConditions instanceof BRLConditionColumn) {
                 final BRLConditionColumn fragment = (BRLConditionColumn) otherDecisionTableConditions;
-                for ( BRLConditionVariableColumn var : fragment.getChildColumns() ) {
+                for (BRLConditionVariableColumn var : fragment.getChildColumns()) {
                     final String factType = var.getFactType();
                     final String fieldName = var.getFactField();
-                    final ActionCol52 linkedActionColumn = getLinkedActionColumn( factType,
-                                                                                  fieldName,
-                                                                                  model,
-                                                                                  helper );
-                    if ( linkedActionColumn != null ) {
-                        final int sourceColumnIndex = model.getExpandedColumns().indexOf( linkedActionColumn );
-                        final int targetColumnIndex = otherModel.getExpandedColumns().indexOf( var );
-                        callback.link( sourceColumnIndex,
-                                       targetColumnIndex );
+                    final ActionCol52 linkedActionColumn = getLinkedActionColumn(factType,
+                                                                                 fieldName,
+                                                                                 model,
+                                                                                 helper);
+                    if (linkedActionColumn != null) {
+                        final int sourceColumnIndex = model.getExpandedColumns().indexOf(linkedActionColumn);
+                        final int targetColumnIndex = otherModel.getExpandedColumns().indexOf(var);
+                        callback.link(sourceColumnIndex,
+                                      targetColumnIndex);
                     }
                 }
             }
         }
     }
 
-    private ActionCol52 getLinkedActionColumn( final String factType,
-                                               final String fieldName,
-                                               final GuidedDecisionTable52 model,
-                                               final BRLRuleModel helper ) {
-        if ( factType == null || fieldName == null ) {
+    private ActionCol52 getLinkedActionColumn(final String factType,
+                                              final String fieldName,
+                                              final GuidedDecisionTable52 model,
+                                              final BRLRuleModel helper) {
+        if (factType == null || fieldName == null) {
             return null;
         }
 
-        for ( ActionCol52 ac : model.getActionCols() ) {
-            if ( ac instanceof ActionInsertFactCol52 ) {
+        for (ActionCol52 ac : model.getActionCols()) {
+            if (ac instanceof ActionInsertFactCol52) {
                 final ActionInsertFactCol52 aif = (ActionInsertFactCol52) ac;
-                if ( factType.equals( aif.getFactType() ) && fieldName.equals( aif.getFactField() ) ) {
+                if (factType.equals(aif.getFactType()) && fieldName.equals(aif.getFactField())) {
                     return ac;
                 }
-            } else if ( ac instanceof ActionSetFieldCol52 ) {
+            } else if (ac instanceof ActionSetFieldCol52) {
                 final ActionSetFieldCol52 asf = (ActionSetFieldCol52) ac;
                 final String binding = asf.getBoundName();
-                final String asfFactType = helper.getLHSBindingType( binding );
-                if ( factType.equals( asfFactType ) && fieldName.equals( asf.getFactField() ) ) {
+                final String asfFactType = helper.getLHSBindingType(binding);
+                if (factType.equals(asfFactType) && fieldName.equals(asf.getFactField())) {
                     return ac;
                 }
-            } else if ( ac instanceof BRLActionColumn ) {
+            } else if (ac instanceof BRLActionColumn) {
                 final BRLActionColumn fragment = (BRLActionColumn) ac;
-                for ( BRLActionVariableColumn var : fragment.getChildColumns() ) {
-                    if ( factType.equals( var.getFactType() ) && fieldName.equals( var.getFactField() ) ) {
-                        return ac;
+
+                if (hasTemplateKeys(fragment)) {
+                    //If the fragment has Template Keys we can attempt to link child columns
+                    for (BRLActionVariableColumn var : fragment.getChildColumns()) {
+                        if (factType.equals(var.getFactType()) && fieldName.equals(var.getFactField())) {
+                            return var;
+                        }
+                    }
+                } else {
+                    // If the fragment has no Template Keys we need to ascertain whether the
+                    // fragment itself references the Fact and Field used by the Constraint
+                    final Map<String, List<String>> rhsTypeFields = rhsTypeFieldsExtractor.extract(model,
+                                                                                                   fragment.getDefinition());
+                    if (rhsTypeFields.containsKey(factType)) {
+                        for (String field : rhsTypeFields.get(factType)) {
+                            if (field.equals(fieldName)) {
+                                // It is safe to get the zero'th column here as we know there are
+                                // no variables and hence they'll be a single boolean column
+                                return fragment.getChildColumns().get(0);
+                            }
+                        }
                     }
                 }
             }
@@ -120,4 +199,13 @@ public class DefaultGuidedDecisionTableLinkManager implements GuidedDecisionTabl
         return null;
     }
 
+    private boolean hasTemplateKeys(final BRLActionColumn column) {
+        final Map<InterpolationVariable, Integer> ivs = new HashMap<>();
+        final RuleModel rm = new RuleModel();
+        column.getDefinition().forEach(rm::addRhsItem);
+
+        final RuleModelVisitor rmv = new RuleModelVisitor(ivs);
+        rmv.visit(rm);
+        return ivs.size() > 0;
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
@@ -173,26 +173,14 @@ public class DefaultGuidedDecisionTableLinkManager implements GuidedDecisionTabl
                 final BRLActionColumn fragment = (BRLActionColumn) ac;
 
                 if (hasTemplateKeys(fragment)) {
-                    //If the fragment has Template Keys we can attempt to link child columns
-                    for (BRLActionVariableColumn var : fragment.getChildColumns()) {
-                        if (factType.equals(var.getFactType()) && fieldName.equals(var.getFactField())) {
-                            return var;
-                        }
-                    }
+                    return getLinkedTemplateKeyColumn(fragment,
+                                                      factType,
+                                                      fieldName);
                 } else {
-                    // If the fragment has no Template Keys we need to ascertain whether the
-                    // fragment itself references the Fact and Field used by the Constraint
-                    final Map<String, List<String>> rhsTypeFields = rhsTypeFieldsExtractor.extract(model,
-                                                                                                   fragment.getDefinition());
-                    if (rhsTypeFields.containsKey(factType)) {
-                        for (String field : rhsTypeFields.get(factType)) {
-                            if (field.equals(fieldName)) {
-                                // It is safe to get the zero'th column here as we know there are
-                                // no variables and hence they'll be a single boolean column
-                                return fragment.getChildColumns().get(0);
-                            }
-                        }
-                    }
+                    return getLinkedDefinitionColumn(model,
+                                                     fragment,
+                                                     factType,
+                                                     fieldName);
                 }
             }
         }
@@ -207,5 +195,32 @@ public class DefaultGuidedDecisionTableLinkManager implements GuidedDecisionTabl
         final RuleModelVisitor rmv = new RuleModelVisitor(ivs);
         rmv.visit(rm);
         return ivs.size() > 0;
+    }
+
+    private ActionCol52 getLinkedTemplateKeyColumn(final BRLActionColumn fragment,
+                                                   final String factType,
+                                                   final String fieldName) {
+        for (BRLActionVariableColumn var : fragment.getChildColumns()) {
+            if (factType.equals(var.getFactType()) && fieldName.equals(var.getFactField())) {
+                return var;
+            }
+        }
+        return null;
+    }
+
+    private ActionCol52 getLinkedDefinitionColumn(final GuidedDecisionTable52 model,
+                                                  final BRLActionColumn fragment,
+                                                  final String factType,
+                                                  final String fieldName) {
+        final Map<String, List<String>> rhsTypeFields = rhsTypeFieldsExtractor.extract(model,
+                                                                                       fragment.getDefinition());
+        if (rhsTypeFields.containsKey(factType)) {
+            for (String field : rhsTypeFields.get(factType)) {
+                if (field.equals(fieldName)) {
+                    return fragment.getChildColumns().get(0);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManager.java
@@ -63,31 +63,27 @@ public class DefaultGuidedDecisionTableLinkManager implements GuidedDecisionTabl
             return typeFields;
         }
 
-        private void extract(final RuleModel rm,
-                             final ActionFieldList afl) {
-            final Optional<String> type = getType(rm,
-                                                  afl);
+        private void extract(final RuleModel ruleModel,
+                             final ActionFieldList actionFieldList) {
+            final Optional<String> type = getType(ruleModel,
+                                                  actionFieldList);
             type.ifPresent(t -> {
-                final ActionFieldValue[] afvs = afl.getFieldValues();
-                for (ActionFieldValue afv : afvs) {
-                    List<String> fields = typeFields.get(t);
-                    if (fields == null) {
-                        fields = new ArrayList<>();
-                        typeFields.put(t,
-                                       fields);
-                    }
-                    fields.add(afv.getField());
+                final ActionFieldValue[] actionFieldValues = actionFieldList.getFieldValues();
+                for (ActionFieldValue actionFieldValue : actionFieldValues) {
+                    final List<String> fields = typeFields.computeIfAbsent(t,
+                                                                           s -> new ArrayList<>());
+                    fields.add(actionFieldValue.getField());
                 }
             });
         }
 
-        private Optional<String> getType(final RuleModel rm,
-                                         final ActionFieldList afl) {
-            if (afl instanceof ActionInsertFact) {
-                return Optional.of(((ActionInsertFact) afl).getFactType());
-            } else if (afl instanceof ActionSetField) {
-                final String var = ((ActionSetField) afl).getVariable();
-                return Optional.ofNullable(rm.getLHSBindingType(var));
+        private Optional<String> getType(final RuleModel ruleModel,
+                                         final ActionFieldList actionFieldList) {
+            if (actionFieldList instanceof ActionInsertFact) {
+                return Optional.of(((ActionInsertFact) actionFieldList).getFactType());
+            } else if (actionFieldList instanceof ActionSetField) {
+                final String var = ((ActionSetField) actionFieldList).getVariable();
+                return Optional.ofNullable(ruleModel.getLHSBindingType(var));
             }
             return Optional.empty();
         }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/test/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManagerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/test/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManagerTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 
 import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
+import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
 import org.drools.workbench.models.datamodel.rule.ActionSetField;
 import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.models.datamodel.rule.IAction;
@@ -46,14 +47,14 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
     @Before
     public void setup() {
         final DefaultGuidedDecisionTableLinkManager wrapped = new DefaultGuidedDecisionTableLinkManager();
-        manager = spy( wrapped );
+        manager = spy(wrapped);
     }
 
     @Test
     public void onlyOneDecisionTableThereforeNoLinks() {
-        manager.link( new GuidedDecisionTable52(),
-                      null,
-                      ( s, t ) -> fail( "There should be no links" ) );
+        manager.link(new GuidedDecisionTable52(),
+                     null,
+                     (s, t) -> fail("There should be no links"));
     }
 
     @Test
@@ -61,35 +62,35 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
         //Columns: Row#[0], Description[1], Condition[2], Action[3]
         final GuidedDecisionTable52 dt1 = new GuidedDecisionTable52();
         final Pattern52 p1 = new Pattern52();
-        p1.setBoundName( "$f" );
-        p1.setFactType( "Fact" );
+        p1.setBoundName("$f");
+        p1.setFactType("Fact");
         final ConditionCol52 p1c1 = new ConditionCol52();
-        p1c1.setFactField( "field" );
-        p1.getChildColumns().add( p1c1 );
-        dt1.getConditions().add( p1 );
+        p1c1.setFactField("field");
+        p1.getChildColumns().add(p1c1);
+        dt1.getConditions().add(p1);
         final ActionSetFieldCol52 asf = new ActionSetFieldCol52();
-        asf.setBoundName( "$f" );
-        asf.setFactField( "field" );
-        dt1.getActionCols().add( asf );
+        asf.setBoundName("$f");
+        asf.setFactField("field");
+        dt1.getActionCols().add(asf);
 
         //Columns: Row#[0], Description[1], Condition[2]
         final GuidedDecisionTable52 dt2 = new GuidedDecisionTable52();
         final Pattern52 p2 = new Pattern52();
-        p2.setBoundName( "$f" );
-        p2.setFactType( "Fact" );
+        p2.setBoundName("$f");
+        p2.setFactType("Fact");
         final ConditionCol52 p2c1 = new ConditionCol52();
-        p2c1.setFactField( "field" );
-        p2.getChildColumns().add( p2c1 );
-        dt2.getConditions().add( p2 );
+        p2c1.setFactField("field");
+        p2.getChildColumns().add(p2c1);
+        dt2.getConditions().add(p2);
 
-        manager.link( dt1,
-                      dt2,
-                      ( s, t ) -> {
-                          assertEquals( 3,
-                                        s );
-                          assertEquals( 2,
-                                        t );
-                      } );
+        manager.link(dt1,
+                     dt2,
+                     (s, t) -> {
+                         assertEquals(3,
+                                      s);
+                         assertEquals(2,
+                                      t);
+                     });
     }
 
     @Test
@@ -97,68 +98,110 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
         //Columns: Row#[0], Description[1], Action[2]
         final GuidedDecisionTable52 dt1 = new GuidedDecisionTable52();
         final ActionInsertFactCol52 aif = new ActionInsertFactCol52();
-        aif.setFactType( "Fact" );
-        aif.setFactField( "field" );
-        dt1.getActionCols().add( aif );
+        aif.setFactType("Fact");
+        aif.setFactField("field");
+        dt1.getActionCols().add(aif);
 
         //Columns: Row#[0], Description[1], Condition[2]
         final GuidedDecisionTable52 dt2 = new GuidedDecisionTable52();
         final Pattern52 p2 = new Pattern52();
-        p2.setBoundName( "$f" );
-        p2.setFactType( "Fact" );
+        p2.setBoundName("$f");
+        p2.setFactType("Fact");
         final ConditionCol52 p2c1 = new ConditionCol52();
-        p2c1.setFactField( "field" );
-        p2.getChildColumns().add( p2c1 );
-        dt2.getConditions().add( p2 );
+        p2c1.setFactField("field");
+        p2.getChildColumns().add(p2c1);
+        dt2.getConditions().add(p2);
 
-        manager.link( dt1,
-                      dt2,
-                      ( s, t ) -> {
-                          assertEquals( 2,
-                                        s );
-                          assertEquals( 2,
-                                        t );
-                      } );
+        manager.link(dt1,
+                     dt2,
+                     (s, t) -> {
+                         assertEquals(2,
+                                      s);
+                         assertEquals(2,
+                                      t);
+                     });
     }
 
     @Test
-    public void fieldConstraintWithActionBRLFragmentFieldWithBoolean() {
+    public void fieldConstraintWithActionBRLFragmentFieldWithoutTemplateKey() {
+        //Columns: Row#[0], Description[1], Action[2]
+        final GuidedDecisionTable52 dt1 = new GuidedDecisionTable52();
+        final BRLActionColumn brl = new BRLActionColumn();
+        final ActionInsertFact aif = new ActionInsertFact();
+        aif.setFactType("Fact");
+        aif.addFieldValue(new ActionFieldValue() {{
+            setField("field");
+            setValue("10");
+            setNature(FieldNatureType.TYPE_LITERAL);
+        }});
+        brl.setDefinition(new ArrayList<IAction>() {{
+            add(aif);
+        }});
+        brl.getChildColumns().add(new BRLActionVariableColumn("",
+                                                              DataType.TYPE_BOOLEAN));
+
+        dt1.getActionCols().add(brl);
+
+        //Columns: Row#[0], Description[1], Condition[2]
+        final GuidedDecisionTable52 dt2 = new GuidedDecisionTable52();
+        final Pattern52 p2 = new Pattern52();
+        p2.setBoundName("$f");
+        p2.setFactType("Fact");
+        final ConditionCol52 p2c1 = new ConditionCol52();
+        p2c1.setFactField("field");
+        p2.getChildColumns().add(p2c1);
+        dt2.getConditions().add(p2);
+
+        manager.link(dt1,
+                     dt2,
+                     (s, t) -> {
+                         assertEquals(2,
+                                      s);
+                         assertEquals(2,
+                                      t);
+                     });
+    }
+
+    @Test
+    public void fieldConstraintWithActionBRLFragmentFieldWithTemplateKey() {
         //Columns: Row#[0], Description[1], Action[2]
         final GuidedDecisionTable52 dt1 = new GuidedDecisionTable52();
         final BRLActionColumn brl = new BRLActionColumn();
         final ActionSetField asf = new ActionSetField();
-        asf.setVariable( "$f" );
-        asf.addFieldValue( new ActionFieldValue() {{
-            setField( "field" );
-            setValue( "10" );
-            setNature( FieldNatureType.TYPE_LITERAL );
-        }} );
-        brl.setDefinition( new ArrayList<IAction>() {{
-            add( asf );
-        }} );
-        brl.getChildColumns().add( new BRLActionVariableColumn( "",
-                                                                DataType.TYPE_BOOLEAN ) );
+        asf.setVariable("$f");
+        asf.addFieldValue(new ActionFieldValue() {{
+            setField("field");
+            setValue("10");
+            setType(DataType.TYPE_STRING);
+            setNature(FieldNatureType.TYPE_LITERAL);
+        }});
+        brl.setDefinition(new ArrayList<IAction>() {{
+            add(asf);
+        }});
+        brl.getChildColumns().add(new BRLActionVariableColumn("$f",
+                                                              DataType.TYPE_STRING,
+                                                              "Fact",
+                                                              "field"));
 
-        dt1.getActionCols().add( brl );
+        dt1.getActionCols().add(brl);
 
         //Columns: Row#[0], Description[1], Condition[2]
         final GuidedDecisionTable52 dt2 = new GuidedDecisionTable52();
         final Pattern52 p2 = new Pattern52();
-        p2.setBoundName( "$f" );
-        p2.setFactType( "Fact" );
+        p2.setBoundName("$f");
+        p2.setFactType("Fact");
         final ConditionCol52 p2c1 = new ConditionCol52();
-        p2c1.setFactField( "field" );
-        p2.getChildColumns().add( p2c1 );
-        dt2.getConditions().add( p2 );
+        p2c1.setFactField("field");
+        p2.getChildColumns().add(p2c1);
+        dt2.getConditions().add(p2);
 
-        manager.link( dt1,
-                      dt2,
-                      ( s, t ) -> {
-                          assertEquals( 3,
-                                        s );
-                          assertEquals( 2,
-                                        t );
-                      } );
+        manager.link(dt1,
+                     dt2,
+                     (s, t) -> {
+                         assertEquals(2,
+                                      s);
+                         assertEquals(2,
+                                      t);
+                     });
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/test/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManagerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/test/java/org/drools/workbench/screens/guided/dtable/shared/DefaultGuidedDecisionTableLinkManagerTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import org.appformer.project.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
-import org.drools.workbench.models.datamodel.rule.ActionSetField;
 import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.models.datamodel.rule.IAction;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
@@ -167,16 +166,15 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
         //Columns: Row#[0], Description[1], Action[2]
         final GuidedDecisionTable52 dt1 = new GuidedDecisionTable52();
         final BRLActionColumn brl = new BRLActionColumn();
-        final ActionSetField asf = new ActionSetField();
-        asf.setVariable("$f");
-        asf.addFieldValue(new ActionFieldValue() {{
+        final ActionInsertFact aif = new ActionInsertFact("Fact");
+        aif.addFieldValue(new ActionFieldValue() {{
             setField("field");
             setValue("10");
             setType(DataType.TYPE_STRING);
-            setNature(FieldNatureType.TYPE_LITERAL);
+            setNature(FieldNatureType.TYPE_TEMPLATE);
         }});
         brl.setDefinition(new ArrayList<IAction>() {{
-            add(asf);
+            add(aif);
         }});
         brl.getChildColumns().add(new BRLActionVariableColumn("$f",
                                                               DataType.TYPE_STRING,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.widget.table;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,10 @@ import com.google.gwt.user.client.Command;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.appformer.project.datamodel.oracle.DataType;
 import org.appformer.project.datamodel.oracle.DropDownData;
+import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
+import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
 import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLActionColumn;
@@ -673,8 +677,16 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
                                            final String factType,
                                            final String field) {
         final BRLActionColumn brlAction = new BRLActionColumn();
-        BRLActionVariableColumn variableColumn = new BRLActionVariableColumn(null,
-                                                                             null,
+        final ActionInsertFact aif = new ActionInsertFact(factType);
+        final ActionFieldValue afv = new ActionFieldValue(field,
+                                                          "$var",
+                                                          DataType.TYPE_STRING);
+        afv.setNature(FieldNatureType.TYPE_VARIABLE);
+        aif.addFieldValue(afv);
+        brlAction.setDefinition(Collections.singletonList(aif));
+
+        BRLActionVariableColumn variableColumn = new BRLActionVariableColumn("$var",
+                                                                             DataType.TYPE_STRING,
                                                                              factType,
                                                                              field);
         brlAction.getChildColumns().add(variableColumn);


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3472

@jomarko This PR also fixes an existing "linking" test.

Test ```fieldConstraintWithActionBRLFragmentFieldWithoutTemplateKey()``` never formed a link and hence the ascertain never executed and never failed. The reason was that ```BRLActionColumn``` with no Template Keys (and hence a boolean column) should have links checked against the definition itself.