### PR TITLE
[7.3.x] GUVNOR-3486: [Guided Decision Table Graph] Refresh after removal of table

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -323,7 +323,7 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
             decisionTableSelectedEvent.fire(DecisionTableSelectedEvent.NONE);
         } else {
             final GuidedDecisionTableView.Presenter dtPresenter = availableDecisionTables.iterator().next();
-            activateDocument(dtPresenter);
+            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dtPresenter));
         }
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -57,6 +57,7 @@ import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEdito
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetKeyboardHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.KeyboardOperationEditCell;
@@ -241,9 +242,22 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
                 activeDecisionTable = null;
             }
             dtPresenter.onClose();
+
+            removeLinksForDecisionTable(dtPresenter);
         };
         view.removeDecisionTable(dtPresenter.getView(),
                                  afterRemovalCommand);
+    }
+
+    void removeLinksForDecisionTable(final GuidedDecisionTableView.Presenter dtPresenter) {
+        getAvailableDecisionTables()
+                .stream()
+                .map(other -> other.getView().getModel().getColumns())
+                .forEach(columns -> columns
+                        .stream()
+                        .filter(GridColumn::isLinked)
+                        .filter(column -> dtPresenter.getView().getModel().getColumns().contains(column.getLink()))
+                        .forEach(column -> column.setLink(null)));
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -344,11 +344,11 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         }
         final Command remove = () -> {
             gridLayer.remove(gridWidget);
-            gridLayer.batch();
-
-            disableButtonMenu();
 
             afterRemovalCommand.execute();
+            disableButtonMenu();
+
+            gridLayer.batch();
         };
         if (gridLayer.isGridPinned()) {
             final GridPinnedModeManager.PinnedContext context = gridLayer.getPinnedContext();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -341,8 +341,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                                         parent.getView().asWidget(),
                                         placeRequest,
                                         () -> currentPath.getFileName() + " - " + resourceType.getDescription(),
-                                        () -> {
-                                            /*nothing*/}),
+                                        () -> {/*Nothing*/}),
                          parent);
     }
 
@@ -385,7 +384,6 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             @Override
             public Range deleteCell(int rowIndex,
                                     int columnIndex) {
-
                 Range cellRange = super.deleteCell(rowIndex,
                                                    columnIndex);
                 decisionTableSelectionsChangedEvent.fire(new DecisionTableSelectionsChangedEvent(GuidedDecisionTablePresenter.this));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -364,19 +364,18 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
         presenter.openOtherDecisionTable();
 
-        verify(decisionTableSelectedEvent,
-               times(1)).fire(dtSelectedEventCaptor.capture());
-
-        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
-        assertNotNull(dtSelectedEvent);
-        assertFalse(dtSelectedEvent.getPresenter().isPresent());
-
         verify(presenter,
                never()).activateDocument(any(GuidedDecisionTableView.Presenter.class));
         verify(placeManager,
                never()).forceClosePlace(any(String.class));
         verify(placeManager,
                never()).forceClosePlace(any(PlaceRequest.class));
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull(dtSelectedEvent);
+        assertFalse(dtSelectedEvent.getPresenter().isPresent());
     }
 
     @Test
@@ -394,8 +393,14 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                never()).forceClosePlace(any(String.class));
         verify(placeManager,
                never()).forceClosePlace(any(PlaceRequest.class));
-        verify(presenter,
-               times(1)).activateDocument(remainingDtPresenter);
+        verify(decisionTableSelectedEvent,
+               times(1)).fire(dtSelectedEventCaptor.capture());
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull(dtSelectedEvent);
+        assertTrue(dtSelectedEvent.getPresenter().isPresent());
+        assertEquals(dtSelectedEvent.getPresenter().get(),
+                     remainingDtPresenter);
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -60,7 +60,11 @@ import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.ParameterizedCommand;
@@ -138,15 +142,18 @@ public class GuidedDecisionTableModellerPresenterTest {
 
         when(dtablePresenterProvider.get()).thenReturn(dtablePresenter);
         when(dtablePresenter.getView()).thenReturn(dtableView);
+        when(dtableView.getModel()).thenReturn(new BaseGridData());
     }
 
     private GuidedDecisionTableView.Presenter makeDecisionTable() {
         final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
         final GuidedDecisionTableView dtView = mock(GuidedDecisionTableView.class);
+        final GridData dtData = new BaseGridData();
 
         when(dtPresenter.getView()).thenReturn(dtView);
         when(dtPresenter.getAccess()).thenReturn(mock(GuidedDecisionTablePresenter.Access.class));
         when(dtPresenter.getModel()).thenReturn(mock(GuidedDecisionTable52.class));
+        when(dtView.getModel()).thenReturn(dtData);
 
         return dtPresenter;
     }
@@ -162,6 +169,13 @@ public class GuidedDecisionTableModellerPresenterTest {
                                                                                                 overview,
                                                                                                 dmoBaseline);
         return dtContent;
+    }
+
+    @SuppressWarnings("unchecked")
+    private GridColumn makeUiColumn() {
+        return spy(new BaseGridColumn(mock(GridColumn.HeaderMetaData.class),
+                                      mock(GridColumnRenderer.class),
+                                      100.0));
     }
 
     @Test
@@ -287,6 +301,8 @@ public class GuidedDecisionTableModellerPresenterTest {
                times(1)).refreshColumnsNote(eq(false));
         verify(dtPresenter,
                times(1)).onClose();
+        verify(presenter,
+               times(1)).removeLinksForDecisionTable(eq(dtPresenter));
     }
 
     @Test
@@ -761,5 +777,53 @@ public class GuidedDecisionTableModellerPresenterTest {
                times(1)).link(eq(availableDecisionTables));
         verify(gridLayer,
                times(1)).refreshGridWidgetConnectors();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRemoveLinksPreservesOtherTables() {
+        final GuidedDecisionTableView.Presenter dtPresenter1 = makeDecisionTable();
+        final GuidedDecisionTableView.Presenter dtPresenter2 = makeDecisionTable();
+        final Set<GuidedDecisionTableView.Presenter> availableDecisionTables = new HashSet<GuidedDecisionTableView.Presenter>() {{
+            add(dtPresenter2);
+        }};
+
+        final GridColumn dtPresenter1Column1 = makeUiColumn();
+        final GridColumn dtPresenter1Column2 = makeUiColumn();
+        final GridColumn dtPresenter2Column1 = makeUiColumn();
+        final GridColumn dtPresenter2Column2 = makeUiColumn();
+        dtPresenter1.getView().getModel().appendColumn(dtPresenter1Column1);
+        dtPresenter1.getView().getModel().appendColumn(dtPresenter1Column2);
+        dtPresenter2.getView().getModel().appendColumn(dtPresenter2Column1);
+        dtPresenter2.getView().getModel().appendColumn(dtPresenter2Column2);
+
+        dtPresenter1Column2.setLink(dtPresenter2Column2);
+        dtPresenter2Column1.setLink(dtPresenter1Column1);
+
+        when(presenter.getAvailableDecisionTables()).thenReturn(availableDecisionTables);
+
+        //Check setup
+        verify(dtPresenter1Column2,
+               times(1)).setLink(eq(dtPresenter2Column2));
+        verify(dtPresenter2Column1,
+               times(1)).setLink(eq(dtPresenter1Column1));
+
+        reset(dtPresenter1Column1,
+              dtPresenter1Column2,
+              dtPresenter2Column1,
+              dtPresenter2Column2);
+
+        //Check links after removal
+        presenter.removeLinksForDecisionTable(dtPresenter1);
+
+        verify(dtPresenter1Column1,
+               never()).setLink(any());
+        verify(dtPresenter1Column2,
+               never()).setLink(any());
+
+        verify(dtPresenter2Column1,
+               times(1)).setLink(eq(null));
+        verify(dtPresenter2Column2,
+               never()).setLink(any());
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
@@ -29,6 +29,7 @@ import com.google.gwt.event.dom.client.MouseDownEvent;
 import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.dom.client.ScrollHandler;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.ui.AbsolutePanel;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -51,10 +52,12 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.ruleselector.RuleSelector;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
@@ -90,7 +93,13 @@ public class GuidedDecisionTableModellerViewImplTest {
     private GuidedDecisionTableModellerView.Presenter presenter;
 
     @Mock
-    private GuidedDecisionTableView.Presenter viewPresenter;
+    private GuidedDecisionTableView.Presenter dtablePresenter;
+
+    @Mock
+    private GuidedDecisionTableView dtableView;
+
+    @Captor
+    private ArgumentCaptor<Command> commandArgumentCaptor;
 
     @Mock
     private RootPanel rootPanel;
@@ -446,6 +455,48 @@ public class GuidedDecisionTableModellerViewImplTest {
                times(2)).setTransform(transform);
         verify(viewport).batch();
         verify(mockGridPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testRemoveDecisionTableWhenPinned() {
+        final Command callback = mock(Command.class);
+        final GridPinnedModeManager.PinnedContext context = mock(GridPinnedModeManager.PinnedContext.class);
+
+        when(defaultGridLayer.isGridPinned()).thenReturn(true);
+        when(defaultGridLayer.getPinnedContext()).thenReturn(context);
+        when(context.getGridWidget()).thenReturn(dtableView);
+
+        view.removeDecisionTable(dtableView,
+                                 callback);
+
+        verify(defaultGridLayer,
+               times(1)).exitPinnedMode(commandArgumentCaptor.capture());
+
+        final Command command = commandArgumentCaptor.getValue();
+        assertNotNull(command);
+        command.execute();
+
+        verify(defaultGridLayer,
+               times(1)).remove(dtableView);
+        verify(callback,
+               times(1)).execute();
+        verify(view,
+               times(1)).disableButtonMenu();
+        verify(defaultGridLayer,
+               times(1)).batch();
+    }
+
+    @Test
+    public void testRemoveDecisionTableWhenNotPinned() {
+        final Command callback = mock(Command.class);
+
+        view.removeDecisionTable(dtableView,
+                                 callback);
+
+        verify(callback,
+               times(1)).execute();
+        verify(view,
+               times(1)).disableButtonMenu();
     }
 
     private AttributeCol52 attributeColumn() {


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3486

This is the corollary of https://github.com/kiegroup/drools-wb/pull/604 for 7.3.x

(cherry picked from commit ef437d5ca1ccccc02cc17df377d235a37dda1c4b)