### PR TITLE
PLANNER-826: Guided Rule Editor doesn't have reserved scoreHolder variable

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasRuleModellerPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasRuleModellerPage.java
@@ -22,12 +22,15 @@ import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 
 public interface HasRuleModellerPage {
 
     RuleModel getRuleModel();
 
     Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins();
+
+    Collection<PatternBindingValidator> getPatternBindingValidators();
 
     RuleModellerConfiguration getRuleModellerConfiguration();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPage.java
@@ -32,6 +32,7 @@ import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerWidgetFactory;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.drools.workbench.screens.guided.template.client.editor.TemplateModellerWidgetFactory;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
@@ -91,6 +92,7 @@ public class RuleModellerPage<T extends HasRuleModellerPage & DecisionTableColum
     private RuleModeller newRuleModeller() {
         final RuleModeller ruleModeller = new RuleModeller(ruleModel(),
                                                            actionPlugins(),
+                                                           patternBindingValidators(),
                                                            oracle(),
                                                            widgetFactory(),
                                                            configuration(),
@@ -120,6 +122,10 @@ public class RuleModellerPage<T extends HasRuleModellerPage & DecisionTableColum
 
     private Collection<RuleModellerActionPlugin> actionPlugins() {
         return plugin().getRuleModellerActionPlugins();
+    }
+
+    private Collection<PatternBindingValidator> patternBindingValidators() {
+        return plugin().getPatternBindingValidators();
     }
 
     RuleModellerConfiguration configuration() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
@@ -53,6 +54,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.c
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
@@ -65,6 +67,8 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
     private RuleModellerPage ruleModellerPage;
 
     private Collection<RuleModellerActionPlugin> actionPlugins = new ArrayList<>();
+
+    private Collection<PatternBindingValidator> patternBindingValidators = new ArrayList<>();
 
     private AdditionalInfoPage<BRLActionColumnPlugin> additionalInfoPage;
 
@@ -79,6 +83,7 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
     @Inject
     public BRLActionColumnPlugin(final RuleModellerPage ruleModellerPage,
                                  final Instance<RuleModellerActionPlugin> actionPluginInstance,
+                                 final Instance<PatternBindingValidator> patternBindingValidatorInstance,
                                  final AdditionalInfoPage<BRLActionColumnPlugin> additionalInfoPage,
                                  final Event<WizardPageStatusChangeEvent> changeEvent,
                                  final TranslationService translationService) {
@@ -87,6 +92,8 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
 
         this.ruleModellerPage = ruleModellerPage;
         actionPluginInstance.iterator().forEachRemaining(actionPlugins::add);
+        patternBindingValidatorInstance.iterator().forEachRemaining(patternBindingValidators::add);
+
         this.additionalInfoPage = additionalInfoPage;
     }
 
@@ -272,6 +279,11 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
     @Override
     public Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins() {
         return actionPlugins;
+    }
+
+    @Override
+    public Collection<PatternBindingValidator> getPatternBindingValidators() {
+        return patternBindingValidators;
     }
 
     private RuleModel newRuleModel() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
@@ -27,8 +27,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -59,11 +61,12 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.c
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 
-import static org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat.*;
+import static org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat.LIMITED_ENTRY;
 
 @Dependent
 public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin implements HasRuleModellerPage,
@@ -82,16 +85,20 @@ public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin impl
 
     private RuleModel ruleModel = null;
 
+    private Collection<PatternBindingValidator> patternBindingValidators = new ArrayList<>();
+
     @Inject
     public BRLConditionColumnPlugin(final RuleModellerPage ruleModellerPage,
                                     final AdditionalInfoPage additionalInfoPage,
                                     final Event<WizardPageStatusChangeEvent> changeEvent,
-                                    final TranslationService translationService) {
+                                    final TranslationService translationService,
+                                    final Instance<PatternBindingValidator> patternBindingValidatorInstance) {
         super(changeEvent,
               translationService);
 
         this.ruleModellerPage = ruleModellerPage;
         this.additionalInfoPage = additionalInfoPage;
+        patternBindingValidatorInstance.iterator().forEachRemaining(patternBindingValidators::add);
     }
 
     @Override
@@ -272,6 +279,11 @@ public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin impl
     @Override
     public Collection<RuleModellerActionPlugin> getRuleModellerActionPlugins() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<PatternBindingValidator> getPatternBindingValidators() {
+        return patternBindingValidators;
     }
 
     private RuleModel newRuleModel() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
@@ -276,6 +276,7 @@ public class PluginHandlerTest {
 
         final BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
                                                                            new MockInstanceImpl<>(new ArrayList<>()),
+                                                                           new MockInstanceImpl<>(new ArrayList<>()),
                                                                            additionalInfoPage,
                                                                            event,
                                                                            translationService));
@@ -289,6 +290,7 @@ public class PluginHandlerTest {
         final BRLActionColumn originalColumn = mock(BRLActionColumn.class);
 
         final BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
+                                                                           new MockInstanceImpl<>(new ArrayList<>()),
                                                                            new MockInstanceImpl<>(new ArrayList<>()),
                                                                            additionalInfoPage,
                                                                            event,
@@ -344,7 +346,8 @@ public class PluginHandlerTest {
         final BRLConditionColumnPlugin plugin = spy(new BRLConditionColumnPlugin(ruleModellerPage,
                                                                                  additionalInfoPage,
                                                                                  event,
-                                                                                 translationService));
+                                                                                 translationService,
+                                                                                 new MockInstanceImpl<>(new ArrayList<>())));
 
         doReturn(wizard).when(wizardManagedInstance).get();
         doReturn(plugin).when(brlConditionColumnPlugin).get();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPluginTest.java
@@ -81,6 +81,7 @@ public class BRLActionColumnPluginTest {
     @InjectMocks
     private BRLActionColumnPlugin plugin = spy(new BRLActionColumnPlugin(ruleModellerPage,
                                                                          new MockInstanceImpl<>(new ArrayList<>()),
+                                                                         new MockInstanceImpl<>(new ArrayList<>()),
                                                                          additionalInfoPage,
                                                                          changeEvent,
                                                                          translationService));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPluginTest.java
@@ -33,6 +33,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLCon
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.popovers.MockInstanceImpl;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.RuleModellerPage;
@@ -84,7 +85,8 @@ public class BRLConditionColumnPluginTest {
     private BRLConditionColumnPlugin plugin = spy(new BRLConditionColumnPlugin(ruleModellerPage,
                                                                                additionalInfoPage,
                                                                                changeEvent,
-                                                                               translationService));
+                                                                               translationService,
+                                                                               new MockInstanceImpl<>(new ArrayList<>())));
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.client.editor.validator.GuidedRuleEditorValidator;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
 import org.drools.workbench.screens.guided.rule.client.type.GuidedRuleDRLResourceType;
 import org.drools.workbench.screens.guided.rule.client.type.GuidedRuleDSLRResourceType;
@@ -99,6 +100,9 @@ public class GuidedRuleEditorPresenter
     @Inject
     private ManagedInstance<RuleModellerActionPlugin> actionPluginInstance;
 
+    @Inject
+    private ManagedInstance<PatternBindingValidator> patternBindingValidatorInstance;
+
     private boolean isDSLEnabled;
 
     private RuleModel model;
@@ -160,11 +164,14 @@ public class GuidedRuleEditorPresenter
                 addImportsTab(importsWidget);
 
                 List<RuleModellerActionPlugin> actionPlugins = new ArrayList<>();
-
                 actionPluginInstance.forEach(actionPlugins::add);
+
+                List<PatternBindingValidator> patternBindingValidators = new ArrayList<>();
+                patternBindingValidatorInstance.forEach(patternBindingValidators::add);
 
                 view.setContent(model,
                                 actionPlugins,
+                                patternBindingValidators,
                                 oracle,
                                 ruleNamesService,
                                 isReadOnly,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorView.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorView.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.jboss.errai.common.client.api.Caller;
 import org.kie.workbench.common.services.shared.rulename.RuleNamesService;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
@@ -33,6 +34,7 @@ public interface GuidedRuleEditorView
 
     void setContent(final RuleModel model,
                     final Collection<RuleModellerActionPlugin> actionPlugins,
+                    final Collection<PatternBindingValidator> patternBindingValidators,
                     final AsyncPackageDataModelOracle dataModel,
                     final Caller<RuleNamesService> ruleNamesService,
                     final boolean isReadOnly,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorViewImpl.java
@@ -24,6 +24,7 @@ import com.google.gwt.event.shared.SimpleEventBus;
 import com.google.gwt.user.client.ui.SimplePanel;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.workbench.common.services.shared.rulename.RuleNamesService;
@@ -48,12 +49,14 @@ public class GuidedRuleEditorViewImpl
     @Override
     public void setContent(final RuleModel model,
                            final Collection<RuleModellerActionPlugin> actionPlugins,
+                           final Collection<PatternBindingValidator> patternBindingValidators,
                            final AsyncPackageDataModelOracle oracle,
                            final Caller<RuleNamesService> ruleNamesService,
                            final boolean isReadOnly,
                            final boolean isDSLEnabled) {
         this.modeller = new RuleModeller(model,
                                          actionPlugins,
+                                         patternBindingValidators,
                                          oracle,
                                          new RuleModellerWidgetFactory(actionPlugins),
                                          localBus,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
@@ -43,6 +43,7 @@ import org.drools.workbench.models.datamodel.rule.RuleMetadata;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
 import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
 import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
 import org.drools.workbench.screens.guided.rule.client.widget.FactTypeKnownValueChangeEvent;
@@ -68,6 +69,7 @@ public class RuleModeller extends Composite
     private FlexTable layout;
     private RuleModel model;
     private Collection<RuleModellerActionPlugin> actionPlugins;
+    private Collection<PatternBindingValidator> patternBindingValidators;
     private AsyncPackageDataModelOracle oracle;
     private RuleModellerConfiguration configuration;
     private Map<String, Object> serviceInvocationCache = new HashMap<>();
@@ -95,6 +97,7 @@ public class RuleModeller extends Composite
     //used by Guided Rule (DRL + DSLR)
     public RuleModeller(final RuleModel model,
                         final Collection<RuleModellerActionPlugin> actionPlugins,
+                        final Collection<PatternBindingValidator> patternBindingValidators,
                         final AsyncPackageDataModelOracle oracle,
                         final ModellerWidgetFactory widgetFactory,
                         final EventBus eventBus,
@@ -102,6 +105,7 @@ public class RuleModeller extends Composite
                         final boolean isDSLEnabled) {
         this(model,
              actionPlugins,
+             patternBindingValidators,
              oracle,
              widgetFactory,
              RuleModellerConfiguration.getDefault(),
@@ -118,6 +122,7 @@ public class RuleModeller extends Composite
                         final boolean isReadOnly) {
         this(model,
              Collections.emptyList(),
+             Collections.emptyList(),
              oracle,
              widgetFactory,
              eventBus,
@@ -128,6 +133,7 @@ public class RuleModeller extends Composite
     //used by Guided Decision BRL Fragments
     public RuleModeller(final RuleModel model,
                         final Collection<RuleModellerActionPlugin> actionPlugins,
+                        final Collection<PatternBindingValidator> patternBindingValidators,
                         final AsyncPackageDataModelOracle oracle,
                         final ModellerWidgetFactory widgetFactory,
                         final RuleModellerConfiguration configuration,
@@ -135,6 +141,7 @@ public class RuleModeller extends Composite
                         final boolean isReadOnly) {
         this.model = model;
         this.actionPlugins = actionPlugins;
+        this.patternBindingValidators = patternBindingValidators;
         this.oracle = oracle;
         this.widgetFactory = widgetFactory;
         this.configuration = configuration;
@@ -791,6 +798,10 @@ public class RuleModeller extends Composite
 
     public Collection<RuleModellerActionPlugin> getActionPlugins() {
         return actionPlugins;
+    }
+
+    public Collection<PatternBindingValidator> getPatternBindingValidators() {
+        return patternBindingValidators;
     }
 
     /**

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/factPattern/PopupCreator.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/factPattern/PopupCreator.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.guided.rule.client.editor.factPattern;
 
+import java.util.stream.Collectors;
+
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
@@ -33,15 +35,17 @@ import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.HasConstraints;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.SingleFieldConstraintEBLeftSide;
-import org.kie.workbench.common.widgets.client.widget.BindingTextBox;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidatorUtils;
 import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
 import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.resources.i18n.HumanReadableConstants;
+import org.kie.workbench.common.widgets.client.widget.BindingTextBox;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.widgets.common.client.common.InfoPopup;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
@@ -64,7 +68,7 @@ public class PopupCreator {
     /**
      * @param pattern the pattern to set
      */
-    public void setPattern( FactPattern pattern ) {
+    public void setPattern(FactPattern pattern) {
         this.pattern = pattern;
     }
 
@@ -78,7 +82,7 @@ public class PopupCreator {
     /**
      * @param oracle the oracle to set
      */
-    public void setDataModelOracle( AsyncPackageDataModelOracle oracle ) {
+    public void setDataModelOracle(AsyncPackageDataModelOracle oracle) {
         this.oracle = oracle;
     }
 
@@ -92,7 +96,7 @@ public class PopupCreator {
     /**
      * @param modeller the modeller to set
      */
-    public void setModeller( RuleModeller modeller ) {
+    public void setModeller(RuleModeller modeller) {
         this.modeller = modeller;
     }
 
@@ -106,71 +110,77 @@ public class PopupCreator {
     /**
      * @param bindable the bindable to set
      */
-    public void setBindable( boolean bindable ) {
+    public void setBindable(boolean bindable) {
         this.bindable = bindable;
     }
 
     /**
      * Display a little editor for field bindings.
      */
-    public void showBindFieldPopup( final FactPattern fp,
-                                    final SingleFieldConstraint con,
-                                    final ModelField[] fields,
-                                    final PopupCreator popupCreator ) {
-        final FormStylePopup popup = new FormStylePopup( GuidedRuleEditorResources.CONSTANTS.AddAField() );
+    public void showBindFieldPopup(final FactPattern fp,
+                                   final SingleFieldConstraint con,
+                                   final ModelField[] fields,
+                                   final PopupCreator popupCreator) {
+        final FormStylePopup popup = new FormStylePopup(GuidedRuleEditorResources.CONSTANTS.AddAField());
 //        popup.setWidth( 500 + "px" );
 //        popup.setHeight( 100 + "px" );
         final HorizontalPanel vn = new HorizontalPanel();
         final TextBox varName = new BindingTextBox();
-        if ( con.getFieldBinding() != null ) {
-            varName.setText( con.getFieldBinding() );
+        if (con.getFieldBinding() != null) {
+            varName.setText(con.getFieldBinding());
         }
-        final Button ok = new Button( HumanReadableConstants.INSTANCE.Set() );
-        vn.add( varName );
-        vn.add( ok );
+        final Button ok = new Button(HumanReadableConstants.INSTANCE.Set());
+        vn.add(varName);
+        vn.add(ok);
 
-        ok.addClickHandler( new ClickHandler() {
-            public void onClick( ClickEvent event ) {
+        ok.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
                 String var = varName.getText();
-                if ( modeller.isVariableNameUsed( var ) ) {
-                    Window.alert( GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken( var ) );
+                if (modeller.isVariableNameUsed(var)) {
+                    Window.alert(GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken(var));
                     return;
                 }
-                con.setFieldBinding( var );
+                String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getModeller().getPatternBindingValidators(),
+                                                                                                         var);
+                if (!validationTextToDisplay.isEmpty()) {
+                    Window.alert(validationTextToDisplay);
+                    return;
+                }
+                con.setFieldBinding(var);
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.BindTheFieldCalled0ToAVariable( con.getFieldName() ),
-                            vn );
+        });
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.BindTheFieldCalled0ToAVariable(con.getFieldName()),
+                           vn);
 
         //Show the sub-field selector is there are applicable sub-fields
-        if ( hasApplicableFields( fields ) ) {
-            Button sub = new Button( GuidedRuleEditorResources.CONSTANTS.ShowSubFields() );
-            popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.ApplyAConstraintToASubFieldOf0( con.getFieldName() ),
-                                sub );
-            sub.addClickHandler( new ClickHandler() {
-                public void onClick( ClickEvent event ) {
+        if (hasApplicableFields(fields)) {
+            Button sub = new Button(GuidedRuleEditorResources.CONSTANTS.ShowSubFields());
+            popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.ApplyAConstraintToASubFieldOf0(con.getFieldName()),
+                               sub);
+            sub.addClickHandler(new ClickHandler() {
+                public void onClick(ClickEvent event) {
                     popup.hide();
-                    popupCreator.showPatternPopup( fp,
-                                                   con,
-                                                   true );
+                    popupCreator.showPatternPopup(fp,
+                                                  con,
+                                                  true);
                 }
-            } );
+            });
         }
 
         popup.show();
     }
 
     //Check if there are any fields other than "this"
-    private boolean hasApplicableFields( final ModelField[] fields ) {
-        if ( fields == null || fields.length == 0 ) {
+    private boolean hasApplicableFields(final ModelField[] fields) {
+        if (fields == null || fields.length == 0) {
             return false;
         }
-        if ( fields.length > 1 ) {
+        if (fields.length > 1) {
             return true;
         }
-        if ( DataType.TYPE_THIS.equals( fields[ 0 ].getName() ) ) {
+        if (DataType.TYPE_THIS.equals(fields[0].getName())) {
             return false;
         }
         return true;
@@ -179,234 +189,233 @@ public class PopupCreator {
     /**
      * This shows a popup for adding fields to a composite
      */
-    public void showPatternPopupForComposite( final HasConstraints hasConstraints ) {
-        final FormStylePopup popup = new FormStylePopup( GuidedRuleEditorImages508.INSTANCE.Wizard(),
-                                                         GuidedRuleEditorResources.CONSTANTS.AddFieldsToThisConstraint() );
+    public void showPatternPopupForComposite(final HasConstraints hasConstraints) {
+        final FormStylePopup popup = new FormStylePopup(GuidedRuleEditorImages508.INSTANCE.Wizard(),
+                                                        GuidedRuleEditorResources.CONSTANTS.AddFieldsToThisConstraint());
 
         final ListBox box = new ListBox();
-        box.addItem( "..." );
-        this.oracle.getFieldCompletions( this.pattern.getFactType(),
-                                         new Callback<ModelField[]>() {
+        box.addItem("...");
+        this.oracle.getFieldCompletions(this.pattern.getFactType(),
+                                        new Callback<ModelField[]>() {
 
-                                             @Override
-                                             public void callback( final ModelField[] fields ) {
-                                                 for ( int i = 0; i < fields.length; i++ ) {
-                                                     final String fieldName = fields[ i ].getName();
-                                                     box.addItem( fieldName );
-                                                 }
-                                             }
-                                         } );
+                                            @Override
+                                            public void callback(final ModelField[] fields) {
+                                                for (int i = 0; i < fields.length; i++) {
+                                                    final String fieldName = fields[i].getName();
+                                                    box.addItem(fieldName);
+                                                }
+                                            }
+                                        });
 
-        box.setSelectedIndex( 0 );
+        box.setSelectedIndex(0);
 
-        box.addChangeHandler( new ChangeHandler() {
-            public void onChange( ChangeEvent event ) {
+        box.addChangeHandler(new ChangeHandler() {
+            public void onChange(ChangeEvent event) {
                 String factType = pattern.getFactType();
-                String fieldName = box.getItemText( box.getSelectedIndex() );
-                String fieldType = getDataModelOracle().getFieldType( factType,
-                                                                      fieldName );
-                hasConstraints.addConstraint( new SingleFieldConstraint( factType,
-                                                                         fieldName,
-                                                                         fieldType,
-                                                                         null ) );
+                String fieldName = box.getItemText(box.getSelectedIndex());
+                String fieldType = getDataModelOracle().getFieldType(factType,
+                                                                     fieldName);
+                hasConstraints.addConstraint(new SingleFieldConstraint(factType,
+                                                                       fieldName,
+                                                                       fieldType,
+                                                                       null));
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.AddARestrictionOnAField(),
-                            box );
+        });
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.AddARestrictionOnAField(),
+                           box);
 
         final ListBox composites = new ListBox();
-        composites.addItem( "..." ); //NON-NLS
-        composites.addItem( GuidedRuleEditorResources.CONSTANTS.AllOfAnd(),
-                            CompositeFieldConstraint.COMPOSITE_TYPE_AND );
-        composites.addItem( GuidedRuleEditorResources.CONSTANTS.AnyOfOr(),
-                            CompositeFieldConstraint.COMPOSITE_TYPE_OR );
-        composites.setSelectedIndex( 0 );
+        composites.addItem("..."); //NON-NLS
+        composites.addItem(GuidedRuleEditorResources.CONSTANTS.AllOfAnd(),
+                           CompositeFieldConstraint.COMPOSITE_TYPE_AND);
+        composites.addItem(GuidedRuleEditorResources.CONSTANTS.AnyOfOr(),
+                           CompositeFieldConstraint.COMPOSITE_TYPE_OR);
+        composites.setSelectedIndex(0);
 
-        composites.addChangeHandler( new ChangeHandler() {
-            public void onChange( ChangeEvent event ) {
+        composites.addChangeHandler(new ChangeHandler() {
+            public void onChange(ChangeEvent event) {
                 CompositeFieldConstraint comp = new CompositeFieldConstraint();
-                comp.setCompositeJunctionType( composites.getValue( composites.getSelectedIndex() ) );
-                hasConstraints.addConstraint( comp );
+                comp.setCompositeJunctionType(composites.getValue(composites.getSelectedIndex()));
+                hasConstraints.addConstraint(comp);
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
+        });
 
-        InfoPopup infoComp = new InfoPopup( GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraints(),
-                                            GuidedRuleEditorResources.CONSTANTS.MultipleConstraintsTip() );
+        InfoPopup infoComp = new InfoPopup(GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraints(),
+                                           GuidedRuleEditorResources.CONSTANTS.MultipleConstraintsTip());
 
         HorizontalPanel horiz = new HorizontalPanel();
-        horiz.add( composites );
-        horiz.add( infoComp );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraint(),
-                            horiz );
+        horiz.add(composites);
+        horiz.add(infoComp);
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraint(),
+                           horiz);
 
         //Include Expression Editor
-        popup.addRow( new SmallLabel( "<i>" + GuidedRuleEditorResources.CONSTANTS.AdvancedOptionsColon() + "</i>" ) );
+        popup.addRow(new SmallLabel("<i>" + GuidedRuleEditorResources.CONSTANTS.AdvancedOptionsColon() + "</i>"));
 
-        Button predicate = new Button( GuidedRuleEditorResources.CONSTANTS.NewFormula() );
-        predicate.addClickHandler( new ClickHandler() {
-            public void onClick( ClickEvent event ) {
+        Button predicate = new Button(GuidedRuleEditorResources.CONSTANTS.NewFormula());
+        predicate.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
                 SingleFieldConstraint con = new SingleFieldConstraint();
-                con.setConstraintValueType( SingleFieldConstraint.TYPE_PREDICATE );
-                hasConstraints.addConstraint( con );
+                con.setConstraintValueType(SingleFieldConstraint.TYPE_PREDICATE);
+                hasConstraints.addConstraint(con);
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.AddANewFormulaStyleExpression(),
-                            predicate );
+        });
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.AddANewFormulaStyleExpression(),
+                           predicate);
 
-        Button ebBtn = new Button( GuidedRuleEditorResources.CONSTANTS.ExpressionEditor() );
+        Button ebBtn = new Button(GuidedRuleEditorResources.CONSTANTS.ExpressionEditor());
 
-        ebBtn.addClickHandler( new ClickHandler() {
-            public void onClick( ClickEvent event ) {
+        ebBtn.addClickHandler(new ClickHandler() {
+            public void onClick(ClickEvent event) {
                 SingleFieldConstraintEBLeftSide con = new SingleFieldConstraintEBLeftSide();
-                con.setConstraintValueType( SingleFieldConstraint.TYPE_UNDEFINED );
-                con.setExpressionLeftSide( new ExpressionFormLine( new ExpressionUnboundFact( pattern.getFactType() ) ) );
-                hasConstraints.addConstraint( con );
+                con.setConstraintValueType(SingleFieldConstraint.TYPE_UNDEFINED);
+                con.setExpressionLeftSide(new ExpressionFormLine(new ExpressionUnboundFact(pattern.getFactType())));
+                hasConstraints.addConstraint(con);
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.ExpressionEditor(),
-                            ebBtn );
+        });
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.ExpressionEditor(),
+                           ebBtn);
 
         popup.show();
-
     }
 
     /**
      * This shows a popup allowing you to add field constraints to a pattern
      * (its a popup).
      */
-    public void showPatternPopup( final FactPattern fp,
-                                  final SingleFieldConstraint con,
-                                  final boolean isNested ) {
+    public void showPatternPopup(final FactPattern fp,
+                                 final SingleFieldConstraint con,
+                                 final boolean isNested) {
 
-        final String factType = getFactType( fp,
-                                             con );
+        final String factType = getFactType(fp,
+                                            con);
 
-        String title = ( con == null ) ? GuidedRuleEditorResources.CONSTANTS.ModifyConstraintsFor0( fp.getFactType() ) : GuidedRuleEditorResources.CONSTANTS.AddSubFieldConstraint();
-        final FormStylePopup popup = new FormStylePopup( GuidedRuleEditorImages508.INSTANCE.Wizard(),
-                                                         title );
+        String title = (con == null) ? GuidedRuleEditorResources.CONSTANTS.ModifyConstraintsFor0(fp.getFactType()) : GuidedRuleEditorResources.CONSTANTS.AddSubFieldConstraint();
+        final FormStylePopup popup = new FormStylePopup(GuidedRuleEditorImages508.INSTANCE.Wizard(),
+                                                        title);
 
         final ListBox box = new ListBox();
-        box.addItem( "..." );
-        this.oracle.getFieldCompletions( factType,
-                                         FieldAccessorsAndMutators.ACCESSOR,
-                                         new Callback<ModelField[]>() {
-                                             @Override
-                                             public void callback( final ModelField[] fields ) {
-                                                 for ( int i = 0; i < fields.length; i++ ) {
-                                                     //You can't use "this" in a nested accessor
-                                                     final String fieldName = fields[ i ].getName();
-                                                     if ( !isNested || !fieldName.equals( DataType.TYPE_THIS ) ) {
-                                                         box.addItem( fieldName );
-                                                     }
-                                                 }
-                                             }
-                                         } );
+        box.addItem("...");
+        this.oracle.getFieldCompletions(factType,
+                                        FieldAccessorsAndMutators.ACCESSOR,
+                                        new Callback<ModelField[]>() {
+                                            @Override
+                                            public void callback(final ModelField[] fields) {
+                                                for (int i = 0; i < fields.length; i++) {
+                                                    //You can't use "this" in a nested accessor
+                                                    final String fieldName = fields[i].getName();
+                                                    if (!isNested || !fieldName.equals(DataType.TYPE_THIS)) {
+                                                        box.addItem(fieldName);
+                                                    }
+                                                }
+                                            }
+                                        });
 
-        box.setSelectedIndex( 0 );
+        box.setSelectedIndex(0);
 
-        box.addChangeHandler( new ChangeHandler() {
-            public void onChange( ChangeEvent event ) {
-                String fieldName = box.getItemText( box.getSelectedIndex() );
-                if ( "...".equals( fieldName ) ) {
+        box.addChangeHandler(new ChangeHandler() {
+            public void onChange(ChangeEvent event) {
+                String fieldName = box.getItemText(box.getSelectedIndex());
+                if ("...".equals(fieldName)) {
                     return;
                 }
-                String fieldType = oracle.getFieldType( factType,
-                                                        fieldName );
-                fp.addConstraint( new SingleFieldConstraint( factType,
-                                                             fieldName,
-                                                             fieldType,
-                                                             con ) );
+                String fieldType = oracle.getFieldType(factType,
+                                                       fieldName);
+                fp.addConstraint(new SingleFieldConstraint(factType,
+                                                           fieldName,
+                                                           fieldType,
+                                                           con));
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
-        popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.AddARestrictionOnAField(),
-                            box );
+        });
+        popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.AddARestrictionOnAField(),
+                           box);
 
         final ListBox composites = new ListBox();
-        composites.addItem( "..." );
-        composites.addItem( GuidedRuleEditorResources.CONSTANTS.AllOfAnd(),
-                            CompositeFieldConstraint.COMPOSITE_TYPE_AND );
-        composites.addItem( GuidedRuleEditorResources.CONSTANTS.AnyOfOr(),
-                            CompositeFieldConstraint.COMPOSITE_TYPE_OR );
-        composites.setSelectedIndex( 0 );
+        composites.addItem("...");
+        composites.addItem(GuidedRuleEditorResources.CONSTANTS.AllOfAnd(),
+                           CompositeFieldConstraint.COMPOSITE_TYPE_AND);
+        composites.addItem(GuidedRuleEditorResources.CONSTANTS.AnyOfOr(),
+                           CompositeFieldConstraint.COMPOSITE_TYPE_OR);
+        composites.setSelectedIndex(0);
 
-        composites.addChangeHandler( new ChangeHandler() {
-            public void onChange( ChangeEvent event ) {
+        composites.addChangeHandler(new ChangeHandler() {
+            public void onChange(ChangeEvent event) {
                 CompositeFieldConstraint comp = new CompositeFieldConstraint();
-                comp.setCompositeJunctionType( composites.getValue( composites.getSelectedIndex() ) );
-                fp.addConstraint( comp );
+                comp.setCompositeJunctionType(composites.getValue(composites.getSelectedIndex()));
+                fp.addConstraint(comp);
                 modeller.refreshWidget();
                 popup.hide();
             }
-        } );
+        });
 
-        InfoPopup infoComp = new InfoPopup( GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraints(),
-                                            GuidedRuleEditorResources.CONSTANTS.MultipleConstraintsTip1() );
+        InfoPopup infoComp = new InfoPopup(GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraints(),
+                                           GuidedRuleEditorResources.CONSTANTS.MultipleConstraintsTip1());
 
         HorizontalPanel horiz = new HorizontalPanel();
 
-        horiz.add( composites );
-        horiz.add( infoComp );
-        if ( con == null ) {
-            popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraint(),
-                                horiz );
+        horiz.add(composites);
+        horiz.add(infoComp);
+        if (con == null) {
+            popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.MultipleFieldConstraint(),
+                               horiz);
         }
 
-        if ( con == null ) {
-            popup.addRow( new SmallLabel( "<i>" + GuidedRuleEditorResources.CONSTANTS.AdvancedOptionsColon() + "</i>" ) ); //NON-NLS
-            Button predicate = new Button( GuidedRuleEditorResources.CONSTANTS.NewFormula() );
-            predicate.addClickHandler( new ClickHandler() {
-                public void onClick( ClickEvent event ) {
+        if (con == null) {
+            popup.addRow(new SmallLabel("<i>" + GuidedRuleEditorResources.CONSTANTS.AdvancedOptionsColon() + "</i>")); //NON-NLS
+            Button predicate = new Button(GuidedRuleEditorResources.CONSTANTS.NewFormula());
+            predicate.addClickHandler(new ClickHandler() {
+                public void onClick(ClickEvent event) {
                     SingleFieldConstraint con = new SingleFieldConstraint();
-                    con.setConstraintValueType( SingleFieldConstraint.TYPE_PREDICATE );
-                    fp.addConstraint( con );
+                    con.setConstraintValueType(SingleFieldConstraint.TYPE_PREDICATE);
+                    fp.addConstraint(con);
                     modeller.refreshWidget();
                     popup.hide();
                 }
-            } );
-            popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.AddANewFormulaStyleExpression(),
-                                predicate );
+            });
+            popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.AddANewFormulaStyleExpression(),
+                               predicate);
 
-            Button ebBtn = new Button( GuidedRuleEditorResources.CONSTANTS.ExpressionEditor() );
+            Button ebBtn = new Button(GuidedRuleEditorResources.CONSTANTS.ExpressionEditor());
 
-            ebBtn.addClickHandler( new ClickHandler() {
-                public void onClick( ClickEvent event ) {
+            ebBtn.addClickHandler(new ClickHandler() {
+                public void onClick(ClickEvent event) {
                     SingleFieldConstraintEBLeftSide con = new SingleFieldConstraintEBLeftSide();
-                    con.setConstraintValueType( SingleFieldConstraint.TYPE_UNDEFINED );
-                    fp.addConstraint( con );
-                    con.setExpressionLeftSide( new ExpressionFormLine( new ExpressionUnboundFact( pattern.getFactType() ) ) );
+                    con.setConstraintValueType(SingleFieldConstraint.TYPE_UNDEFINED);
+                    fp.addConstraint(con);
+                    con.setExpressionLeftSide(new ExpressionFormLine(new ExpressionUnboundFact(pattern.getFactType())));
                     modeller.refreshWidget();
                     popup.hide();
                 }
-            } );
-            popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.ExpressionEditor(),
-                                ebBtn );
+            });
+            popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.ExpressionEditor(),
+                               ebBtn);
 
-            doBindingEditor( popup );
+            doBindingEditor(popup);
         }
 
         popup.show();
     }
 
-    private String getFactType( FactPattern fp,
-                                SingleFieldConstraint sfc ) {
+    private String getFactType(FactPattern fp,
+                               SingleFieldConstraint sfc) {
         String factType;
-        if ( sfc == null ) {
+        if (sfc == null) {
             factType = fp.getFactType();
         } else {
             factType = sfc.getFieldType();
             //If field name is "this" use parent FactPattern type otherwise we can use the Constraint's field type
             String fieldName = sfc.getFieldName();
-            if ( DataType.TYPE_THIS.equals( fieldName ) ) {
+            if (DataType.TYPE_THIS.equals(fieldName)) {
                 factType = fp.getFactType();
             }
         }
@@ -418,37 +427,43 @@ public class PopupCreator {
      * name. If its a bindable pattern, it will show the editor, if it is
      * already bound, and the name is used, it should not be editable.
      */
-    private void doBindingEditor( final FormStylePopup popup ) {
-        if ( bindable || !( modeller.getModel().isBoundFactUsed( pattern.getBoundName() ) ) ) {
+    private void doBindingEditor(final FormStylePopup popup) {
+        if (bindable || !(modeller.getModel().isBoundFactUsed(pattern.getBoundName()))) {
             HorizontalPanel varName = new HorizontalPanel();
             final TextBox varTxt = new BindingTextBox();
-            if ( pattern.getBoundName() == null ) {
-                varTxt.setText( "" );
+            if (pattern.getBoundName() == null) {
+                varTxt.setText("");
             } else {
-                varTxt.setText( pattern.getBoundName() );
+                varTxt.setText(pattern.getBoundName());
             }
 
-            ( (InputElement) varTxt.getElement().cast() ).setSize( 6 );
-            varName.add( varTxt );
+            ((InputElement) varTxt.getElement().cast()).setSize(6);
+            varName.add(varTxt);
 
-            Button bindVar = new Button( HumanReadableConstants.INSTANCE.Set() );
-            bindVar.addClickHandler( new ClickHandler() {
-                public void onClick( ClickEvent event ) {
+            Button bindVar = new Button(HumanReadableConstants.INSTANCE.Set());
+            bindVar.addClickHandler(new ClickHandler() {
+                public void onClick(ClickEvent event) {
                     String var = varTxt.getText();
-                    if ( modeller.isVariableNameUsed( var ) ) {
-                        Window.alert( GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken( var ) );
+                    if (modeller.isVariableNameUsed(var)) {
+                        Window.alert(GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken(var));
                         return;
                     }
-                    pattern.setBoundName( varTxt.getText() );
+                    String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getModeller().getPatternBindingValidators(),
+                                                                                                             var);
+                    if (!validationTextToDisplay.isEmpty()) {
+                        Window.alert(validationTextToDisplay);
+                        return;
+                    }
+
+                    pattern.setBoundName(varTxt.getText());
                     modeller.refreshWidget();
                     popup.hide();
                 }
-            } );
+            });
 
-            varName.add( bindVar );
-            popup.addAttribute( GuidedRuleEditorResources.CONSTANTS.VariableName(),
-                                varName );
-
+            varName.add(bindVar);
+            popup.addAttribute(GuidedRuleEditorResources.CONSTANTS.VariableName(),
+                               varName);
         }
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/validator/PatternBindingValidator.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/validator/PatternBindingValidator.java
@@ -1,0 +1,10 @@
+package org.drools.workbench.screens.guided.rule.client.editor.validator;
+
+import java.util.Collection;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+
+public interface PatternBindingValidator {
+
+    Collection<ValidationMessage> validate(final String variableName);
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/validator/PatternBindingValidatorUtils.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/validator/PatternBindingValidatorUtils.java
@@ -1,0 +1,22 @@
+package org.drools.workbench.screens.guided.rule.client.editor.validator;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+
+public final class PatternBindingValidatorUtils {
+
+    private PatternBindingValidatorUtils() {
+    }
+
+    public static String getValidationTextToDisplay(final Collection<PatternBindingValidator> validators,
+                                                    final String variableName) {
+        return validators
+                .stream()
+                .flatMap(v -> v.validate(variableName).stream())
+                .map(ValidationMessage::getText)
+                .collect(Collectors.joining("\n"));
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/ActionInsertFactWidget.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/ActionInsertFactWidget.java
@@ -44,6 +44,7 @@ import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.screens.guided.rule.client.editor.ActionValueEditor;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
 import org.drools.workbench.screens.guided.rule.client.editor.events.TemplateVariablesChangedEvent;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidatorUtils;
 import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
 import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
 import org.drools.workbench.screens.guided.rule.client.util.ModelFieldUtil;
@@ -275,6 +276,12 @@ public class ActionInsertFactWidget extends RuleModellerWidget {
                 String var = varName.getText();
                 if (getModeller().isVariableNameUsed(var) && ((model.getBoundName() != null && model.getBoundName().equals(var) == false) || model.getBoundName() == null)) {
                     Window.alert(GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken(var));
+                    return;
+                }
+                String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getModeller().getPatternBindingValidators(),
+                                                                                                         var);
+                if (!validationTextToDisplay.isEmpty()) {
+                    Window.alert(validationTextToDisplay);
                     return;
                 }
                 model.setBoundName(var);

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/ExpressionBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/ExpressionBuilder.java
@@ -55,6 +55,7 @@ import org.drools.workbench.screens.guided.rule.client.editor.ExpressionTypeChan
 import org.drools.workbench.screens.guided.rule.client.editor.HasExpressionChangeHandlers;
 import org.drools.workbench.screens.guided.rule.client.editor.HasExpressionTypeChangeHandlers;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidatorUtils;
 import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.InputGroup;
@@ -497,6 +498,12 @@ public class ExpressionBuilder extends RuleModellerWidget
                             String var = varName.getText();
                             if ( getModeller().isVariableNameUsed( var ) ) {
                                 Window.alert( GuidedRuleEditorResources.CONSTANTS.TheVariableName0IsAlreadyTaken( var ) );
+                                return;
+                            }
+                            String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getModeller().getPatternBindingValidators(),
+                                                                                                                     var);
+                            if (!validationTextToDisplay.isEmpty()) {
+                                Window.alert(validationTextToDisplay);
                                 return;
                             }
                             expression.setBinding( var );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/validator/PatternBindingValidatorUtilsTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/validator/PatternBindingValidatorUtilsTest.java
@@ -1,0 +1,40 @@
+package org.drools.workbench.screens.guided.rule.client.validator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidator;
+import org.drools.workbench.screens.guided.rule.client.editor.validator.PatternBindingValidatorUtils;
+import org.guvnor.common.services.shared.message.Level;
+import org.guvnor.common.services.shared.validation.model.ValidationMessage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PatternBindingValidatorUtilsTest {
+
+    @Test
+    public void getValidationTextToDisplayMatchingVariable() {
+        String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getPatternBindingValidators(),
+                                                                                                 "variable");
+        assertEquals("validator\nvalidator", validationTextToDisplay);
+    }
+
+    @Test
+    public void getValidationTextToDisplayNonMatchingVariable() {
+        String validationTextToDisplay = PatternBindingValidatorUtils.getValidationTextToDisplay(getPatternBindingValidators(),
+                                                                                                 "nonMatchingVariable");
+        assertEquals("", validationTextToDisplay);
+    }
+
+    private Collection<PatternBindingValidator> getPatternBindingValidators() {
+        PatternBindingValidator validator = variableName -> {
+            if ("variable".equals(variableName)) {
+                return Arrays.asList(new ValidationMessage(Level.WARNING, "validator"));
+            }
+            return Collections.emptyList();
+        };
+        return Arrays.asList(validator, validator);
+    }
+}


### PR DESCRIPTION
@manstis This simply displays a warning message when user tries to use 'scoreHolder' (or other) reserved variable name in GRE/GDT. Individual domains (e.g. planner) need to provide PatternBindingValidator implementations. Would you mind taking a look? Thanks in advance.