### PR TITLE
GUVNOR-3486: [Guided Decision Table Graph] Refresh after removal of table

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -323,7 +323,7 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
             decisionTableSelectedEvent.fire(DecisionTableSelectedEvent.NONE);
         } else {
             final GuidedDecisionTableView.Presenter dtPresenter = availableDecisionTables.iterator().next();
-            activateDocument(dtPresenter);
+            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dtPresenter));
         }
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -57,6 +57,7 @@ import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEdito
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetKeyboardHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.KeyboardOperationEditCell;
@@ -242,10 +243,21 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
             }
             dtPresenter.onClose();
 
-            updateLinks();
+            removeLinksForDecisionTable(dtPresenter);
         };
         view.removeDecisionTable(dtPresenter.getView(),
                                  afterRemovalCommand);
+    }
+
+    void removeLinksForDecisionTable(final GuidedDecisionTableView.Presenter dtPresenter) {
+        getAvailableDecisionTables()
+                .stream()
+                .map(other -> other.getView().getModel().getColumns())
+                .forEach(columns -> columns
+                        .stream()
+                        .filter(GridColumn::isLinked)
+                        .filter(column -> dtPresenter.getView().getModel().getColumns().contains(column.getLink()))
+                        .forEach(column -> column.setLink(null)));
     }
 
     @Override
@@ -481,7 +493,6 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     @Override
     public void updateLinks() {
         for (GuidedDecisionTableView.Presenter dtPresenter : getAvailableDecisionTables()) {
-            dtPresenter.getView().getModel().getColumns().forEach(c -> c.setLink(null));
             dtPresenter.link(getAvailableDecisionTables());
         }
         getView().getGridLayerView().refreshGridWidgetConnectors();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -241,6 +241,8 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
                 activeDecisionTable = null;
             }
             dtPresenter.onClose();
+
+            updateLinks();
         };
         view.removeDecisionTable(dtPresenter.getView(),
                                  afterRemovalCommand);
@@ -479,6 +481,7 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     @Override
     public void updateLinks() {
         for (GuidedDecisionTableView.Presenter dtPresenter : getAvailableDecisionTables()) {
+            dtPresenter.getView().getModel().getColumns().forEach(c -> c.setLink(null));
             dtPresenter.link(getAvailableDecisionTables());
         }
         getView().getGridLayerView().refreshGridWidgetConnectors();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -350,11 +350,11 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         }
         final Command remove = () -> {
             gridLayer.remove(gridWidget);
-            gridLayer.batch();
-
-            disableButtonMenu();
 
             afterRemovalCommand.execute();
+            disableButtonMenu();
+
+            gridLayer.batch();
         };
         if (gridLayer.isGridPinned()) {
             final GridPinnedModeManager.PinnedContext context = gridLayer.getPinnedContext();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -341,8 +341,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                                         parent.getView().asWidget(),
                                         placeRequest,
                                         () -> currentPath.getFileName() + " - " + resourceType.getDescription(),
-                                        () -> {
-                                            /*nothing*/}),
+                                        () -> {/*Nothing*/}),
                          parent);
     }
 
@@ -492,12 +491,10 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         view.registerNodeMouseDoubleClickHandler((event) -> {
             if (view.isNodeMouseEventOverCaption(event)) {
                 if (isGridPinned()) {
-                    exitPinnedMode(() -> {
-                        /*Nothing*/});
+                    exitPinnedMode(() -> {/*Nothing*/});
                 } else {
                     enterPinnedMode(view,
-                                    () -> {
-                                        /*Nothing*/});
+                                    () -> {/*Nothing*/});
                 }
             }
         });

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -364,19 +364,18 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
         presenter.openOtherDecisionTable();
 
-        verify(decisionTableSelectedEvent,
-               times(1)).fire(dtSelectedEventCaptor.capture());
-
-        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
-        assertNotNull(dtSelectedEvent);
-        assertFalse(dtSelectedEvent.getPresenter().isPresent());
-
         verify(presenter,
                never()).activateDocument(any(GuidedDecisionTableView.Presenter.class));
         verify(placeManager,
                never()).forceClosePlace(any(String.class));
         verify(placeManager,
                never()).forceClosePlace(any(PlaceRequest.class));
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull(dtSelectedEvent);
+        assertFalse(dtSelectedEvent.getPresenter().isPresent());
     }
 
     @Test
@@ -394,8 +393,14 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                never()).forceClosePlace(any(String.class));
         verify(placeManager,
                never()).forceClosePlace(any(PlaceRequest.class));
-        verify(presenter,
-               times(1)).activateDocument(remainingDtPresenter);
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull(dtSelectedEvent);
+        assertTrue(dtSelectedEvent.getPresenter().isPresent());
+        assertEquals(dtSelectedEvent.getPresenter().get(),
+                     remainingDtPresenter);
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -61,6 +61,7 @@ import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.ParameterizedCommand;
@@ -138,6 +139,7 @@ public class GuidedDecisionTableModellerPresenterTest {
 
         when(dtablePresenterProvider.get()).thenReturn(dtablePresenter);
         when(dtablePresenter.getView()).thenReturn(dtableView);
+        when(dtableView.getModel()).thenReturn(new BaseGridData());
     }
 
     private GuidedDecisionTableView.Presenter makeDecisionTable() {
@@ -147,6 +149,7 @@ public class GuidedDecisionTableModellerPresenterTest {
         when(dtPresenter.getView()).thenReturn(dtView);
         when(dtPresenter.getAccess()).thenReturn(mock(GuidedDecisionTablePresenter.Access.class));
         when(dtPresenter.getModel()).thenReturn(mock(GuidedDecisionTable52.class));
+        when(dtView.getModel()).thenReturn(new BaseGridData());
 
         return dtPresenter;
     }
@@ -287,6 +290,8 @@ public class GuidedDecisionTableModellerPresenterTest {
                times(1)).refreshColumnsNote(eq(false));
         verify(dtPresenter,
                times(1)).onClose();
+        verify(presenter,
+               times(1)).updateLinks();
     }
 
     @Test
@@ -763,5 +768,27 @@ public class GuidedDecisionTableModellerPresenterTest {
                times(1)).link(eq(availableDecisionTables));
         verify(gridLayer,
                times(1)).refreshGridWidgetConnectors();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void updateLinksClearsExistingLinks() {
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable();
+        final Set<GuidedDecisionTableView.Presenter> availableDecisionTables = new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter);
+        }};
+
+        final GridColumn uiColumn1 = mock(GridColumn.class);
+        final GridColumn uiColumn2 = mock(GridColumn.class);
+        dtPresenter.getView().getModel().appendColumn(uiColumn1);
+        dtPresenter.getView().getModel().appendColumn(uiColumn2);
+
+        when(presenter.isDecisionTableAvailable(eq(dtPresenter))).thenReturn(true);
+        when(presenter.getAvailableDecisionTables()).thenReturn(availableDecisionTables);
+
+        presenter.updateLinks();
+
+        verify(uiColumn1).setLink(eq(null));
+        verify(uiColumn2).setLink(eq(null));
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3486

@jomarko @karreiro I noticed, with a "graph", that selection of a table (clicking on it) resets the scrollbar position to the origin (0,0).. I double checked this is not caused by this PR. If either of you confirm then I'll open a new JIRA (for @karreiro sorry) as selection of a table should not affect the canvas scroll.