### PR TITLE
[7.3.x] GUVNOR-3491: [Guided Decision Table] Context menu doesn't disappear if editor toolbar is clicked and even if the editor is closed

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -18,6 +18,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
 import com.google.gwt.event.dom.client.ContextMenuHandler;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -31,6 +32,7 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -263,7 +265,12 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
 
     @Override
     public HandlerRegistration addMouseDownHandler(final MouseDownHandler handler) {
-        return gridPanel.addMouseDownHandler(handler);
+        return rootPanel().addDomHandler(handler,
+                                         MouseDownEvent.getType());
+    }
+
+    RootPanel rootPanel() {
+        return RootPanel.get();
     }
 
     Widget ruleInheritanceWidget() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
@@ -23,13 +23,17 @@ import com.ait.lienzo.client.core.mediator.Mediators;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
 import com.google.gwt.dev.util.collect.HashMap;
+import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -62,33 +66,36 @@ import static org.mockito.Mockito.*;
 public class GuidedDecisionTableModellerViewImplTest {
 
     @Mock
-    FlowPanel flowPanel;
+    private FlowPanel flowPanel;
 
     @Mock
-    GridLienzoPanel mockGridPanel;
+    private GridLienzoPanel mockGridPanel;
 
     @Mock
-    DefaultGridLayer gridLayer;
+    private DefaultGridLayer gridLayer;
 
     @Mock
-    DefaultGridLayer defaultGridLayer;
+    private DefaultGridLayer defaultGridLayer;
 
     @Mock
-    RestrictedMousePanMediator restrictedMousePanMediator;
+    private RestrictedMousePanMediator restrictedMousePanMediator;
 
     @Mock
-    VerticalPanel attributeConfigWidget;
+    private VerticalPanel attributeConfigWidget;
 
     @Mock
-    GuidedDecisionTableAccordion accordion;
+    private GuidedDecisionTableAccordion accordion;
 
     @Mock
-    GuidedDecisionTableModellerView.Presenter presenter;
+    private GuidedDecisionTableModellerView.Presenter presenter;
 
     @Mock
-    GuidedDecisionTableView.Presenter viewPresenter;
+    private GuidedDecisionTableView.Presenter viewPresenter;
 
-    GuidedDecisionTableModellerViewImpl view;
+    @Mock
+    private RootPanel rootPanel;
+
+    private GuidedDecisionTableModellerViewImpl view;
 
     @Before
     public void setup() {
@@ -280,12 +287,28 @@ public class GuidedDecisionTableModellerViewImplTest {
 
         view.addKeyDownHandler(handler);
 
+        verify(rootPanel,
+               never()).addDomHandler(eq(handler),
+                                      eq(KeyDownEvent.getType()));
         verify(mockGridPanel).addKeyDownHandler(eq(handler));
     }
 
     @Test
-    public void testEnableButtonMenu() {
+    public void testAddMouseDownHandlerAttachesToRootPanel() {
+        //Ensure nobody thinks its a good idea to attach to the GridPanel at some time in the future!
+        //See https://issues.jboss.org/browse/GUVNOR-3491
+        final MouseDownHandler handler = mock(MouseDownHandler.class);
 
+        view.addMouseDownHandler(handler);
+
+        verify(mockGridPanel,
+               never()).addMouseDownHandler(eq(handler));
+        verify(rootPanel).addDomHandler(eq(handler),
+                                        eq(MouseDownEvent.getType()));
+    }
+
+    @Test
+    public void testEnableButtonMenu() {
         final Button addColumn = mock(Button.class);
         final Button editColumns = mock(Button.class);
 
@@ -300,7 +323,6 @@ public class GuidedDecisionTableModellerViewImplTest {
 
     @Test
     public void testDisableButtonMenu() {
-
         final Button addColumn = mock(Button.class);
         final Button editColumns = mock(Button.class);
 
@@ -315,7 +337,6 @@ public class GuidedDecisionTableModellerViewImplTest {
 
     @Test
     public void testSelect() {
-
         final GridWidget gridWidget = mock(GridWidget.class);
         final RuleSelector ruleSelector = mock(RuleSelector.class);
         final DefaultGridLayer gridLayer = mock(DefaultGridLayer.class);
@@ -449,6 +470,11 @@ public class GuidedDecisionTableModellerViewImplTest {
 
         RestrictedMousePanMediator restrictedMousePanMediator() {
             return restrictedMousePanMediator;
+        }
+
+        @Override
+        RootPanel rootPanel() {
+            return rootPanel;
         }
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3491

This is the corollary of https://github.com/kiegroup/drools-wb/pull/608 for 7.3.x

(cherry picked from commit 862bb2606f025b66d4a19d90c023ed4e098acbe6)