### PR TITLE
[7.4.x] GUVNOR-3556: [Guided Decision Table] Default Value hint stays shown after wizard is finished or cancelled

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
@@ -31,7 +32,7 @@ import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDe
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
-import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.common.client.menu.MenuItemFactory;
@@ -65,6 +66,7 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
     private Clipboard clipboard;
     private TranslationService ts;
     private MenuItemFactory menuItemFactory;
+    private DecisionTablePopoverUtils popoverUtils;
 
     MenuItemViewHolder<MenuItemWithIconView> miCut;
     MenuItemViewHolder<MenuItemWithIconView> miCopy;
@@ -77,10 +79,12 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
     @Inject
     public EditMenuBuilder(final Clipboard clipboard,
                            final TranslationService ts,
-                           final MenuItemFactory menuItemFactory) {
+                           final MenuItemFactory menuItemFactory,
+                           final DecisionTablePopoverUtils popoverUtils) {
         this.clipboard = clipboard;
         this.ts = ts;
         this.menuItemFactory = menuItemFactory;
+        this.popoverUtils = popoverUtils;
     }
 
     @PostConstruct
@@ -106,8 +110,8 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
     private void setupOtherwisePopover() {
         miOtherwiseCell.getMenuItemView().getElement().setAttribute("data-toggle",
                                                                     "popover");
-        DecisionTableColumnViewUtils.setupPopover(miOtherwiseCell.getMenuItemView().getElement(),
-                                                  ts.getTranslation(GuidedDecisionTableErraiConstants.EditMenu_otherwiseDescription));
+        popoverUtils.setupPopover(miOtherwiseCell.getMenuItemView().getElement(),
+                                  ts.getTranslation(GuidedDecisionTableErraiConstants.EditMenu_otherwiseDescription));
     }
 
     @Override
@@ -212,8 +216,8 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
         miDeleteSelectedColumns.getMenuItem().setEnabled(false);
         miDeleteSelectedRows.getMenuItem().setEnabled(false);
         miOtherwiseCell.getMenuItem().setEnabled(false);
-        DecisionTableColumnViewUtils.enableOtherwisePopover(miOtherwiseCell.getMenuItemView().getElement(),
-                                                            false);
+        popoverUtils.enableOtherwisePopover(miOtherwiseCell.getMenuItemView().getElement(),
+                                            false);
     }
 
     private void enableMenuItems(final List<GridData.SelectedCell> selections) {
@@ -228,8 +232,8 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
         miDeleteSelectedColumns.getMenuItem().setEnabled(isColumnDeletable);
         miDeleteSelectedRows.getMenuItem().setEnabled(enabled);
         miOtherwiseCell.getMenuItem().setEnabled(isOtherwiseEnabled);
-        DecisionTableColumnViewUtils.enableOtherwisePopover(miOtherwiseCell.getMenuItemView().getElement(),
-                                                            isOtherwiseEnabled);
+        popoverUtils.enableOtherwisePopover(miOtherwiseCell.getMenuItemView().getElement(),
+                                            isOtherwiseEnabled);
     }
 
     private boolean isColumnDeletable(final List<GridData.SelectedCell> selections) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizard.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizard.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -28,6 +29,7 @@ import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDe
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.SummaryPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.BaseDecisionTableColumnPage;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.DecisionTableColumnPlugin;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.client.callbacks.Callback;
@@ -52,6 +54,8 @@ public class NewGuidedDecisionTableColumnWizard extends AbstractWizard {
 
     private GuidedDecisionTableView.Presenter presenter;
 
+    private DecisionTablePopoverUtils popoverUtils;
+
     private Command onCloseCallback = () -> {
     };
 
@@ -60,10 +64,12 @@ public class NewGuidedDecisionTableColumnWizard extends AbstractWizard {
     @Inject
     public NewGuidedDecisionTableColumnWizard(final WizardView view,
                                               final SummaryPage summaryPage,
-                                              final TranslationService translationService) {
+                                              final TranslationService translationService,
+                                              final DecisionTablePopoverUtils popoverUtils) {
         this.view = view;
         this.summaryPage = summaryPage;
         this.translationService = translationService;
+        this.popoverUtils = popoverUtils;
     }
 
     @Override
@@ -187,6 +193,8 @@ public class NewGuidedDecisionTableColumnWizard extends AbstractWizard {
 
     @Override
     public void close() {
+        popoverUtils.destroyPopovers();
+
         onCloseCallback.execute();
 
         super.close();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/AdditionalInfoPageView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/AdditionalInfoPageView.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
-import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Input;
@@ -83,13 +83,17 @@ public class AdditionalInfoPageView implements IsElement,
 
     private TranslationService translationService;
 
+    private DecisionTablePopoverUtils popoverUtils;
+
     public AdditionalInfoPageView() {
         //CDI proxy
     }
 
     @Inject
-    public AdditionalInfoPageView(final TranslationService translationService) {
+    public AdditionalInfoPageView(final TranslationService translationService,
+                                  final DecisionTablePopoverUtils popoverUtils) {
         this.translationService = translationService;
+        this.popoverUtils = popoverUtils;
     }
 
     @PostConstruct
@@ -107,12 +111,12 @@ public class AdditionalInfoPageView implements IsElement,
         updateEngineWithChanges.setAttribute("data-toggle",
                                              "popover");
 
-        DecisionTableColumnViewUtils.setupPopover(hideColumn,
-                                                  translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_HideColumnDescription));
-        DecisionTableColumnViewUtils.setupPopover(logicallyInsert,
-                                                  translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_LogicalInsertDescription));
-        DecisionTableColumnViewUtils.setupPopover(updateEngineWithChanges,
-                                                  translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_UpdateEngineDescription));
+        popoverUtils.setupAndRegisterPopover(hideColumn,
+                                             translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_HideColumnDescription));
+        popoverUtils.setupAndRegisterPopover(logicallyInsert,
+                                             translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_LogicalInsertDescription));
+        popoverUtils.setupAndRegisterPopover(updateEngineWithChanges,
+                                             translate(GuidedDecisionTableErraiConstants.AdditionalInfoPage_UpdateEngineDescription));
     }
 
     @EventHandler("header")

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPageView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/PatternPageView.java
@@ -28,7 +28,7 @@ import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasPatternPage;
-import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -63,23 +63,27 @@ public class PatternPageView implements IsElement,
 
     private TranslationService translationService;
 
+    private DecisionTablePopoverUtils popoverUtils;
+
     @Inject
     public PatternPageView(final ListBox patternList,
                            final TextBox entryPointName,
                            final Button createANewFactPattern,
                            final Div entryPointContainer,
-                           final TranslationService translationService) {
+                           final TranslationService translationService,
+                           final DecisionTablePopoverUtils popoverUtils) {
         this.patternList = patternList;
         this.entryPointName = entryPointName;
         this.createANewFactPattern = createANewFactPattern;
         this.entryPointContainer = entryPointContainer;
         this.translationService = translationService;
+        this.popoverUtils = popoverUtils;
     }
 
     @PostConstruct
     public void initPopovers() {
-        DecisionTableColumnViewUtils.setupPopover(entryPointName.getElement(),
-                                                  translate(GuidedDecisionTableErraiConstants.PatternPageView_EntryPointDescription));
+        popoverUtils.setupAndRegisterPopover(entryPointName.getElement(),
+                                             translate(GuidedDecisionTableErraiConstants.PatternPageView_EntryPointDescription));
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/ValueOptionsPageView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/ValueOptionsPageView.java
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
-import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.api.IsElement;
@@ -73,6 +73,8 @@ public class ValueOptionsPageView implements IsElement,
 
     private TranslationService translationService;
 
+    private DecisionTablePopoverUtils popoverUtils;
+
     @Inject
     public ValueOptionsPageView(final Div valueListGroupContainer,
                                 final Div cepWindowOperatorsGroupContainer,
@@ -84,7 +86,8 @@ public class ValueOptionsPageView implements IsElement,
                                 final Div defaultValueContainer,
                                 final Div limitedValueContainer,
                                 final Div bindingContainer,
-                                final TranslationService translationService) {
+                                final TranslationService translationService,
+                                final DecisionTablePopoverUtils popoverUtils) {
         this.valueListGroupContainer = valueListGroupContainer;
         this.cepWindowOperatorsGroupContainer = cepWindowOperatorsGroupContainer;
         this.defaultValueGroupContainer = defaultValueGroupContainer;
@@ -96,16 +99,17 @@ public class ValueOptionsPageView implements IsElement,
         this.limitedValueContainer = limitedValueContainer;
         this.bindingContainer = bindingContainer;
         this.translationService = translationService;
+        this.popoverUtils = popoverUtils;
     }
 
     @PostConstruct
     public void initPopovers() {
-        DecisionTableColumnViewUtils.setupPopover(cepWindowOperatorsContainer,
-                                                  translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_CEPWindowDescription));
-        DecisionTableColumnViewUtils.setupPopover(defaultValueContainer,
-                                                  translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_DefaultValueDescription));
-        DecisionTableColumnViewUtils.setupPopover(bindingContainer,
-                                                  translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_BindingDescription));
+        popoverUtils.setupAndRegisterPopover(cepWindowOperatorsContainer,
+                                             translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_CEPWindowDescription));
+        popoverUtils.setupAndRegisterPopover(defaultValueContainer,
+                                             translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_DefaultValueDescription));
+        popoverUtils.setupAndRegisterPopover(bindingContainer,
+                                             translate(GuidedDecisionTableErraiConstants.ValueOptionsPage_BindingDescription));
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTableColumnViewUtils.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTableColumnViewUtils.java
@@ -19,7 +19,6 @@ package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.co
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.ListBox;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
@@ -33,7 +32,6 @@ import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.common.client.dom.HTMLElement;
 
 public class DecisionTableColumnViewUtils {
 
@@ -122,61 +120,4 @@ public class DecisionTableColumnViewUtils {
     private static void clean(final Div container) {
         DOMUtil.removeAllChildren(container);
     }
-
-    public static void setupPopover(final Element e,
-                                    final String content) {
-        doSetupPopover(e,
-                       content);
-    }
-
-    private static native void doSetupPopover(final Element e,
-                                              final String content) /*-{
-        $wnd.jQuery(e).popover({
-            container: 'body',
-            placement: 'bottom',
-            content: content,
-            html: true,
-            trigger: 'hover'
-        }).on("show.bs.popover",
-                function () {
-                    $wnd.jQuery(e).data("bs.popover").tip().css("max-width", "600px");
-                });
-    }-*/;
-
-    public static void setupPopover(final HTMLElement e,
-                                    final String content) {
-        doSetupPopover(e,
-                       content);
-    }
-
-    private static native void doSetupPopover(final HTMLElement e,
-                                              final String content) /*-{
-        $wnd.jQuery(e).popover({
-            container: 'body',
-            placement: 'bottom',
-            content: content,
-            html: true,
-            trigger: 'hover'
-        }).on("show.bs.popover",
-                function () {
-                    $wnd.jQuery(e).data("bs.popover").tip().css("max-width", "600px");
-                });
-    }-*/;
-
-    public static void enableOtherwisePopover(final HTMLElement e,
-                                              final boolean enabled) {
-        if (enabled) {
-            doEnablePopover(e);
-        } else {
-            doDisablePopover(e);
-        }
-    }
-
-    private static native void doEnablePopover(final HTMLElement e) /*-{
-        $wnd.jQuery(e).popover('enable');
-    }-*/;
-
-    private static native void doDisablePopover(final HTMLElement e) /*-{
-        $wnd.jQuery(e).popover('disable');
-    }-*/;
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTablePopoverUtils.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTablePopoverUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import com.google.gwt.dom.client.Element;
+import org.jboss.errai.common.client.dom.HTMLElement;
+
+@ApplicationScoped
+public class DecisionTablePopoverUtils {
+
+    private final List<Element> popoverElementRegistrations = new ArrayList<>();
+    private final List<HTMLElement> popoverHTMLElementRegistrations = new ArrayList<>();
+
+    public void setupPopover(final Element e,
+                             final String content) {
+        doSetupPopover(e,
+                       content);
+    }
+
+    public void setupAndRegisterPopover(final Element e,
+                                        final String content) {
+        setupPopover(e,
+                     content);
+        popoverElementRegistrations.add(e);
+    }
+
+    private native void doSetupPopover(final Element e,
+                                       final String content) /*-{
+        $wnd.jQuery(e).popover({
+            container: 'body',
+            placement: 'bottom',
+            content: content,
+            html: true,
+            trigger: 'hover'
+        }).on("show.bs.popover",
+                function () {
+                    $wnd.jQuery(e).data("bs.popover").tip().css("max-width", "600px");
+                });
+    }-*/;
+
+    public void setupPopover(final HTMLElement e,
+                             final String content) {
+        doSetupPopover(e,
+                       content);
+    }
+
+    public void setupAndRegisterPopover(final HTMLElement e,
+                                        final String content) {
+        setupPopover(e,
+                     content);
+        popoverHTMLElementRegistrations.add(e);
+    }
+
+    private native void doSetupPopover(final HTMLElement e,
+                                       final String content) /*-{
+        $wnd.jQuery(e).popover({
+            container: 'body',
+            placement: 'bottom',
+            content: content,
+            html: true,
+            trigger: 'hover'
+        }).on("show.bs.popover",
+                function () {
+                    $wnd.jQuery(e).data("bs.popover").tip().css("max-width", "600px");
+                });
+    }-*/;
+
+    public void enableOtherwisePopover(final HTMLElement e,
+                                       final boolean enabled) {
+        if (enabled) {
+            doEnablePopover(e);
+        } else {
+            doDisablePopover(e);
+        }
+    }
+
+    private native void doEnablePopover(final HTMLElement e) /*-{
+        $wnd.jQuery(e).popover('enable');
+    }-*/;
+
+    private native void doDisablePopover(final HTMLElement e) /*-{
+        $wnd.jQuery(e).popover('disable');
+    }-*/;
+
+    public void destroyPopovers() {
+        popoverElementRegistrations.forEach(DecisionTablePopoverUtils::doDestroyPopover);
+        popoverHTMLElementRegistrations.forEach(DecisionTablePopoverUtils::doDestroyPopover);
+        popoverElementRegistrations.clear();
+        popoverHTMLElementRegistrations.clear();
+    }
+
+    private static native void doDestroyPopover(final Element e) /*-{
+        $wnd.jQuery(e).popover('destroy');
+    }-*/;
+
+    private static native void doDestroyPopover(final HTMLElement e) /*-{
+        $wnd.jQuery(e).popover('destroy');
+    }-*/;
+
+    List<Element> getPopoverElementRegistrations() {
+        return Collections.unmodifiableList(popoverElementRegistrations);
+    }
+
+    List<HTMLElement> getPopoverHTMLElementRegistrations() {
+        return Collections.unmodifiableList(popoverHTMLElementRegistrations);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBui
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.project.context.ProjectContext;
 import org.jboss.errai.common.client.api.Caller;
@@ -86,8 +87,12 @@ import org.uberfire.workbench.model.menu.MenuItemPlain;
 import org.uberfire.workbench.model.menu.MenuVisitor;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTableEditorMenusTest {
@@ -222,6 +227,9 @@ public class GuidedDecisionTableEditorMenusTest {
     @Mock
     protected MenuItemWithIconView menuItemWithIconView;
 
+    @Mock
+    private DecisionTablePopoverUtils popoverUtils;
+
     private GuidedDecisionTableEditorPresenter presenter;
     private GuidedDTableResourceType resourceType = new GuidedDTableResourceType();
 
@@ -282,7 +290,8 @@ public class GuidedDecisionTableEditorMenusTest {
 
         this.editMenuBuilder = new EditMenuBuilder(clipboard,
                                                    ts,
-                                                   menuItemFactory);
+                                                   menuItemFactory,
+                                                   popoverUtils);
         this.editMenuBuilder.setup();
         this.insertMenuBuilder = new InsertMenuBuilder(ts,
                                                        menuItemFactory);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilderTest.java
@@ -36,6 +36,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -54,6 +55,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.Gr
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -84,6 +86,9 @@ public class EditMenuBuilderTest {
     private MenuItemWithIconView menuItemWithIconView;
 
     @Mock
+    private HTMLElement menuItemHTMLElement;
+
+    @Mock
     private GuidedDecisionTableView.Presenter dtPresenter;
 
     @Mock
@@ -94,6 +99,9 @@ public class EditMenuBuilderTest {
 
     @Mock
     private GuidedDecisionTableView dtPresenterView;
+
+    @Mock
+    private DecisionTablePopoverUtils popoverUtils;
 
     @Before
     public void setup() {
@@ -111,15 +119,24 @@ public class EditMenuBuilderTest {
         when(ts.getTranslation(any(String.class))).thenReturn("i18n");
         when(menuItemViewProducer.select(any(Annotation.class))).thenReturn(menuItemViewProducer);
         when(menuItemViewProducer.get()).thenReturn(menuItemWithIconView);
-        when(menuItemWithIconView.getElement()).thenReturn(mock(HTMLElement.class));
+        when(menuItemWithIconView.getElement()).thenReturn(menuItemHTMLElement);
 
         uiModel.appendColumn(new BaseGridColumn<>(headerMetaData, gridColumnRenderer, 100));
         uiModel.appendColumn(new BaseGridColumn<>(headerMetaData, gridColumnRenderer, 100));
         uiModel.appendColumn(new BaseGridColumn<>(headerMetaData, gridColumnRenderer, 100));
         uiModel.appendRow(new BaseGridRow());
 
-        builder = new EditMenuBuilder(clipboard, ts, menuItemFactory);
+        builder = new EditMenuBuilder(clipboard,
+                                      ts,
+                                      menuItemFactory,
+                                      popoverUtils);
         builder.setup();
+    }
+
+    @Test
+    public void testPopoverSetup() {
+        verify(popoverUtils).setupPopover(eq(menuItemHTMLElement),
+                                          anyString());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/PluginHandlerTest.java
@@ -46,6 +46,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.Rul
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.SummaryPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.ValueOptionsPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.WorkItemPage;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionRetractFactPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionSetFactPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionWorkItemPlugin;
@@ -67,7 +68,11 @@ import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.ext.widgets.core.client.wizards.WizardView;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class PluginHandlerTest {
@@ -144,6 +149,9 @@ public class PluginHandlerTest {
     @Mock
     private EventSourceMock<WizardPageStatusChangeEvent> event;
 
+    @Mock
+    private DecisionTablePopoverUtils popoverUtils;
+
     private PluginHandler pluginHandler;
 
     private NewGuidedDecisionTableColumnWizard wizard;
@@ -162,7 +170,8 @@ public class PluginHandlerTest {
 
         wizard = spy(new NewGuidedDecisionTableColumnWizard(mock(WizardView.class),
                                                             summaryPage,
-                                                            translationService));
+                                                            translationService,
+                                                            popoverUtils));
 
         doReturn(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY).when(model).getTableFormat();
         doReturn(model).when(presenter).getModel();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizardTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizardTest.java
@@ -27,6 +27,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.Add
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.OperatorPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.PatternPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.SummaryPage;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionRetractFactPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionSetFactPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.ActionWorkItemPlugin;
@@ -44,7 +45,16 @@ import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardView;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class NewGuidedDecisionTableColumnWizardTest {
@@ -93,13 +103,17 @@ public class NewGuidedDecisionTableColumnWizardTest {
     @Mock
     private TranslationService translationService;
 
+    @Mock
+    private DecisionTablePopoverUtils popoverUtils;
+
     private NewGuidedDecisionTableColumnWizard wizard;
 
     @Before
     public void setup() {
         wizard = spy(new NewGuidedDecisionTableColumnWizard(view,
                                                             summaryPage,
-                                                            translationService));
+                                                            translationService,
+                                                            popoverUtils));
 
         pages = spy(new ArrayList<>());
         wizard.setPages(pages);
@@ -229,6 +243,13 @@ public class NewGuidedDecisionTableColumnWizardTest {
     public void testCompleteWizardConditionColumnPlugin() {
         when(conditionColumnPlugin.editingPattern()).thenReturn(new Pattern52());
         testCompleteWizard(conditionColumnPlugin);
+    }
+
+    @Test
+    public void testClosureDestroysPopovers() {
+        wizard.close();
+
+        verify(popoverUtils).destroyPopovers();
     }
 
     private void testCompleteWizard(DecisionTableColumnPlugin plugin) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTablePopoverUtilsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/common/DecisionTablePopoverUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DecisionTablePopoverUtilsTest {
+
+    @Mock
+    private Element element;
+
+    @Mock
+    private HTMLElement htmlElement;
+
+    private DecisionTablePopoverUtils popoverUtils;
+
+    @Before
+    public void setup() {
+        this.popoverUtils = new DecisionTablePopoverUtils();
+    }
+
+    @Test
+    public void checkElementRegistration() {
+        popoverUtils.setupPopover(element,
+                                  "hello");
+
+        assertTrue(popoverUtils.getPopoverElementRegistrations().isEmpty());
+
+        popoverUtils.setupAndRegisterPopover(element,
+                                             "hello");
+
+        assertFalse(popoverUtils.getPopoverElementRegistrations().isEmpty());
+        assertEquals(1,
+                     popoverUtils.getPopoverElementRegistrations().size());
+
+        popoverUtils.destroyPopovers();
+
+        assertTrue(popoverUtils.getPopoverElementRegistrations().isEmpty());
+    }
+
+    @Test
+    public void checkHTMLElementRegistration() {
+        popoverUtils.setupPopover(htmlElement,
+                                  "hello");
+
+        assertTrue(popoverUtils.getPopoverHTMLElementRegistrations().isEmpty());
+
+        popoverUtils.setupAndRegisterPopover(htmlElement,
+                                             "hello");
+
+        assertFalse(popoverUtils.getPopoverHTMLElementRegistrations().isEmpty());
+        assertEquals(1,
+                     popoverUtils.getPopoverHTMLElementRegistrations().size());
+
+        popoverUtils.destroyPopovers();
+
+        assertTrue(popoverUtils.getPopoverElementRegistrations().isEmpty());
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3556

This is the corollary of https://github.com/kiegroup/drools-wb/pull/651 for 7.4.x

(cherry picked from commit 3bb679d1cbf5091644d4d8f0952476bbc9dbfe65)

(Product JIRA https://issues.jboss.org/browse/RHBRMS-3001 is an approved blocker for 7.0.0.LA)