### PR TITLE
[7.4.x] GUVNOR-3547: [Guided Decision Table] Patterns from BRL conditions are not available for another action columns

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -762,18 +763,13 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
 
     @Override
     public boolean canConditionBeDeleted(final ConditionCol52 col) {
-        Pattern52 pattern = model.getPattern(col);
-        if (pattern.getChildColumns().size() > 1) {
-            return true;
+        if (col instanceof BRLConditionColumn) {
+            return doCanConditionBeDeleted((BRLConditionColumn) col);
         }
-        if (isBindingUsed(pattern.getBoundName())) {
-            return false;
-        }
-        return true;
+        return doCanConditionBeDeleted(col);
     }
 
-    @Override
-    public boolean canConditionBeDeleted(final BRLConditionColumn col) {
+    private boolean doCanConditionBeDeleted(final BRLConditionColumn col) {
         for (IPattern p : col.getDefinition()) {
             if (p instanceof FactPattern) {
                 FactPattern fp = (FactPattern) p;
@@ -783,6 +779,17 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                     }
                 }
             }
+        }
+        return true;
+    }
+
+    private boolean doCanConditionBeDeleted(final ConditionCol52 col) {
+        Pattern52 pattern = model.getPattern(col);
+        if (pattern.getChildColumns().size() > 1) {
+            return true;
+        }
+        if (isBindingUsed(pattern.getBoundName())) {
+            return false;
         }
         return true;
     }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
@@ -127,8 +127,6 @@ public interface GuidedDecisionTableView extends GridWidget,
 
         boolean canConditionBeDeleted(final ConditionCol52 col);
 
-        boolean canConditionBeDeleted(final BRLConditionColumn col);
-
         Map<String, String> getValueListLookups(final BaseColumn column);
 
         void getEnumLookups(final String factType,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasPatternPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/commons/HasPatternPage.java
@@ -16,7 +16,7 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.commons;
 
-import java.util.List;
+import java.util.Set;
 
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.PatternWrapper;
 
@@ -30,5 +30,5 @@ public interface HasPatternPage {
 
     String getEntryPointName();
 
-    List<PatternWrapper> getPatterns();
+    Set<PatternWrapper> getPatterns();
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPage.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPage.java
@@ -17,11 +17,11 @@
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -80,7 +80,7 @@ public class PatternPage<T extends HasPatternPage & DecisionTableColumnPlugin> e
     @Override
     public void isComplete(final Callback<Boolean> callback) {
         boolean isPatternSet = isPatternSet();
-        if(!isPatternSet) {
+        if (!isPatternSet) {
             view.showPatternWarning();
         } else {
             view.hidePatternWarning();
@@ -185,8 +185,8 @@ public class PatternPage<T extends HasPatternPage & DecisionTableColumnPlugin> e
         return currentPattern().key();
     }
 
-    List<PatternWrapper> getPatterns() {
-        final List<PatternWrapper> patterns = plugin().getPatterns();
+    Set<PatternWrapper> getPatterns() {
+        final Set<PatternWrapper> patterns = plugin().getPatterns();
 
         if (isPatternSet()) {
             patterns.add(currentPattern());
@@ -199,7 +199,7 @@ public class PatternPage<T extends HasPatternPage & DecisionTableColumnPlugin> e
         return patterns
                 .stream()
                 .filter(pattern -> !pattern.isNegated())
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     private PatternWrapper currentPattern() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPlugin.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -31,6 +32,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.guided.dtable.shared.model.BRLRuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
@@ -260,14 +262,19 @@ public class ConditionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
     }
 
     @Override
-    public List<PatternWrapper> getPatterns() {
+    public Set<PatternWrapper> getPatterns() {
         final Set<PatternWrapper> patterns = new HashSet<>();
+        final BRLRuleModel brlRuleModel = new BRLRuleModel(presenter.getModel());
+        final List<String> variables = brlRuleModel.getLHSPatternVariables();
+        variables.forEach(var -> {
+            final String factType = brlRuleModel.getLHSBoundFact(var).getFactType();
+            final boolean isNegated = brlRuleModel.getLHSBoundFact(var).isNegated();
+            patterns.add(new PatternWrapper(factType,
+                                            var,
+                                            isNegated));
+        });
 
-        for (Pattern52 pattern52 : model().getPatterns()) {
-            patterns.add(new PatternWrapper(pattern52));
-        }
-
-        return new ArrayList<>(patterns);
+        return patterns;
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/PatternWrapper.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/PatternWrapper.java
@@ -16,8 +16,6 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons;
 
-import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
 
 import static org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils.nil;
@@ -34,35 +32,30 @@ public class PatternWrapper {
 
     private String entryPointName = "";
 
-    public PatternWrapper(final Pattern52 pattern52) {
-        this(pattern52.getFactType(),
-             pattern52.getBoundName(),
-             pattern52.isNegated());
-    }
-
-    public PatternWrapper(final ActionInsertFactCol52 actionCol52) {
-        this(actionCol52.getFactType(),
-             actionCol52.getBoundName(),
+    public PatternWrapper(final String factType,
+                          final String boundName) {
+        this(factType,
+             boundName,
              null);
     }
 
     public PatternWrapper(final String factType,
                           final String boundName,
                           final Boolean negated) {
-        this.factType = factType;
-        this.boundName = boundName;
-        this.negated = negated;
+        this(factType,
+             boundName,
+             null,
+             negated);
     }
 
     public PatternWrapper(final String factType,
                           final String boundName,
                           final String entryPointName,
                           final Boolean negated) {
-        this(factType,
-             boundName,
-             negated);
-
+        this.factType = factType;
+        this.boundName = boundName;
         this.entryPointName = entryPointName;
+        this.negated = negated;
     }
 
     public PatternWrapper() {
@@ -126,5 +119,41 @@ public class PatternWrapper {
 
     public String getBoundName() {
         return boundName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PatternWrapper that = (PatternWrapper) o;
+
+        if (!boundName.equals(that.boundName)) {
+            return false;
+        }
+        if (!factType.equals(that.factType)) {
+            return false;
+        }
+        if (negated != null ? !negated.equals(that.negated) : that.negated != null) {
+            return false;
+        }
+        return entryPointName != null ? entryPointName.equals(that.entryPointName) : that.entryPointName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = boundName.hashCode();
+        result = ~~result;
+        result = 31 * result + factType.hashCode();
+        result = ~~result;
+        result = 31 * result + (negated != null ? negated.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (entryPointName != null ? entryPointName.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPageTest.java
@@ -17,7 +17,9 @@
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.gwt.junit.GWTMockUtilities;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -40,8 +42,14 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class PatternPageTest {
@@ -201,7 +209,7 @@ public class PatternPageTest {
     public void testGetPatternsWhenCurrentPatternIsNull() {
         when(plugin.getPatterns()).thenReturn(fakePatterns());
 
-        final List<PatternWrapper> patterns = page.getPatterns();
+        final Set<PatternWrapper> patterns = page.getPatterns();
 
         assertEquals(2,
                      patterns.size());
@@ -214,7 +222,7 @@ public class PatternPageTest {
                                                             "boundName3",
                                                             true));
 
-        final List<PatternWrapper> patterns = page.getPatterns();
+        final Set<PatternWrapper> patterns = page.getPatterns();
 
         assertEquals(3,
                      patterns.size());
@@ -226,7 +234,7 @@ public class PatternPageTest {
 
         when(plugin.getPatterns()).thenReturn(fakePatterns());
 
-        final List<PatternWrapper> patterns = page.getPatterns();
+        final Set<PatternWrapper> patterns = page.getPatterns();
 
         assertEquals(1,
                      patterns.size());
@@ -340,7 +348,7 @@ public class PatternPageTest {
         final PatternWrapper pattern2 = newPattern("factType2",
                                                    "boundName2",
                                                    false);
-        final List<PatternWrapper> patterns = new ArrayList<PatternWrapper>() {{
+        final Set<PatternWrapper> patterns = new HashSet<PatternWrapper>() {{
             add(pattern1);
             add(pattern2);
         }};
@@ -369,7 +377,7 @@ public class PatternPageTest {
         final PatternWrapper pattern2 = newPattern("factType2",
                                                    "boundName2",
                                                    false);
-        final List<PatternWrapper> patterns = new ArrayList<PatternWrapper>() {{
+        final Set<PatternWrapper> patterns = new HashSet<PatternWrapper>() {{
             add(pattern1);
             add(pattern2);
         }};
@@ -390,8 +398,8 @@ public class PatternPageTest {
         verify(view).disablePatternCreation();
     }
 
-    private List<PatternWrapper> fakePatterns() {
-        return new ArrayList<PatternWrapper>() {{
+    private Set<PatternWrapper> fakePatterns() {
+        return new HashSet<PatternWrapper>() {{
             add(newPattern("factType1",
                            "boundName1",
                            false));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPluginTest.java
@@ -20,11 +20,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.workitems.PortableFloatParameterDefinition;
@@ -36,7 +37,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCo
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetFieldCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.BRLRuleModel;
+import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -61,15 +62,25 @@ import org.mockito.Mock;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-@WithClassesToStub(BRLRuleModel.class)
 public class ActionWorkItemSetFieldPluginTest {
 
     @Mock
-    PatternWrapper patternWrapper;
+    private PatternWrapper patternWrapper;
 
     @Mock
     private BiConsumer<String, String> biConsumer;
@@ -323,10 +334,15 @@ public class ActionWorkItemSetFieldPluginTest {
 
         doReturn(true).when(plugin).isNewColumn();
 
-        final List<PatternWrapper> patterns = plugin.getPatterns();
+        final Set<PatternWrapper> patterns = plugin.getPatterns();
 
-        assertEquals(3,
+        assertEquals(2,
                      patterns.size());
+        assertTrue(patterns.contains(new PatternWrapper("factType",
+                                                        "boundName",
+                                                        true)));
+        assertTrue(patterns.contains(new PatternWrapper("factType",
+                                                        "boundName")));
     }
 
     @Test
@@ -336,10 +352,12 @@ public class ActionWorkItemSetFieldPluginTest {
         doReturn(false).when(plugin).isNewColumn();
         doReturn(true).when(plugin).isNewFactPattern();
 
-        final List<PatternWrapper> patterns = plugin.getPatterns();
+        final Set<PatternWrapper> patterns = plugin.getPatterns();
 
-        assertEquals(2,
+        assertEquals(1,
                      patterns.size());
+        assertTrue(patterns.contains(new PatternWrapper("factType",
+                                                        "boundName")));
     }
 
     @Test
@@ -349,7 +367,7 @@ public class ActionWorkItemSetFieldPluginTest {
         doReturn(false).when(plugin).isNewColumn();
         doReturn(false).when(plugin).isNewFactPattern();
 
-        final List<PatternWrapper> patterns = plugin.getPatterns();
+        final Set<PatternWrapper> patterns = plugin.getPatterns();
 
         assertEquals(1,
                      patterns.size());
@@ -545,7 +563,7 @@ public class ActionWorkItemSetFieldPluginTest {
     @Test
     public void testNewPatternWrapperWhenPatternIsFound() throws Exception {
         final PatternWrapper expectedWrapper = mockPatternWrapper("BoundName");
-        final ArrayList<PatternWrapper> actionWrappers = new ArrayList<PatternWrapper>() {{
+        final Set<PatternWrapper> actionWrappers = new HashSet<PatternWrapper>() {{
             add(expectedWrapper);
         }};
 
@@ -560,7 +578,7 @@ public class ActionWorkItemSetFieldPluginTest {
 
     @Test
     public void testNewPatternWrapperWhenPatternIsNotFound() throws Exception {
-        final ArrayList<PatternWrapper> actionWrappers = new ArrayList<>();
+        final Set<PatternWrapper> actionWrappers = new HashSet<>();
         final ActionWorkItemWrapper actionWrapper = mockActionWrapper("BoundName",
                                                                       "FactType");
 
@@ -632,6 +650,26 @@ public class ActionWorkItemSetFieldPluginTest {
         verify(editingWrapper).setHideColumn(hideColumn);
     }
 
+    @Test
+    public void testIsNewFactPatternWhenIsNew() throws Exception {
+        mockPatterns();
+
+        plugin.setEditingPattern(new PatternWrapper("factType",
+                                                    "bananna"));
+
+        assertTrue(plugin.isNewFactPattern());
+    }
+
+    @Test
+    public void testIsNewFactPatternWhenIsExisting() throws Exception {
+        mockPatterns();
+
+        plugin.setEditingPattern(new PatternWrapper("factType",
+                                                    "boundName"));
+
+        assertFalse(plugin.isNewFactPattern());
+    }
+
     private ActionWorkItemWrapper mockActionWrapper(final String boundName,
                                                     final String factType) {
         final ActionWorkItemWrapper wrapper = mock(ActionWorkItemWrapper.class);
@@ -689,13 +727,29 @@ public class ActionWorkItemSetFieldPluginTest {
     }
 
     private void mockPatterns() {
-        when(model.getPatterns()).thenReturn(new ArrayList<Pattern52>() {{
-            add(new Pattern52());
-        }});
-        when(model.getActionCols()).thenReturn(new ArrayList<ActionCol52>() {{
-            add(new ActionWorkItemInsertFactCol52());
-            add(new ActionWorkItemInsertFactCol52());
-        }});
+        final GuidedDecisionTable52 model = mock(GuidedDecisionTable52.class);
+        final List<CompositeColumn<?>> patterns = Collections.singletonList(fakePattern());
+        final List<ActionCol52> actions = Arrays.asList(fakeActionCol(),
+                                                        fakeActionCol());
+
+        when(model.getConditions()).thenReturn(patterns);
+        when(model.getActionCols()).thenReturn(actions);
+
         when(presenter.getModel()).thenReturn(model);
+    }
+
+    private Pattern52 fakePattern() {
+        return new Pattern52() {{
+            setFactType("factType");
+            setBoundName("boundName");
+            setNegated(true);
+        }};
+    }
+
+    private ActionInsertFactCol52 fakeActionCol() {
+        return new ActionWorkItemInsertFactCol52() {{
+            setFactType("factType");
+            setBoundName("boundName");
+        }};
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPluginTest.java
@@ -16,12 +16,17 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -48,8 +53,20 @@ import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ConditionColumnPluginTest {
@@ -697,6 +714,32 @@ public class ConditionColumnPluginTest {
         plugin.setHideColumn(hideColumn);
 
         verify(editingCol).setHideColumn(hideColumn);
+    }
+
+    @Test
+    public void testGetPatterns() throws Exception {
+        final Pattern52 pattern = new Pattern52() {{
+            setFactType("FactType");
+            setBoundName("$fact");
+        }};
+        final BRLConditionColumn brlColumn = new BRLConditionColumn();
+        brlColumn.setDefinition(Collections.singletonList(new FactPattern("AnotherFact") {{
+            setBoundName("$another");
+        }}));
+
+        doReturn(Arrays.asList(pattern,
+                               brlColumn)).when(model).getConditions();
+
+        final Set<PatternWrapper> patterns = plugin.getPatterns();
+
+        assertEquals(2,
+                     patterns.size());
+        assertTrue(patterns.contains(new PatternWrapper("FactType",
+                                                        "$fact",
+                                                        false)));
+        assertTrue(patterns.contains(new PatternWrapper("AnotherFact",
+                                                        "$another",
+                                                        false)));
     }
 
     private ConditionCol52 makeConditionCol52(final int constraintValueType,


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3547

Corollary of https://github.com/kiegroup/drools-wb/pull/648 for 7.4.x

(Product https://issues.jboss.org/browse/RHBRMS-2905 is approved blocker for 7.0.0.LA)

(cherry picked from commit 34d410814fa67f5a644ce468dac8710c7e14f11b)