### PR TITLE
GUVNOR-3471: [Guided Decision Table] Delete Multiple Cells and Rows f…

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerContextMenuSupport.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerContextMenuSupport.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.guided.dtable.client.widget.table;
 
+import java.util.stream.Stream;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -31,6 +33,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.menu.RowContextM
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.IsRowDragHandle;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
@@ -43,21 +46,21 @@ public class GuidedDecisionTableModellerContextMenuSupport {
     private final RowContextMenu rowContextMenu;
 
     @Inject
-    public GuidedDecisionTableModellerContextMenuSupport( final CellContextMenu cellContextMenu,
-                                                          final RowContextMenu rowContextMenu ) {
+    public GuidedDecisionTableModellerContextMenuSupport(final CellContextMenu cellContextMenu,
+                                                         final RowContextMenu rowContextMenu) {
         this.cellContextMenu = cellContextMenu;
         this.rowContextMenu = rowContextMenu;
     }
 
-    public ContextMenuHandler getContextMenuHandler( final GuidedDecisionTableModellerView.Presenter modellerPresenter ) {
-        return new GuidedDecisionTableModellerContextMenuHandler( modellerPresenter,
-                                                                  cellContextMenu,
-                                                                  rowContextMenu );
+    public ContextMenuHandler getContextMenuHandler(final GuidedDecisionTableModellerView.Presenter modellerPresenter) {
+        return new GuidedDecisionTableModellerContextMenuHandler(modellerPresenter,
+                                                                 cellContextMenu,
+                                                                 rowContextMenu);
     }
 
     public MouseDownHandler getContextMenuMouseDownHandler() {
-        return new GuidedDecisionTableModellerContextMenuMouseDownHandler( cellContextMenu,
-                                                                           rowContextMenu );
+        return new GuidedDecisionTableModellerContextMenuMouseDownHandler(cellContextMenu,
+                                                                          rowContextMenu);
     }
 
     private static class GuidedDecisionTableModellerContextMenuHandler implements ContextMenuHandler {
@@ -66,95 +69,106 @@ public class GuidedDecisionTableModellerContextMenuSupport {
         private final CellContextMenu cellContextMenu;
         private final RowContextMenu rowContextMenu;
 
-        public GuidedDecisionTableModellerContextMenuHandler( final GuidedDecisionTableModellerView.Presenter modellerPresenter,
-                                                              final CellContextMenu cellContextMenu,
-                                                              final RowContextMenu rowContextMenu ) {
+        public GuidedDecisionTableModellerContextMenuHandler(
+                                                             final GuidedDecisionTableModellerView.Presenter modellerPresenter,
+                                                             final CellContextMenu cellContextMenu,
+                                                             final RowContextMenu rowContextMenu) {
             this.modellerPresenter = modellerPresenter;
             this.cellContextMenu = cellContextMenu;
             this.rowContextMenu = rowContextMenu;
         }
 
         @Override
-        public void onContextMenu( final ContextMenuEvent event ) {
+        public void onContextMenu(final ContextMenuEvent event) {
             event.preventDefault();
             event.stopPropagation();
             final boolean isShiftKeyDown = event.getNativeEvent().getShiftKey();
             final boolean isControlKeyDown = event.getNativeEvent().getCtrlKey();
             final int eventX = event.getNativeEvent().getClientX();
             final int eventY = event.getNativeEvent().getClientY();
-            final int canvasX = getRelativeX( event );
-            final int canvasY = getRelativeY( event );
+            final int canvasX = getRelativeX(event);
+            final int canvasY = getRelativeY(event);
 
-            for ( GuidedDecisionTableView.Presenter dtPresenter : modellerPresenter.getAvailableDecisionTables() ) {
+            for (GuidedDecisionTableView.Presenter dtPresenter : modellerPresenter.getAvailableDecisionTables()) {
                 final GuidedDecisionTableView gridView = dtPresenter.getView();
                 final GridData gridModel = gridView.getModel();
 
-                final Point2D ap = CoordinateUtilities.convertDOMToGridCoordinate( gridView,
-                                                                                   new Point2D( canvasX,
-                                                                                                canvasY ) );
-                final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex( gridView,
-                                                                              ap.getY() );
-                final Integer uiColumnIndex = CoordinateUtilities.getUiColumnIndex( gridView,
-                                                                                    ap.getX() );
-                if ( uiRowIndex == null || uiColumnIndex == null ) {
+                final Point2D ap = CoordinateUtilities.convertDOMToGridCoordinate(gridView,
+                                                                                  new Point2D(canvasX,
+                                                                                              canvasY));
+                final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(gridView,
+                                                                             ap.getY());
+                final Integer uiColumnIndex = CoordinateUtilities.getUiColumnIndex(gridView,
+                                                                                   ap.getX());
+                if (uiRowIndex == null || uiColumnIndex == null) {
                     continue;
                 }
 
-                final GridColumn<?> column = gridModel.getColumns().get( uiColumnIndex );
-                if ( column instanceof IsRowDragHandle ) {
-                    rowContextMenu.show( eventX,
-                                         eventY );
+                final GridColumn<?> column = gridModel.getColumns().get(uiColumnIndex);
+                if (column instanceof IsRowDragHandle) {
+                    rowContextMenu.show(eventX,
+                                        eventY);
 
                 } else {
-                    cellContextMenu.show( eventX,
-                                          eventY );
+                    cellContextMenu.show(eventX,
+                                         eventY);
                 }
-                selectCell( uiRowIndex,
-                            uiColumnIndex,
-                            gridView,
-                            isShiftKeyDown,
-                            isControlKeyDown );
+
+                // the original column index before any moves
+                final int modelColumnIndex = column.getIndex();
+                // selected cells of UIModel whose column index is that of the context menu selected cell
+                final Stream<SelectedCell> modelColumnSelectedCells = gridModel.getSelectedCells().stream().filter(cell -> cell.getColumnIndex() == modelColumnIndex);
+                // does row index of context menu selected cell match one in UIModel selected cells?
+                final boolean isContextMenuCellSelectedCell = modelColumnSelectedCells.map(GridData.SelectedCell::getRowIndex).anyMatch(rowIndex -> rowIndex == uiRowIndex);
+                // if cell selected for context menu is not one of the selected cells from CTRL or SHIFT then handle the selected cell
+                if (!isContextMenuCellSelectedCell) {
+                    selectCell(uiRowIndex,
+                               uiColumnIndex,
+                               gridView,
+                               isShiftKeyDown,
+                               isControlKeyDown);
+                }
             }
         }
 
-        private int getRelativeX( final ContextMenuEvent event ) {
+        private int getRelativeX(final ContextMenuEvent event) {
             final NativeEvent e = event.getNativeEvent();
             final Element target = event.getRelativeElement();
             return e.getClientX() - target.getAbsoluteLeft() + target.getScrollLeft() + target.getOwnerDocument().getScrollLeft();
         }
 
-        private int getRelativeY( final ContextMenuEvent event ) {
+        private int getRelativeY(final ContextMenuEvent event) {
             final NativeEvent e = event.getNativeEvent();
             final Element target = event.getRelativeElement();
             return e.getClientY() - target.getAbsoluteTop() + target.getScrollTop() + target.getOwnerDocument().getScrollTop();
         }
 
-        private void selectCell( final int uiRowIndex,
-                                 final int uiColumnIndex,
-                                 final GuidedDecisionTableView gridView,
-                                 final boolean isShiftKeyDown,
-                                 final boolean isControlKeyDown ) {
-            //Lookup CellSelectionManager for cell
+        private void selectCell(final int uiRowIndex,
+                                final int uiColumnIndex,
+                                final GuidedDecisionTableView gridView,
+                                final boolean isShiftKeyDown,
+                                final boolean isControlKeyDown) {
+            // Lookup CellSelectionManager for cell
             final GridData gridModel = gridView.getModel();
 
             CellSelectionStrategy selectionStrategy;
-            final GridCell<?> cell = gridModel.getCell( uiRowIndex,
-                                                        uiColumnIndex );
-            if ( cell == null ) {
+            final GridCell<?> cell = gridModel.getCell(uiRowIndex,
+                                                       uiColumnIndex);
+            if (cell == null) {
                 selectionStrategy = RangeSelectionStrategy.INSTANCE;
             } else {
                 selectionStrategy = cell.getSelectionManager();
             }
-            if ( selectionStrategy == null ) {
+            if (selectionStrategy == null) {
                 return;
             }
 
-            //Handle selection
-            if ( selectionStrategy.handleSelection( gridModel,
-                                                    uiRowIndex,
-                                                    uiColumnIndex,
-                                                    isShiftKeyDown,
-                                                    isControlKeyDown ) ) {
+            // Handle selection
+            if (selectionStrategy.handleSelection(gridModel,
+                                                  uiRowIndex,
+                                                  uiColumnIndex,
+                                                  isShiftKeyDown,
+                                                  isControlKeyDown)) {
                 gridView.getLayer().batch();
             }
         }
@@ -166,29 +180,28 @@ public class GuidedDecisionTableModellerContextMenuSupport {
         private final CellContextMenu cellContextMenu;
         private final RowContextMenu rowContextMenu;
 
-        public GuidedDecisionTableModellerContextMenuMouseDownHandler( final CellContextMenu cellContextMenu,
-                                                                       final RowContextMenu rowContextMenu ) {
+        public GuidedDecisionTableModellerContextMenuMouseDownHandler(final CellContextMenu cellContextMenu,
+                                                                      final RowContextMenu rowContextMenu) {
             this.cellContextMenu = cellContextMenu;
             this.rowContextMenu = rowContextMenu;
         }
 
         @Override
-        public void onMouseDown( final MouseDownEvent event ) {
-            if ( !eventTargetsPopup( event.getNativeEvent(),
-                                     cellContextMenu.asWidget().getElement() ) ) {
+        public void onMouseDown(final MouseDownEvent event) {
+            if (!eventTargetsPopup(event.getNativeEvent(),
+                                   cellContextMenu.asWidget().getElement())) {
                 cellContextMenu.hide();
             }
-            if ( !eventTargetsPopup( event.getNativeEvent(),
-                                     rowContextMenu.asWidget().getElement() ) ) {
+            if (!eventTargetsPopup(event.getNativeEvent(),
+                                   rowContextMenu.asWidget().getElement())) {
                 rowContextMenu.hide();
             }
         }
 
-        private boolean eventTargetsPopup( final NativeEvent event,
-                                           final Element element ) {
+        private boolean eventTargetsPopup(final NativeEvent event, final Element element) {
             final EventTarget target = event.getEventTarget();
-            if ( Element.is( target ) ) {
-                return element.isOrHasChild( Element.as( target ) );
+            if (Element.is(target)) {
+                return element.isOrHasChild(Element.as(target));
             }
             return false;
         }


### PR DESCRIPTION
…rom context menu

NOTE:  only change to GuidedDecisionTableModellerContextMenuSupport is to line 79. Setting the getControlKey event to true works for the use case of selecting multiple cells with CTRL and either keeping it held down or not before right clicking to display the context menu.   RangeSelectionStrategy.handleSelection will then not remove selected cells as it was before if the user let go of CTRL before right clicking.