### PR TITLE
[7.3.x] GUVNOR-3479 : [GSS-RFE] Add support for missing keywords like "not matches" condition in Guided Rule

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
@@ -221,7 +221,7 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "soundslike", "== null", "!= null", "in", "not in"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null", "in", "not in"});
     }
 
     @Test
@@ -233,7 +233,7 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "soundslike", "== null", "!= null"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null"});
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/GUVNOR-3479

(cherry picked from commit bee14c31269815023e20a29b4edd65649afe5aa6)


https://github.com/kiegroup/drools/pull/1480
https://github.com/kiegroup/kie-wb-common/pull/1173
https://github.com/kiegroup/drools-wb/pull/626