### PR TITLE
GUVNOR-3409: [Guided Decision Table] Change the pattern of an action column

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.java
@@ -207,6 +207,15 @@ public class GuidedDecisionTableErraiConstants {
     public static final String NewGuidedDecisionTableColumnWizard_EditColumn = "NewGuidedDecisionTableColumnWizard.EditColumn";
 
     @TranslationKey(defaultValue = "")
+    public static final String NewGuidedDecisionTableColumnWizard_GenericVetoError = "NewGuidedDecisionTableColumnWizard.GenericVetoError";
+
+    @TranslationKey(defaultValue = "")
+    public static final String NewGuidedDecisionTableColumnWizard_UpdatePatternInUseVetoError = "NewGuidedDecisionTableColumnWizard.UpdatePatternInUseVetoError";
+
+    @TranslationKey(defaultValue = "")
+    public static final String NewGuidedDecisionTableColumnWizard_DeletePatternInUseVetoError0 = "NewGuidedDecisionTableColumnWizard.DeletePatternInUseVetoError0";
+
+    @TranslationKey(defaultValue = "")
     public static final String NewPatternView_CreateANewFact = "NewPatternView.CreateANewFact";
 
     @TranslationKey(defaultValue = "")

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -29,6 +29,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
@@ -93,6 +94,12 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
     Bounds getBounds();
 
     void setPinnedModeIndicatorVisibility(final boolean visible);
+
+    void showGenericVetoMessage();
+
+    void showUnableToDeleteColumnMessage(final ConditionCol52 column);
+
+    void showUnableToDeleteColumnMessage(final ActionCol52 column);
 
     interface Presenter extends GridPinnedModeManager,
                                 ViewMenuBuilder.SupportsZoom,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -49,6 +49,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.co
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.ColumnLabelWidget;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.ColumnManagementView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.DeleteColumnManagementAnchorWidget;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTableColumnViewUtils;
 import org.gwtbootstrap3.client.ui.Button;
@@ -461,8 +462,12 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
                 public void onClick(final ClickEvent event) {
                     final MetadataCol52 editedColumn = originalColumn.cloneColumn();
                     editedColumn.setHideColumn(chkHideColumn.getValue());
-                    presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                    editedColumn);
+                    try {
+                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                        editedColumn);
+                    } catch (VetoException veto) {
+                        //Swallow
+                    }
                 }
             });
 
@@ -471,7 +476,13 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
             if (isEditable) {
                 final DeleteColumnManagementAnchorWidget deleteWidget = deleteColumnManagementAnchorWidgets.get();
                 deleteWidget.init(metaDataColumn.getMetadata(),
-                                  () -> presenter.getActiveDecisionTable().deleteColumn(metaDataColumn));
+                                  () -> {
+                                      try {
+                                          presenter.getActiveDecisionTable().deleteColumn(metaDataColumn);
+                                      } catch (VetoException veto) {
+                                          //Swallow
+                                      }
+                                  });
                 hp.add(deleteWidget);
             }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -116,9 +116,6 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         }
     };
 
-    @Inject
-    private GuidedDecisionTableAccordion guidedDecisionTableAccordion;
-
     private VerticalPanel attributeConfigWidget = makeDefaultPanel();
 
     private VerticalPanel metaDataConfigWidget = makeDefaultPanel();
@@ -145,6 +142,8 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
 
     private ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets;
 
+    private GuidedDecisionTableAccordion guidedDecisionTableAccordion;
+
     private TranslationService translationService;
 
     public GuidedDecisionTableModellerViewImpl() {
@@ -156,11 +155,13 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
                                                final ColumnManagementView conditionsPanel,
                                                final ManagedInstance<AttributeColumnConfigRow> attributeColumnConfigRows,
                                                final ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets,
+                                               final GuidedDecisionTableAccordion guidedDecisionTableAccordion,
                                                final TranslationService translationService) {
         this.actionsPanel = actionsPanel;
         this.conditionsPanel = conditionsPanel;
         this.attributeColumnConfigRows = attributeColumnConfigRows;
         this.deleteColumnManagementAnchorWidgets = deleteColumnManagementAnchorWidgets;
+        this.guidedDecisionTableAccordion = guidedDecisionTableAccordion;
         this.translationService = translationService;
 
         initWidget(uiBinder.createAndBindUi(this));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.event.shared.SimpleEventBus;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Window;
 import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
 import org.drools.workbench.models.guided.dtable.shared.auditlog.DeleteColumnAuditLogEntry;
 import org.drools.workbench.models.guided.dtable.shared.auditlog.DeleteRowAuditLogEntry;
@@ -884,7 +883,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                                                                   column));
             callback.execute();
         } catch (VetoException e) {
-            //Swallow. The VetoException signals that the column could not be appended.
+            getModellerPresenter().getView().showGenericVetoMessage();
         }
     }
 
@@ -902,7 +901,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             model.getAuditLog().add(new InsertRowAuditLogEntry(identity.getIdentifier(),
                                                                model.getData().size() - 1));
         } catch (VetoException e) {
-            //Swallow
+            getModellerPresenter().getView().showGenericVetoMessage();
         }
     }
 
@@ -1228,18 +1227,30 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             }
         }
         for (BaseColumn columnToDelete : columnsToDelete) {
-            try {
-                if (columnToDelete instanceof AttributeCol52) {
+            if (columnToDelete instanceof AttributeCol52) {
+                try {
                     deleteColumn((AttributeCol52) columnToDelete);
-                } else if (columnToDelete instanceof MetadataCol52) {
-                    deleteColumn((MetadataCol52) columnToDelete);
-                } else if (columnToDelete instanceof ConditionCol52) {
-                    deleteColumn((ConditionCol52) columnToDelete);
-                } else if (columnToDelete instanceof ActionCol52) {
-                    deleteColumn((ActionCol52) columnToDelete);
+                } catch (VetoException veto) {
+                    getModellerPresenter().getView().showGenericVetoMessage();
                 }
-            } catch (VetoException veto) {
-                Window.alert("Could not delete!");
+            } else if (columnToDelete instanceof MetadataCol52) {
+                try {
+                    deleteColumn((MetadataCol52) columnToDelete);
+                } catch (VetoException veto) {
+                    getModellerPresenter().getView().showGenericVetoMessage();
+                }
+            } else if (columnToDelete instanceof ConditionCol52) {
+                try {
+                    deleteColumn((ConditionCol52) columnToDelete);
+                } catch (VetoException veto) {
+                    getModellerPresenter().getView().showUnableToDeleteColumnMessage((ConditionCol52) columnsToDelete);
+                }
+            } else if (columnToDelete instanceof ActionCol52) {
+                try {
+                    deleteColumn((ActionCol52) columnToDelete);
+                } catch (VetoException veto) {
+                    getModellerPresenter().getView().showUnableToDeleteColumnMessage((ActionCol52) columnsToDelete);
+                }
             }
         }
     }
@@ -1285,7 +1296,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             model.getAuditLog().add(new DeleteRowAuditLogEntry(identity.getIdentifier(),
                                                                rowIndex));
         } catch (VetoException e) {
-            //Swallow
+            getModellerPresenter().getView().showGenericVetoMessage();
         }
     }
 
@@ -1344,7 +1355,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             model.getAuditLog().add(new InsertRowAuditLogEntry(identity.getIdentifier(),
                                                                rowIndex));
         } catch (VetoException e) {
-            //Swallow
+            getModellerPresenter().getView().showGenericVetoMessage();
         }
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
@@ -36,6 +36,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.EditMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.guvnor.common.services.shared.metadata.model.Overview;
@@ -125,8 +126,6 @@ public interface GuidedDecisionTableView extends GridWidget,
 
         List<String> getLHSBoundFacts();
 
-        boolean canConditionBeDeleted(final ConditionCol52 col);
-
         Map<String, String> getValueListLookups(final BaseColumn column);
 
         void getEnumLookups(final String factType,
@@ -156,30 +155,30 @@ public interface GuidedDecisionTableView extends GridWidget,
 
         void appendColumn(final ActionCol52 column);
 
-        void deleteColumn(final AttributeCol52 column);
+        void deleteColumn(final AttributeCol52 column) throws VetoException;
 
-        void deleteColumn(final MetadataCol52 column);
+        void deleteColumn(final MetadataCol52 column) throws VetoException;
 
-        void deleteColumn(final ConditionCol52 column);
+        void deleteColumn(final ConditionCol52 column) throws VetoException;
 
-        void deleteColumn(final ActionCol52 column);
+        void deleteColumn(final ActionCol52 column) throws VetoException;
 
         void updateColumn(final AttributeCol52 originalColumn,
-                          final AttributeCol52 editedColumn);
+                          final AttributeCol52 editedColumn) throws VetoException;
 
         void updateColumn(final MetadataCol52 originalColumn,
-                          final MetadataCol52 editedColumn);
+                          final MetadataCol52 editedColumn) throws VetoException;
 
         void updateColumn(final Pattern52 originalPattern,
                           final ConditionCol52 originalColumn,
                           final Pattern52 editedPattern,
-                          final ConditionCol52 editedColumn);
+                          final ConditionCol52 editedColumn) throws VetoException;
 
         void updateColumn(final ConditionCol52 originalColumn,
-                          final ConditionCol52 editedColumn);
+                          final ConditionCol52 editedColumn) throws VetoException;
 
         void updateColumn(final ActionCol52 originalColumn,
-                          final ActionCol52 editedColumn);
+                          final ActionCol52 editedColumn) throws VetoException;
 
         void link(final Set<GuidedDecisionTableView.Presenter> dtPresenters);
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
@@ -19,12 +19,9 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.c
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
-import org.drools.workbench.screens.guided.dtable.client.widget.DefaultValueWidgetFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
@@ -43,7 +40,7 @@ public class AttributeColumnConfigRow {
     public AttributeColumnConfigRow() {
     }
 
-    public void init(AttributeCol52 attributeColumn,
+    public void init(final AttributeCol52 attributeColumn,
                      final GuidedDecisionTableModellerView.Presenter presenter) {
         view.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
 
@@ -54,18 +51,15 @@ public class AttributeColumnConfigRow {
         if (attributeColumn.getAttribute().equals(RuleAttributeWidget.SALIENCE_ATTR)) {
             useRowNumberCheckBox = view.addUseRowNumberCheckBox(attributeColumn,
                                                                 presenter.isActiveDecisionTableEditable(),
-                                                                new ClickHandler() {
-                                                                    @Override
-                                                                    public void onClick(ClickEvent event) {
-                                                                        final AttributeCol52 editedColumn = originalColumn.cloneColumn();
-                                                                        editedColumn.setUseRowNumber(useRowNumberCheckBox.getValue());
-                                                                        reverseOrderCheckBox.setEnabled(useRowNumberCheckBox.getValue());
-                                                                        try {
-                                                                            presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                            editedColumn);
-                                                                        } catch (VetoException veto) {
-                                                                            //Swallow
-                                                                        }
+                                                                (event) -> {
+                                                                    final AttributeCol52 editedColumn = originalColumn.cloneColumn();
+                                                                    editedColumn.setUseRowNumber(useRowNumberCheckBox.getValue());
+                                                                    reverseOrderCheckBox.setEnabled(useRowNumberCheckBox.getValue());
+                                                                    try {
+                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                        editedColumn);
+                                                                    } catch (VetoException veto) {
+                                                                        presenter.getView().showGenericVetoMessage();
                                                                     }
                                                                 });
 
@@ -73,17 +67,14 @@ public class AttributeColumnConfigRow {
 
             reverseOrderCheckBox = view.addReverseOrderCheckBox(attributeColumn,
                                                                 presenter.isActiveDecisionTableEditable(),
-                                                                new ClickHandler() {
-                                                                    @Override
-                                                                    public void onClick(ClickEvent event) {
-                                                                        final AttributeCol52 editedColumn = originalColumn.cloneColumn();
-                                                                        editedColumn.setReverseOrder(reverseOrderCheckBox.getValue());
-                                                                        try {
-                                                                            presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                            editedColumn);
-                                                                        } catch (VetoException veto) {
-                                                                            //Swallow
-                                                                        }
+                                                                (event) -> {
+                                                                    final AttributeCol52 editedColumn = originalColumn.cloneColumn();
+                                                                    editedColumn.setReverseOrder(reverseOrderCheckBox.getValue());
+                                                                    try {
+                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                        editedColumn);
+                                                                    } catch (VetoException veto) {
+                                                                        presenter.getView().showGenericVetoMessage();
                                                                     }
                                                                 });
             view.add(new Span(")"));
@@ -91,32 +82,26 @@ public class AttributeColumnConfigRow {
 
         view.addDefaultValue(attributeColumn,
                              presenter.isActiveDecisionTableEditable(),
-                             new DefaultValueWidgetFactory.DefaultValueChangedEventHandler() {
-                                 @Override
-                                 public void onDefaultValueChanged(DefaultValueWidgetFactory.DefaultValueChangedEvent event) {
-                                     final AttributeCol52 editedColumn = originalColumn.cloneColumn();
-                                     editedColumn.setDefaultValue(event.getEditedDefaultValue());
-                                     try {
-                                         presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                         editedColumn);
-                                     } catch (VetoException veto) {
-                                         //Swallow
-                                     }
+                             (event) -> {
+                                 final AttributeCol52 editedColumn = originalColumn.cloneColumn();
+                                 editedColumn.setDefaultValue(event.getEditedDefaultValue());
+                                 try {
+                                     presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                     editedColumn);
+                                 } catch (VetoException veto) {
+                                     presenter.getView().showGenericVetoMessage();
                                  }
                              });
 
         hideColumnCheckBox = view.addHideColumnCheckBox(attributeColumn,
-                                                        new ClickHandler() {
-                                                            @Override
-                                                            public void onClick(ClickEvent event) {
-                                                                final AttributeCol52 editedColumn = originalColumn.cloneColumn();
-                                                                editedColumn.setHideColumn(hideColumnCheckBox.getValue());
-                                                                try {
-                                                                    presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                    editedColumn);
-                                                                } catch (VetoException veto) {
-                                                                    //Swallow
-                                                                }
+                                                        (event) -> {
+                                                            final AttributeCol52 editedColumn = originalColumn.cloneColumn();
+                                                            editedColumn.setHideColumn(hideColumnCheckBox.getValue());
+                                                            try {
+                                                                presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                editedColumn);
+                                                            } catch (VetoException veto) {
+                                                                presenter.getView().showGenericVetoMessage();
                                                             }
                                                         });
 
@@ -132,7 +117,7 @@ public class AttributeColumnConfigRow {
                                           try {
                                               presenter.getActiveDecisionTable().deleteColumn(attributeColumn);
                                           } catch (VetoException veto) {
-                                              //Swallow
+                                              presenter.getView().showGenericVetoMessage();
                                           }
                                       },
                                       isEditable);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.DefaultValueWidgetFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.gwtbootstrap3.client.ui.CheckBox;
 import org.gwtbootstrap3.client.ui.html.Span;
@@ -59,8 +60,12 @@ public class AttributeColumnConfigRow {
                                                                         final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                                                         editedColumn.setUseRowNumber(useRowNumberCheckBox.getValue());
                                                                         reverseOrderCheckBox.setEnabled(useRowNumberCheckBox.getValue());
-                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                        editedColumn);
+                                                                        try {
+                                                                            presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                            editedColumn);
+                                                                        } catch (VetoException veto) {
+                                                                            //Swallow
+                                                                        }
                                                                     }
                                                                 });
 
@@ -73,8 +78,12 @@ public class AttributeColumnConfigRow {
                                                                     public void onClick(ClickEvent event) {
                                                                         final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                                                         editedColumn.setReverseOrder(reverseOrderCheckBox.getValue());
-                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                        editedColumn);
+                                                                        try {
+                                                                            presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                            editedColumn);
+                                                                        } catch (VetoException veto) {
+                                                                            //Swallow
+                                                                        }
                                                                     }
                                                                 });
             view.add(new Span(")"));
@@ -87,8 +96,12 @@ public class AttributeColumnConfigRow {
                                  public void onDefaultValueChanged(DefaultValueWidgetFactory.DefaultValueChangedEvent event) {
                                      final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                      editedColumn.setDefaultValue(event.getEditedDefaultValue());
-                                     presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                     editedColumn);
+                                     try {
+                                         presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                         editedColumn);
+                                     } catch (VetoException veto) {
+                                         //Swallow
+                                     }
                                  }
                              });
 
@@ -98,8 +111,12 @@ public class AttributeColumnConfigRow {
                                                             public void onClick(ClickEvent event) {
                                                                 final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                                                 editedColumn.setHideColumn(hideColumnCheckBox.getValue());
-                                                                presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                editedColumn);
+                                                                try {
+                                                                    presenter.getActiveDecisionTable().updateColumn(originalColumn,
+                                                                                                                    editedColumn);
+                                                                } catch (VetoException veto) {
+                                                                    //Swallow
+                                                                }
                                                             }
                                                         });
 
@@ -111,7 +128,13 @@ public class AttributeColumnConfigRow {
                                           final GuidedDecisionTableModellerView.Presenter presenter) {
         final boolean isEditable = presenter.isActiveDecisionTableEditable();
 
-        view.addRemoveAttributeButton(() -> presenter.getActiveDecisionTable().deleteColumn(attributeColumn),
+        view.addRemoveAttributeButton(() -> {
+                                          try {
+                                              presenter.getActiveDecisionTable().deleteColumn(attributeColumn);
+                                          } catch (VetoException veto) {
+                                              //Swallow
+                                          }
+                                      },
                                       isEditable);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementView.java
@@ -35,21 +35,16 @@ import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
-import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
-import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 
 @Dependent
 public class ColumnManagementView extends VerticalPanel {
 
     private ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets;
-
-    private TranslationService translationService;
 
     private GuidedDecisionTableModellerView.Presenter presenter;
 
@@ -57,10 +52,8 @@ public class ColumnManagementView extends VerticalPanel {
     }
 
     @Inject
-    public ColumnManagementView(final ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets,
-                                final TranslationService translationService) {
+    public ColumnManagementView(final ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets) {
         this.deleteColumnManagementAnchorWidgets = deleteColumnManagementAnchorWidgets;
-        this.translationService = translationService;
     }
 
     public void init(final GuidedDecisionTableModellerView.Presenter presenter) {
@@ -106,9 +99,9 @@ public class ColumnManagementView extends VerticalPanel {
                                      try {
                                          presenter.getActiveDecisionTable().deleteColumn(actionColumn);
                                      } catch (VetoDeletePatternInUseException veto) {
-                                         showUnableToDeleteColumnMessage(actionColumn);
+                                         presenter.getView().showUnableToDeleteColumnMessage(actionColumn);
                                      } catch (VetoException veto) {
-                                         showGenericVetoMessage();
+                                         presenter.getView().showGenericVetoMessage();
                                      }
                                  }));
             }
@@ -194,25 +187,11 @@ public class ColumnManagementView extends VerticalPanel {
                                 try {
                                     presenter.getActiveDecisionTable().deleteColumn(column);
                                 } catch (VetoDeletePatternInUseException veto) {
-                                    showUnableToDeleteColumnMessage(column);
+                                    presenter.getView().showUnableToDeleteColumnMessage(column);
                                 } catch (VetoException veto) {
-                                    showGenericVetoMessage();
+                                    presenter.getView().showGenericVetoMessage();
                                 }
                             });
-    }
-
-    void showGenericVetoMessage() {
-        ErrorPopup.showMessage(translate(GuidedDecisionTableErraiConstants.NewGuidedDecisionTableColumnWizard_GenericVetoError));
-    }
-
-    void showUnableToDeleteColumnMessage(final ConditionCol52 column) {
-        ErrorPopup.showMessage(translate(GuidedDecisionTableErraiConstants.NewGuidedDecisionTableColumnWizard_DeletePatternInUseVetoError0,
-                                         column.getHeader()));
-    }
-
-    void showUnableToDeleteColumnMessage(final ActionCol52 column) {
-        ErrorPopup.showMessage(translate(GuidedDecisionTableErraiConstants.NewGuidedDecisionTableColumnWizard_DeletePatternInUseVetoError0,
-                                         column.getHeader()));
     }
 
     HorizontalPanel newHorizontalPanel() {
@@ -229,11 +208,5 @@ public class ColumnManagementView extends VerticalPanel {
         widget.init(columnHeader,
                     command);
         return widget;
-    }
-
-    private String translate(final String key,
-                             final Object... args) {
-        return translationService.format(key,
-                                         args);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/GuidedDecisionTableUiModel.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/GuidedDecisionTableUiModel.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model;
 import java.util.List;
 
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -72,7 +73,7 @@ public class GuidedDecisionTableUiModel extends BaseGridData {
                                        columns);
             super.moveColumnsTo(index,
                                 columns);
-        } catch (ModelSynchronizer.MoveColumnVetoException ignore) {
+        } catch (VetoException ignore) {
             //Do nothing. The move has been vetoed.
         }
     }
@@ -86,7 +87,7 @@ public class GuidedDecisionTableUiModel extends BaseGridData {
             super.moveRowsTo(index,
                              rows);
             synchronizer.updateSystemControlledColumnValues();
-        } catch (ModelSynchronizer.MoveColumnVetoException ignore) {
+        } catch (VetoException ignore) {
             //Do nothing. The move has been vetoed.
         }
     }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/ModelSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/ModelSynchronizer.java
@@ -43,64 +43,75 @@ import org.uberfire.ext.wires.core.grids.client.model.GridRow;
  */
 public interface ModelSynchronizer {
 
-    class MoveColumnVetoException extends Exception {
+    class VetoException extends Exception {
 
     }
 
-    void setSynchronizers( final List<Synchronizer<? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData>> synchronizers );
+    class VetoDeletePatternInUseException extends VetoException {
 
-    void initialise( final GuidedDecisionTable52 model,
-                     final GuidedDecisionTableUiModel uiModel,
-                     final CellUtilities cellUtilities,
-                     final ColumnUtilities columnUtilities,
-                     final DependentEnumsUtilities dependentEnumsUtilities,
-                     final GridWidgetCellFactory gridWidgetCellFactory,
-                     final GridWidgetColumnFactory gridWidgetColumnFactory,
-                     final GuidedDecisionTableView view,
-                     final BRLRuleModel rm,
-                     final EventBus eventBus,
-                     final GuidedDecisionTablePresenter.Access access );
+    }
 
-    void setCell( final GridData.Range rowRange,
-                  final int columnIndex,
-                  final GridCellValue<?> value );
+    class VetoUpdatePatternInUseException extends VetoException {
 
-    void deleteCell( final GridData.Range rowRange,
-                     final int columnIndex );
+    }
 
-    void appendColumn( final BaseColumn column ) throws MoveColumnVetoException;
+    class MoveVetoException extends VetoException {
 
-    void appendColumn( final Pattern52 pattern,
-                       final ConditionCol52 column ) throws MoveColumnVetoException;
+    }
 
-    void deleteColumn( final BaseColumn column ) throws MoveColumnVetoException;
+    void setSynchronizers(final List<Synchronizer<? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData, ? extends Synchronizer.MetaData>> synchronizers);
 
-    List<BaseColumnFieldDiff> updateColumn( final Pattern52 originalPattern,
-                                            final ConditionCol52 originalColumn,
-                                            final Pattern52 editedPattern,
-                                            final ConditionCol52 editedColumn ) throws MoveColumnVetoException;
+    void initialise(final GuidedDecisionTable52 model,
+                    final GuidedDecisionTableUiModel uiModel,
+                    final CellUtilities cellUtilities,
+                    final ColumnUtilities columnUtilities,
+                    final DependentEnumsUtilities dependentEnumsUtilities,
+                    final GridWidgetCellFactory gridWidgetCellFactory,
+                    final GridWidgetColumnFactory gridWidgetColumnFactory,
+                    final GuidedDecisionTableView view,
+                    final BRLRuleModel rm,
+                    final EventBus eventBus,
+                    final GuidedDecisionTablePresenter.Access access);
 
-    List<BaseColumnFieldDiff> updateColumn( final BaseColumn originalColumn,
-                                            final BaseColumn editedColumn ) throws MoveColumnVetoException;
+    void setCell(final GridData.Range rowRange,
+                 final int columnIndex,
+                 final GridCellValue<?> value);
 
-    void moveColumnTo( final int targetColumnIndex,
-                       final GridColumn<?> column ) throws MoveColumnVetoException;
+    void deleteCell(final GridData.Range rowRange,
+                    final int columnIndex);
 
-    void moveColumnsTo( final int targetColumnIndex,
-                        final List<GridColumn<?>> columns ) throws MoveColumnVetoException;
+    void appendColumn(final BaseColumn column) throws VetoException;
 
-    void moveRowsTo( final int targetRowIndex,
-                     final List<GridRow> rows ) throws MoveColumnVetoException;
+    void appendColumn(final Pattern52 pattern,
+                      final ConditionCol52 column) throws VetoException;
 
-    void appendRow() throws MoveColumnVetoException;
+    void deleteColumn(final BaseColumn column) throws VetoException;
 
-    void insertRow( final int rowIndex ) throws MoveColumnVetoException;
+    List<BaseColumnFieldDiff> updateColumn(final Pattern52 originalPattern,
+                                           final ConditionCol52 originalColumn,
+                                           final Pattern52 editedPattern,
+                                           final ConditionCol52 editedColumn) throws VetoException;
 
-    void deleteRow( final int rowIndex ) throws MoveColumnVetoException;
+    List<BaseColumnFieldDiff> updateColumn(final BaseColumn originalColumn,
+                                           final BaseColumn editedColumn) throws VetoException;
+
+    void moveColumnTo(final int targetColumnIndex,
+                      final GridColumn<?> column) throws VetoException;
+
+    void moveColumnsTo(final int targetColumnIndex,
+                       final List<GridColumn<?>> columns) throws VetoException;
+
+    void moveRowsTo(final int targetRowIndex,
+                    final List<GridRow> rows) throws VetoException;
+
+    void appendRow() throws VetoException;
+
+    void insertRow(final int rowIndex) throws VetoException;
+
+    void deleteRow(final int rowIndex) throws VetoException;
 
     void updateSystemControlledColumnValues();
 
-    void setCellOtherwiseState( final int rowIndex,
-                                final int columnIndex );
-
+    void setCellOtherwiseState(final int rowIndex,
+                               final int columnIndex);
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/Synchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/Synchronizer.java
@@ -27,10 +27,11 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.cell.GridWidgetCellFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.CellUtilities;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.Synchronizer.*;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.Synchronizer.MetaData;
 
 public interface Synchronizer<A extends MetaData, U extends MetaData, D extends MetaData, MC extends MetaData, MR extends MetaData> {
 
@@ -40,40 +41,39 @@ public interface Synchronizer<A extends MetaData, U extends MetaData, D extends 
 
     int priority();
 
-    void initialise( final GuidedDecisionTable52 model,
-                     final GuidedDecisionTableUiModel uiModel,
-                     final CellUtilities cellUtilities,
-                     final ColumnUtilities columnUtilities,
-                     final GridWidgetCellFactory gridWidgetCellFactory,
-                     final GridWidgetColumnFactory gridWidgetColumnFactory,
-                     final GuidedDecisionTableView view,
-                     final BRLRuleModel rm,
-                     final EventBus eventBus,
-                     final GuidedDecisionTablePresenter.Access access );
+    void initialise(final GuidedDecisionTable52 model,
+                    final GuidedDecisionTableUiModel uiModel,
+                    final CellUtilities cellUtilities,
+                    final ColumnUtilities columnUtilities,
+                    final GridWidgetCellFactory gridWidgetCellFactory,
+                    final GridWidgetColumnFactory gridWidgetColumnFactory,
+                    final GuidedDecisionTableView view,
+                    final BRLRuleModel rm,
+                    final EventBus eventBus,
+                    final GuidedDecisionTablePresenter.Access access);
 
-    boolean handlesAppend( final MetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesAppend(final MetaData metaData) throws VetoException;
 
-    void append( final A metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    void append(final A metaData) throws VetoException;
 
-    boolean handlesInsert( final MetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesInsert(final MetaData metaData) throws VetoException;
 
-    void insert( final A metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    void insert(final A metaData) throws VetoException;
 
-    boolean handlesUpdate( final MetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesUpdate(final MetaData metaData) throws VetoException;
 
-    List<BaseColumnFieldDiff> update( final U originalMetaData,
-                                      final U editedMetaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    List<BaseColumnFieldDiff> update(final U originalMetaData,
+                                     final U editedMetaData) throws VetoException;
 
-    boolean handlesDelete( final MetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesDelete(final MetaData metaData) throws VetoException;
 
-    void delete( final D metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    void delete(final D metaData) throws VetoException;
 
-    boolean handlesMoveColumnsTo( final List<? extends MetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException;
 
-    void moveColumnsTo( final List<MC> metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    void moveColumnsTo(final List<MC> metaData) throws VetoException;
 
-    boolean handlesMoveRowsTo( final List<? extends MetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException;
+    boolean handlesMoveRowsTo(final List<? extends MetaData> metaData) throws VetoException;
 
-    void moveRowsTo( final List<MR> metaData ) throws ModelSynchronizer.MoveColumnVetoException;
-
+    void moveRowsTo(final List<MR> metaData) throws VetoException;
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionColumnSynchronizer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -35,6 +36,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetF
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseColumnSynchronizer.ColumnMetaData;
 
@@ -42,31 +44,31 @@ import static org.drools.workbench.screens.guided.dtable.client.widget.table.mod
 public class ActionColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaData, ColumnMetaData, ColumnMetaData> {
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         //All sub-classes of ActionCol52 have their appends synchronized by specialised synchronizers
         return false;
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //All sub-classes of ActionCol52 have their appends synchronized by specialised synchronizers
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         //All sub-classes of ActionCol52 have their updates synchronized by specialised synchronizers
         return false;
     }
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //All sub-classes of ActionCol52 have their updates synchronized by specialised synchronizers
         return Collections.emptyList();
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -74,7 +76,7 @@ public class ActionColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaD
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -87,13 +89,13 @@ public class ActionColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaD
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         //All sub-classes of ActionCol52 have their updates synchronized by specialised synchronizers
         return false;
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -157,7 +159,7 @@ public class ActionColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaD
         return result.get();
     }
 
-    protected void doMoveActionFragment(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    protected void doMoveActionFragment(final List<MoveColumnToMetaData> metaData) throws VetoException {
         final MoveColumnToMetaData md = metaData.get(0);
         final BaseColumn firstColumnInFragment = md.getColumn();
         final BaseColumn lastColumnInFragment = metaData.get(metaData.size() - 1).getColumn();
@@ -172,10 +174,10 @@ public class ActionColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaD
 
         final int srcModelFragmentColumnsCount = srcModelFragmentColumns.size();
         if (srcModelFragmentColumnsCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         if (srcModelFragmentColumnsCount != metaData.size()) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final int tgtColumnIndex = md.getTargetColumnIndex();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizer.java
@@ -31,6 +31,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionInsertFactColumnSynchronizer extends ActionColumnSynchronizer {
@@ -41,12 +42,12 @@ public class ActionInsertFactColumnSynchronizer extends ActionColumnSynchronizer
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         if (!handlesAppend(metaData)) {
             return;
         }
@@ -64,7 +65,7 @@ public class ActionInsertFactColumnSynchronizer extends ActionColumnSynchronizer
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -73,7 +74,7 @@ public class ActionInsertFactColumnSynchronizer extends ActionColumnSynchronizer
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -151,7 +152,7 @@ public class ActionInsertFactColumnSynchronizer extends ActionColumnSynchronizer
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveVetoException {
         final boolean isActionInsetFactFragment = isActionInsertFactFragment(metaData);
         if (!isActionInsetFactFragment) {
             return false;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -26,7 +27,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionRetractFactColumnSynchronizer extends ActionColumnSynchronizer {
@@ -37,12 +38,12 @@ public class ActionRetractFactColumnSynchronizer extends ActionColumnSynchronize
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         if (!handlesAppend(metaData)) {
             return;
         }
@@ -53,7 +54,7 @@ public class ActionRetractFactColumnSynchronizer extends ActionColumnSynchronize
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -62,7 +63,7 @@ public class ActionRetractFactColumnSynchronizer extends ActionColumnSynchronize
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -107,7 +108,7 @@ public class ActionRetractFactColumnSynchronizer extends ActionColumnSynchronize
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizer.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalInt;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
@@ -26,7 +27,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
@@ -37,12 +38,12 @@ public class ActionSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         if (!handlesAppend(metaData)) {
             return;
         }
@@ -60,7 +61,7 @@ public class ActionSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -69,7 +70,7 @@ public class ActionSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -144,7 +145,7 @@ public class ActionSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isActionSetFieldFragment(metaData);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemExecuteColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemExecuteColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -25,7 +26,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol5
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionWorkItemExecuteColumnSynchronizer extends ActionColumnSynchronizer {
@@ -36,12 +37,12 @@ public class ActionWorkItemExecuteColumnSynchronizer extends ActionColumnSynchro
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         if (!handlesAppend(metaData)) {
             return;
         }
@@ -52,7 +53,7 @@ public class ActionWorkItemExecuteColumnSynchronizer extends ActionColumnSynchro
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -61,7 +62,7 @@ public class ActionWorkItemExecuteColumnSynchronizer extends ActionColumnSynchro
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -103,7 +104,7 @@ public class ActionWorkItemExecuteColumnSynchronizer extends ActionColumnSynchro
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isWorkItemFragment(metaData) && isWorkItemFragmentBeforeInsertFactCol(metaData);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
@@ -25,7 +26,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInse
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionWorkItemInsertFactColumnSynchronizer extends ActionColumnSynchronizer {
@@ -36,12 +37,12 @@ public class ActionWorkItemInsertFactColumnSynchronizer extends ActionColumnSync
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -64,7 +65,7 @@ public class ActionWorkItemInsertFactColumnSynchronizer extends ActionColumnSync
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -73,7 +74,7 @@ public class ActionWorkItemInsertFactColumnSynchronizer extends ActionColumnSync
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -120,7 +121,7 @@ public class ActionWorkItemInsertFactColumnSynchronizer extends ActionColumnSync
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isWorkItemFragment(metaData) && isWorkItemFragmentBeforeInsertFactCol(metaData);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
@@ -25,7 +26,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetF
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class ActionWorkItemSetFieldColumnSynchronizer extends ActionColumnSynchronizer {
@@ -36,12 +37,12 @@ public class ActionWorkItemSetFieldColumnSynchronizer extends ActionColumnSynchr
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -64,7 +65,7 @@ public class ActionWorkItemSetFieldColumnSynchronizer extends ActionColumnSynchr
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -73,7 +74,7 @@ public class ActionWorkItemSetFieldColumnSynchronizer extends ActionColumnSynchr
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) throws ModelSynchronizer.MoveColumnVetoException {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -120,7 +121,7 @@ public class ActionWorkItemSetFieldColumnSynchronizer extends ActionColumnSynchr
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isWorkItemFragment(metaData) && isWorkItemFragmentBeforeInsertFactCol(metaData);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
@@ -26,6 +27,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiffImpl;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseColumnSynchronizer.ColumnMetaData;
 
@@ -33,12 +35,12 @@ import static org.drools.workbench.screens.guided.dtable.client.widget.table.mod
 public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMetaData, ColumnMetaData, ColumnMetaData> {
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -50,7 +52,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -59,7 +61,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -106,7 +108,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -114,7 +116,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -127,7 +129,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;
@@ -141,7 +143,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -153,7 +155,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
         final List<AttributeCol52> modelAttributeColumns = model.getAttributeCols();
         final int modelAttributeColumnCount = modelAttributeColumns.size();
         if (modelAttributeColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -163,7 +165,7 @@ public class AttributeColumnSynchronizer extends BaseColumnSynchronizer<ColumnMe
         final int targetColumnIndex = md.getTargetColumnIndex();
         final int sourceColumnIndex = md.getSourceColumnIndex();
         if (targetColumnIndex < minColumnIndex || targetColumnIndex > maxColumnIndex) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         moveModelData(targetColumnIndex,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizer.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.BRLActionColumn;
@@ -29,6 +30,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData> {
@@ -39,12 +41,12 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -58,7 +60,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -67,7 +69,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -112,7 +114,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -120,7 +122,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -137,7 +139,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isBRLFragment(metaData);
     }
 
@@ -155,7 +157,7 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -163,24 +165,24 @@ public class BRLActionColumnSynchronizer extends BaseColumnSynchronizer<BaseColu
         if (isBRLFragment(metaData)) {
             doMoveBRLFragment(metaData);
         } else {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
     }
 
-    private void doMoveBRLFragment(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    private void doMoveBRLFragment(final List<MoveColumnToMetaData> metaData) throws VetoException {
         final MoveColumnToMetaData md = metaData.get(0);
         final BRLActionVariableColumn srcModelColumn = (BRLActionVariableColumn) md.getColumn();
         final BRLActionColumn srcModelBRLFragment = model.getBRLColumn(srcModelColumn);
         if (srcModelBRLFragment == null) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         final List<BRLActionVariableColumn> srcModelBRLFragmentColumns = srcModelBRLFragment.getChildColumns();
         final int srcModelBRLFragmentColumnsCount = srcModelBRLFragmentColumns.size();
         if (srcModelBRLFragmentColumnsCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         if (srcModelBRLFragmentColumnsCount != metaData.size()) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final int tgtColumnIndex = md.getTargetColumnIndex();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 
-import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.IPattern;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
@@ -153,15 +152,10 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
         final BRLConditionColumn column = (BRLConditionColumn) metaData.getColumn();
 
         //If Pattern has been updated and there was only one child column then original Pattern will be deleted
-        for (IPattern p : column.getDefinition()) {
-            if (p instanceof FactPattern) {
-                final FactPattern fp = (FactPattern) p;
-                if (fp.isBound()) {
-                    final String binding = fp.getBoundName();
-                    if (rm.isBoundFactUsed(binding)) {
-                        throw new VetoDeletePatternInUseException();
-                    }
-                }
+        final Set<String> bindings = getPatternBindings(column);
+        for (String binding : bindings) {
+            if (rm.isBoundFactUsed(binding)) {
+                throw new VetoDeletePatternInUseException();
             }
         }
 
@@ -244,7 +238,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
         final List<IPattern> definition = column.getDefinition();
         final RuleModel rm = new RuleModel();
         rm.lhs = definition.toArray(new IPattern[definition.size()]);
-        bindings.addAll(rm.getLHSVariables(true, false));
+        bindings.addAll(rm.getLHSVariables(true, true));
         return bindings;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
@@ -19,18 +19,26 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import javax.enterprise.context.Dependent;
 
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.rule.IPattern;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.gwt.BoundFactsChangedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 
 @Dependent
 public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData> {
@@ -41,12 +49,12 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -60,7 +68,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -69,22 +77,32 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
         }
 
+        //Check whether any discarded bindings were used. If so veto the update.
         final BRLConditionColumn originalColumn = (BRLConditionColumn) originalMetaData.getColumn();
         final BRLConditionColumn editedColumn = (BRLConditionColumn) editedMetaData.getColumn();
+
+        final Set<String> originalBindings = getPatternBindings(originalColumn);
+        final Set<String> editedBindings = getPatternBindings(editedColumn);
+        originalBindings.removeAll(editedBindings);
+        for (String binding : originalBindings) {
+            if (rm.isBoundFactUsed(binding)) {
+                throw new VetoUpdatePatternInUseException();
+            }
+        }
 
         final List<BaseColumnFieldDiff> diffs = originalColumn.diff(editedColumn);
 
         //Copy existing data for re-use if applicable
-        final Map<String, List<DTCellValue52>> originalColumnsData = new HashMap<String, List<DTCellValue52>>();
+        final Map<String, List<DTCellValue52>> originalColumnsData = new HashMap<>();
         for (BRLConditionVariableColumn variable : originalColumn.getChildColumns()) {
             int iColumnIndex = model.getExpandedColumns().indexOf(variable);
-            final List<DTCellValue52> originalColumnData = new ArrayList<DTCellValue52>();
+            final List<DTCellValue52> originalColumnData = new ArrayList<>();
             final String key = makeUpdateBRLConditionColumnKey(variable);
             for (List<DTCellValue52> row : model.getData()) {
                 originalColumnData.add(row.get(iColumnIndex));
@@ -118,7 +136,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -126,13 +144,27 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
         }
 
         final BRLConditionColumn column = (BRLConditionColumn) metaData.getColumn();
+
+        //If Pattern has been updated and there was only one child column then original Pattern will be deleted
+        for (IPattern p : column.getDefinition()) {
+            if (p instanceof FactPattern) {
+                final FactPattern fp = (FactPattern) p;
+                if (fp.isBound()) {
+                    final String binding = fp.getBoundName();
+                    if (rm.isBoundFactUsed(binding)) {
+                        throw new VetoDeletePatternInUseException();
+                    }
+                }
+            }
+        }
+
         if (column.getChildColumns().size() > 0) {
             final int iFirstColumnIndex = model.getExpandedColumns().indexOf(column.getChildColumns().get(0));
             for (int iColumnIndex = 0; iColumnIndex < column.getChildColumns().size(); iColumnIndex++) {
@@ -143,7 +175,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         return isBRLFragment(metaData);
     }
 
@@ -161,7 +193,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -169,24 +201,24 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
         if (isBRLFragment(metaData)) {
             doMoveBRLFragment(metaData);
         } else {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
     }
 
-    private void doMoveBRLFragment(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    private void doMoveBRLFragment(final List<MoveColumnToMetaData> metaData) throws VetoException {
         final MoveColumnToMetaData md = metaData.get(0);
         final BRLConditionVariableColumn srcModelColumn = (BRLConditionVariableColumn) md.getColumn();
         final BRLConditionColumn srcModelBRLFragment = model.getBRLColumn(srcModelColumn);
         if (srcModelBRLFragment == null) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         final List<BRLConditionVariableColumn> srcModelBRLFragmentColumns = srcModelBRLFragment.getChildColumns();
         final int srcModelPatternConditionColumnCount = srcModelBRLFragmentColumns.size();
         if (srcModelPatternConditionColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         if (srcModelPatternConditionColumnCount != metaData.size()) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final int tgtColumnIndex = md.getTargetColumnIndex();
@@ -205,5 +237,14 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
     private String makeUpdateBRLConditionColumnKey(final BRLConditionVariableColumn variable) {
         StringBuilder key = new StringBuilder(variable.getVarName()).append(":").append(variable.getFieldType()).append(":").append(variable.getFactField()).append(":").append(variable.getFactType());
         return key.toString();
+    }
+
+    private Set<String> getPatternBindings(final BRLConditionColumn column) {
+        final Set<String> bindings = new HashSet<>();
+        final List<IPattern> definition = column.getDefinition();
+        final RuleModel rm = new RuleModel();
+        rm.lhs = definition.toArray(new IPattern[definition.size()]);
+        bindings.addAll(rm.getLHSVariables(true, false));
+        return bindings;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseColumnSynchronizer.java
@@ -26,6 +26,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -53,12 +54,12 @@ public abstract class BaseColumnSynchronizer<A extends BaseColumnSynchronizer.Co
     }
 
     @Override
-    public boolean handlesInsert(final MetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesInsert(final MetaData metaData) throws VetoException {
         return false;
     }
 
     @Override
-    public void insert(final A metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void insert(final A metaData) throws VetoException {
         //Do nothing. Not implemented for columns. All operations are handled by Append.
     }
 
@@ -195,7 +196,7 @@ public abstract class BaseColumnSynchronizer<A extends BaseColumnSynchronizer.Co
         }
     }
 
-    protected int findTargetPatternIndex(final MoveColumnToMetaData md) throws ModelSynchronizer.MoveColumnVetoException {
+    protected int findTargetPatternIndex(final MoveColumnToMetaData md) throws ModelSynchronizer.MoveVetoException {
         int tgtPatternIndex = -1;
         final int tgtColumnIndex = md.getTargetColumnIndex();
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -217,12 +218,12 @@ public abstract class BaseColumnSynchronizer<A extends BaseColumnSynchronizer.Co
         }
 
         if (tgtPatternIndex < 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         return tgtPatternIndex;
     }
 
-    protected int findTargetActionIndex(final MoveColumnToMetaData md) throws ModelSynchronizer.MoveColumnVetoException {
+    protected int findTargetActionIndex(final MoveColumnToMetaData md) throws ModelSynchronizer.MoveVetoException {
         int tgtActionIndex = -1;
         final int tgtColumnIndex = md.getTargetColumnIndex();
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -244,7 +245,7 @@ public abstract class BaseColumnSynchronizer<A extends BaseColumnSynchronizer.Co
         }
 
         if (tgtActionIndex < 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         return tgtActionIndex;
     }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizer.java
@@ -31,12 +31,13 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.model.Guid
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.cell.GridWidgetCellFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.Synchronizer;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.CellUtilities;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.*;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 public abstract class BaseSynchronizer<A extends Synchronizer.MetaData, U extends Synchronizer.MetaData, D extends Synchronizer.MetaData> implements Synchronizer<A, U, D, BaseSynchronizer.MoveColumnToMetaData, BaseSynchronizer.MoveRowToMetaData> {
 
@@ -170,13 +171,13 @@ public abstract class BaseSynchronizer<A extends Synchronizer.MetaData, U extend
     }
 
     @Override
-    public boolean handlesMoveRowsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveRowsTo(final List<? extends MetaData> metaData) throws VetoException {
         return false;
     }
 
     @Override
-    public void moveRowsTo(final List<MoveRowToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
-        throw new ModelSynchronizer.MoveColumnVetoException();
+    public void moveRowsTo(final List<MoveRowToMetaData> metaData) throws VetoException {
+        throw new ModelSynchronizer.MoveVetoException();
     }
 
     protected void moveModelData(final int tgtColumnIndex,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizer.java
@@ -36,6 +36,9 @@ import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.gwt.BoundFactsChangedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.soup.project.datamodel.oracle.OperatorsOracle;
@@ -62,12 +65,12 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final PatternConditionMetaData metaData) {
+    public void append(final PatternConditionMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -90,13 +93,13 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         return metaData instanceof PatternConditionMetaData;
     }
 
     @Override
     public List<BaseColumnFieldDiff> update(final PatternConditionMetaData originalMetaData,
-                                            final PatternConditionMetaData editedMetaData) {
+                                            final PatternConditionMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -123,6 +126,15 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         final boolean isNewPattern = isNewPattern(editedPattern);
         final boolean isUpdatedPattern = BaseColumnFieldDiffImpl.hasChanged(Pattern52.FIELD_BOUND_NAME,
                                                                             diffs);
+
+        //Check if pattern change can be applied to model
+        if (isUpdatedPattern) {
+            if (!isPotentialPatternDeletionSafe(originalPattern)) {
+                throw new VetoUpdatePatternInUseException();
+            }
+        }
+
+        //Perform update
         if (isNewPattern || isUpdatedPattern) {
             append(editedMetaData);
             copyColumnData(originalColumn,
@@ -172,7 +184,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -180,7 +192,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -189,6 +201,13 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         final ConditionCol52 column = (ConditionCol52) metaData.getColumn();
         final int columnIndex = model.getExpandedColumns().indexOf(column);
         final Pattern52 pattern = model.getPattern(column);
+
+        //Check if pattern change can be applied to model
+        if (!isPotentialPatternDeletionSafe(pattern)) {
+            throw new VetoDeletePatternInUseException();
+        }
+
+        //Perform deletion
         pattern.getChildColumns().remove(column);
 
         //Remove pattern if it contains zero conditions
@@ -204,7 +223,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;
@@ -220,7 +239,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -230,7 +249,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         } else if (isSingleCondition(metaData)) {
             doMoveSingleCondition(metaData.get(0));
         } else {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
     }
 
@@ -262,20 +281,20 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         return metaData.get(0).getColumn() instanceof ConditionCol52;
     }
 
-    private void doMovePattern(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    private void doMovePattern(final List<MoveColumnToMetaData> metaData) throws VetoException {
         final MoveColumnToMetaData md = metaData.get(0);
         final ConditionCol52 srcModelColumn = (ConditionCol52) md.getColumn();
         final Pattern52 srcModelPattern = model.getPattern(srcModelColumn);
         if (srcModelPattern == null) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         final List<ConditionCol52> srcModelPatternConditionColumns = srcModelPattern.getChildColumns();
         final int srcModelPatternConditionColumnCount = srcModelPatternConditionColumns.size();
         if (srcModelPatternConditionColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
         if (srcModelPatternConditionColumnCount != metaData.size()) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final int tgtColumnIndex = md.getTargetColumnIndex();
@@ -292,17 +311,17 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
     }
 
     //Move a single Condition column; it must remain within the bounds of it's parent Pattern's columns
-    private void doMoveSingleCondition(final MoveColumnToMetaData metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    private void doMoveSingleCondition(final MoveColumnToMetaData metaData) throws VetoException {
         final ConditionCol52 modelColumn = (ConditionCol52) metaData.getColumn();
         final Pattern52 modelPattern = model.getPattern(modelColumn);
         if (modelPattern == null) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<ConditionCol52> modelPatternConditionColumns = modelPattern.getChildColumns();
         final int modelPatternConditionColumnCount = modelPatternConditionColumns.size();
         if (modelPatternConditionColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -312,7 +331,7 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         final int targetColumnIndex = metaData.getTargetColumnIndex();
         final int sourceColumnIndex = metaData.getSourceColumnIndex();
         if (targetColumnIndex < minColumnIndex || targetColumnIndex > maxColumnIndex) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         moveModelData(targetColumnIndex,
@@ -446,5 +465,15 @@ public class ConditionColumnSynchronizer extends BaseColumnSynchronizer<PatternC
         if (originalColumn instanceof LimitedEntryCol && editedColumn instanceof LimitedEntryCol) {
             ((LimitedEntryCol) originalColumn).setValue(((LimitedEntryCol) editedColumn).getValue());
         }
+    }
+
+    private boolean isPotentialPatternDeletionSafe(final Pattern52 pattern) {
+        if (pattern.getChildColumns().size() == 1) {
+            final String binding = pattern.getBoundName();
+            if (!(binding == null || binding.isEmpty())) {
+                return !rm.isBoundFactUsed(binding);
+            }
+        }
+        return true;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -27,6 +28,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseColumnSynchronizer.ColumnMetaData;
 
@@ -39,12 +41,12 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -56,7 +58,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -65,7 +67,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -99,7 +101,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -107,7 +109,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -120,7 +122,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;
@@ -134,7 +136,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -146,7 +148,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
         final List<ActionCol52> modelActionColumns = model.getActionCols();
         final int modelActionColumnCount = modelActionColumns.size();
         if (modelActionColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -156,7 +158,7 @@ public class LimitedEntryBRLActionColumnSynchronizer extends BaseColumnSynchroni
         final int targetColumnIndex = md.getTargetColumnIndex();
         final int sourceColumnIndex = md.getSourceColumnIndex();
         if (targetColumnIndex < minColumnIndex || targetColumnIndex > maxColumnIndex) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         moveModelData(targetColumnIndex,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
@@ -27,6 +28,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseColumnSynchronizer.ColumnMetaData;
 
@@ -39,12 +41,12 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final ColumnMetaData metaData) {
+    public void append(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -56,7 +58,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -65,7 +67,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
 
     @Override
     public List<BaseColumnFieldDiff> update(final ColumnMetaData originalMetaData,
-                                            final ColumnMetaData editedMetaData) {
+                                            final ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -99,7 +101,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -107,7 +109,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public void delete(final ColumnMetaData metaData) {
+    public void delete(final ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -120,7 +122,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;
@@ -134,7 +136,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -146,7 +148,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
         final List<CompositeColumn<? extends BaseColumn>> modelConditionColumns = model.getConditions();
         final int modelConditionColumnCount = modelConditionColumns.size();
         if (modelConditionColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -156,7 +158,7 @@ public class LimitedEntryBRLConditionColumnSynchronizer extends BaseColumnSynchr
         final int targetColumnIndex = md.getTargetColumnIndex();
         final int sourceColumnIndex = md.getSourceColumnIndex();
         if (targetColumnIndex < minColumnIndex || targetColumnIndex > maxColumnIndex) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         moveModelData(targetColumnIndex,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizer.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
@@ -26,17 +27,18 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 
 @Dependent
 public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData, BaseColumnSynchronizer.ColumnMetaData> {
 
     @Override
-    public boolean handlesAppend(final MetaData metaData) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return handlesUpdate(metaData);
     }
 
     @Override
-    public void append(final BaseColumnSynchronizer.ColumnMetaData metaData) {
+    public void append(final BaseColumnSynchronizer.ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesAppend(metaData)) {
             return;
@@ -48,7 +50,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
     }
 
     @Override
-    public boolean handlesUpdate(final MetaData metaData) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -57,7 +59,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
 
     @Override
     public List<BaseColumnFieldDiff> update(final BaseColumnSynchronizer.ColumnMetaData originalMetaData,
-                                            final BaseColumnSynchronizer.ColumnMetaData editedMetaData) {
+                                            final BaseColumnSynchronizer.ColumnMetaData editedMetaData) throws VetoException {
         //Check operation is supported
         if (!(handlesUpdate(originalMetaData) && handlesUpdate(editedMetaData))) {
             return Collections.emptyList();
@@ -96,7 +98,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
     }
 
     @Override
-    public boolean handlesDelete(final MetaData metaData) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         if (!(metaData instanceof ColumnMetaData)) {
             return false;
         }
@@ -104,7 +106,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
     }
 
     @Override
-    public void delete(final BaseColumnSynchronizer.ColumnMetaData metaData) {
+    public void delete(final BaseColumnSynchronizer.ColumnMetaData metaData) throws VetoException {
         //Check operation is supported
         if (!handlesDelete(metaData)) {
             return;
@@ -117,7 +119,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
     }
 
     @Override
-    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         for (MetaData md : metaData) {
             if (!(md instanceof MoveColumnToMetaData)) {
                 return false;
@@ -131,7 +133,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
     }
 
     @Override
-    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Check operation is supported
         if (!handlesMoveColumnsTo(metaData)) {
             return;
@@ -143,7 +145,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
         final List<MetadataCol52> modelMetaDataColumns = model.getMetadataCols();
         final int modelMetaDataColumnCount = modelMetaDataColumns.size();
         if (modelMetaDataColumnCount == 0) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         final List<BaseColumn> allModelColumns = model.getExpandedColumns();
@@ -153,7 +155,7 @@ public class MetaDataColumnSynchronizer extends BaseColumnSynchronizer<BaseColum
         final int targetColumnIndex = md.getTargetColumnIndex();
         final int sourceColumnIndex = md.getSourceColumnIndex();
         if (targetColumnIndex < minColumnIndex || targetColumnIndex > maxColumnIndex) {
-            throw new ModelSynchronizer.MoveColumnVetoException();
+            throw new ModelSynchronizer.MoveVetoException();
         }
 
         moveModelData(targetColumnIndex,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerImpl.java
@@ -60,12 +60,12 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseColumnSynchronizer.MetaData;
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.*;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.MoveColumnToMetaData;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.MoveColumnToMetaDataImpl;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.MoveRowToMetaData;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.MoveRowToMetaDataImpl;
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities.*;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.ConditionColumnSynchronizer.PatternConditionMetaData;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities.Context;
 
 /**
  * Handles synchronization of Model and UI-Model
@@ -207,7 +207,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void appendColumn(final BaseColumn column) throws MoveColumnVetoException {
+    public void appendColumn(final BaseColumn column) throws VetoException {
         final MetaData metaData = new BaseColumnSynchronizer.ColumnMetaDataImpl(column);
         for (Synchronizer synchronizer : synchronizers) {
             if (synchronizer.handlesAppend(metaData)) {
@@ -222,7 +222,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     @Override
     @SuppressWarnings("unchecked")
     public void appendColumn(final Pattern52 pattern,
-                             final ConditionCol52 column) throws MoveColumnVetoException {
+                             final ConditionCol52 column) throws VetoException {
         final PatternConditionMetaData metaData = new PatternConditionMetaData(pattern,
                                                                                column);
         for (Synchronizer synchronizer : synchronizers) {
@@ -236,7 +236,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void deleteColumn(final BaseColumn column) throws MoveColumnVetoException {
+    public void deleteColumn(final BaseColumn column) throws VetoException {
         final int columnIndex = model.getExpandedColumns().indexOf(column);
         final MetaData metaData = new BaseColumnSynchronizer.ColumnMetaDataImpl(column);
         for (Synchronizer synchronizer : synchronizers) {
@@ -253,7 +253,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     public List<BaseColumnFieldDiff> updateColumn(final Pattern52 originalPattern,
                                                   final ConditionCol52 originalColumn,
                                                   final Pattern52 editedPattern,
-                                                  final ConditionCol52 editedColumn) throws MoveColumnVetoException {
+                                                  final ConditionCol52 editedColumn) throws VetoException {
         final PatternConditionMetaData originalMetaData = new PatternConditionMetaData(originalPattern,
                                                                                        originalColumn);
 
@@ -271,7 +271,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     @Override
     @SuppressWarnings("unchecked")
     public List<BaseColumnFieldDiff> updateColumn(final BaseColumn originalColumn,
-                                                  final BaseColumn editedColumn) throws MoveColumnVetoException {
+                                                  final BaseColumn editedColumn) throws VetoException {
         final MetaData originalMetaData = new BaseColumnSynchronizer.ColumnMetaDataImpl(originalColumn);
         final MetaData editedMetaData = new BaseColumnSynchronizer.ColumnMetaDataImpl(editedColumn);
         for (Synchronizer synchronizer : synchronizers) {
@@ -293,7 +293,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void appendRow() throws MoveColumnVetoException {
+    public void appendRow() throws VetoException {
         final MetaData metaData = new RowSynchronizer.RowMetaDataImpl();
         for (Synchronizer synchronizer : synchronizers) {
             if (synchronizer.handlesAppend(metaData)) {
@@ -307,7 +307,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     }
 
     @Override
-    public void insertRow(final int rowIndex) throws MoveColumnVetoException {
+    public void insertRow(final int rowIndex) throws VetoException {
         final MetaData metaData = new RowSynchronizer.RowMetaDataImpl(rowIndex);
         for (Synchronizer synchronizer : synchronizers) {
             if (synchronizer.handlesInsert(metaData)) {
@@ -322,7 +322,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void deleteRow(final int rowIndex) throws MoveColumnVetoException {
+    public void deleteRow(final int rowIndex) throws VetoException {
         final MetaData metaData = new RowSynchronizer.RowMetaDataImpl(rowIndex);
         for (Synchronizer synchronizer : synchronizers) {
             if (synchronizer.handlesDelete(metaData)) {
@@ -338,10 +338,10 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     @Override
     @SuppressWarnings("unchecked")
     public void moveColumnTo(final int targetColumnIndex,
-                             final GridColumn<?> column) throws MoveColumnVetoException {
+                             final GridColumn<?> column) throws VetoException {
         final int sourceColumnIndex = uiModel.getColumns().indexOf(column);
         if (sourceColumnIndex == targetColumnIndex) {
-            throw new MoveColumnVetoException();
+            throw new MoveVetoException();
         }
 
         final BaseColumn modelColumn = model.getExpandedColumns().get(sourceColumnIndex);
@@ -361,7 +361,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
         }
 
         if (handlers.isEmpty()) {
-            throw new MoveColumnVetoException();
+            throw new MoveVetoException();
         }
 
         for (Synchronizer synchronizer : handlers) {
@@ -372,14 +372,14 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     @Override
     @SuppressWarnings("unchecked")
     public void moveColumnsTo(final int targetColumnIndex,
-                              final List<GridColumn<?>> columns) throws MoveColumnVetoException {
+                              final List<GridColumn<?>> columns) throws VetoException {
         //Generate meta-data to handle moves
         final List<MoveColumnToMetaData> metaData = new ArrayList<MoveColumnToMetaData>();
         for (int index = 0; index < columns.size(); index++) {
             final GridColumn<?> column = columns.get(index);
             final int sourceColumnIndex = uiModel.getColumns().indexOf(column);
             if (sourceColumnIndex == targetColumnIndex) {
-                throw new MoveColumnVetoException();
+                throw new MoveVetoException();
             }
 
             final BaseColumn modelColumn = model.getExpandedColumns().get(sourceColumnIndex);
@@ -397,7 +397,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
         }
 
         if (handler == null) {
-            throw new MoveColumnVetoException();
+            throw new MoveVetoException();
         }
 
         handler.moveColumnsTo(metaData);
@@ -406,14 +406,14 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
     @Override
     @SuppressWarnings("unchecked")
     public void moveRowsTo(final int targetRowIndex,
-                           final List<GridRow> rows) throws MoveColumnVetoException {
+                           final List<GridRow> rows) throws VetoException {
         //Generate meta-data to handle moves
         final List<MoveRowToMetaData> metaData = new ArrayList<MoveRowToMetaData>();
         for (int index = 0; index < rows.size(); index++) {
             final GridRow row = rows.get(index);
             final int sourceRowIndex = uiModel.getRows().indexOf(row);
             if (sourceRowIndex == targetRowIndex) {
-                throw new MoveColumnVetoException();
+                throw new MoveVetoException();
             }
 
             final List<DTCellValue52> modelRow = model.getData().get(sourceRowIndex);
@@ -430,7 +430,7 @@ public class ModelSynchronizerImpl implements ModelSynchronizer {
         }
 
         if (handlers.isEmpty()) {
-            throw new MoveColumnVetoException();
+            throw new MoveVetoException();
         }
 
         for (Synchronizer synchronizer : handlers) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/RowSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/RowSynchronizer.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
@@ -26,14 +27,14 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.RowNumberCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.Synchronizer;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
-import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.RowSynchronizer.*;
+import static org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.RowSynchronizer.RowMetaData;
 
 @Dependent
 public class RowSynchronizer extends BaseSynchronizer<RowMetaData, RowMetaData, RowMetaData> {
@@ -41,7 +42,6 @@ public class RowSynchronizer extends BaseSynchronizer<RowMetaData, RowMetaData, 
     public interface RowMetaData extends Synchronizer.MetaData {
 
         int getRowIndex();
-
     }
 
     public static class RowMetaDataImpl implements RowMetaData {
@@ -49,10 +49,10 @@ public class RowSynchronizer extends BaseSynchronizer<RowMetaData, RowMetaData, 
         private final int rowIndex;
 
         public RowMetaDataImpl() {
-            this( -1 );
+            this(-1);
         }
 
-        public RowMetaDataImpl( final int rowIndex ) {
+        public RowMetaDataImpl(final int rowIndex) {
             this.rowIndex = rowIndex;
         }
 
@@ -60,125 +60,124 @@ public class RowSynchronizer extends BaseSynchronizer<RowMetaData, RowMetaData, 
         public int getRowIndex() {
             return rowIndex;
         }
-
     }
 
     @Override
-    public boolean handlesAppend( final MetaData metaData ) {
+    public boolean handlesAppend(final MetaData metaData) throws VetoException {
         return metaData instanceof RowMetaData;
     }
 
     @Override
-    public void append( final RowMetaData metaData ) {
-        if ( !handlesAppend( metaData ) ) {
+    public void append(final RowMetaData metaData) throws VetoException {
+        if (!handlesAppend(metaData)) {
             return;
         }
         final List<DTCellValue52> modelRow = new ArrayList<DTCellValue52>();
-        model.getData().add( modelRow );
+        model.getData().add(modelRow);
 
-        final GridRow uiModelRow = new BaseGridRow( GuidedDecisionTableView.ROW_HEIGHT );
-        uiModel.appendRow( uiModelRow );
+        final GridRow uiModelRow = new BaseGridRow(GuidedDecisionTableView.ROW_HEIGHT);
+        uiModel.appendRow(uiModelRow);
 
         final int rowIndex = uiModel.getRowCount() - 1;
-        initialiseRowData( rowIndex );
+        initialiseRowData(rowIndex);
     }
 
     @Override
-    public boolean handlesInsert( final MetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesInsert(final MetaData metaData) throws VetoException {
         return metaData instanceof RowMetaData;
     }
 
     @Override
-    public void insert( final RowMetaData metaData ) throws ModelSynchronizer.MoveColumnVetoException {
-        if ( !handlesAppend( metaData ) ) {
+    public void insert(final RowMetaData metaData) throws VetoException {
+        if (!handlesAppend(metaData)) {
             return;
         }
         final int rowIndex = metaData.getRowIndex();
         final List<DTCellValue52> modelRow = new ArrayList<DTCellValue52>();
-        model.getData().add( rowIndex,
-                             modelRow );
+        model.getData().add(rowIndex,
+                            modelRow);
 
-        final GridRow uiModelRow = new BaseGridRow( GuidedDecisionTableView.ROW_HEIGHT );
-        uiModel.insertRow( rowIndex,
-                           uiModelRow );
+        final GridRow uiModelRow = new BaseGridRow(GuidedDecisionTableView.ROW_HEIGHT);
+        uiModel.insertRow(rowIndex,
+                          uiModelRow);
 
-        initialiseRowData( rowIndex );
+        initialiseRowData(rowIndex);
     }
 
-    private void initialiseRowData( final int rowIndex ) {
+    private void initialiseRowData(final int rowIndex) {
         final List<BaseColumn> modelColumns = model.getExpandedColumns();
-        final List<DTCellValue52> modelRow = model.getData().get( rowIndex );
-        for ( int columnIndex = 0; columnIndex < modelColumns.size(); columnIndex++ ) {
-            final BaseColumn modelColumn = modelColumns.get( columnIndex );
-            final DTCellValue52 modelCell = makeModelCellValue( modelColumn );
-            modelRow.add( modelCell );
+        final List<DTCellValue52> modelRow = model.getData().get(rowIndex);
+        for (int columnIndex = 0; columnIndex < modelColumns.size(); columnIndex++) {
+            final BaseColumn modelColumn = modelColumns.get(columnIndex);
+            final DTCellValue52 modelCell = makeModelCellValue(modelColumn);
+            modelRow.add(modelCell);
 
             //BaseGridData is sparsely populated; only add values if needed.
-            if ( modelCell.hasValue() ) {
-                uiModel.setCellInternal( rowIndex,
-                                         columnIndex,
-                                         gridWidgetCellFactory.convertCell( modelCell,
-                                                                            modelColumn,
-                                                                            cellUtilities,
-                                                                            columnUtilities ) );
+            if (modelCell.hasValue()) {
+                uiModel.setCellInternal(rowIndex,
+                                        columnIndex,
+                                        gridWidgetCellFactory.convertCell(modelCell,
+                                                                          modelColumn,
+                                                                          cellUtilities,
+                                                                          columnUtilities));
             }
-            uiModel.indexColumn( columnIndex );
+            uiModel.indexColumn(columnIndex);
 
             //Set-up SelectionManager for Row Number column, to select entire row.
-            if ( modelColumn instanceof RowNumberCol52 ) {
-                uiModel.getCell( rowIndex,
-                                 columnIndex ).setSelectionManager( RowSelectionStrategy.INSTANCE );
+            if (modelColumn instanceof RowNumberCol52) {
+                uiModel.getCell(rowIndex,
+                                columnIndex).setSelectionManager(RowSelectionStrategy.INSTANCE);
             }
         }
     }
 
     @Override
-    public boolean handlesUpdate( final MetaData metaData ) {
+    public boolean handlesUpdate(final MetaData metaData) throws VetoException {
         //We don't support updating a row at present, but we could; e.g. clear all values etc
         return false;
     }
 
     @Override
-    public List<BaseColumnFieldDiff> update( final RowMetaData originalMetaData,
-                                             final RowMetaData editedMetaData ) {
+    public List<BaseColumnFieldDiff> update(final RowMetaData originalMetaData,
+                                            final RowMetaData editedMetaData) throws VetoException {
         //We don't support updating a row at present, but we could; e.g. clear all values etc
         return Collections.emptyList();
     }
 
     @Override
-    public boolean handlesDelete( final MetaData metaData ) {
+    public boolean handlesDelete(final MetaData metaData) throws VetoException {
         return metaData instanceof RowMetaData;
     }
 
     @Override
-    public void delete( final RowMetaData metaData ) {
-        if ( !handlesDelete( metaData ) ) {
+    public void delete(final RowMetaData metaData) throws VetoException {
+        if (!handlesDelete(metaData)) {
             return;
         }
         final int rowIndex = metaData.getRowIndex();
-        final GridData.Range rowRange = uiModel.deleteRow( rowIndex );
+        final GridData.Range rowRange = uiModel.deleteRow(rowIndex);
         final int minRowIndex = rowRange.getMinRowIndex();
         final int maxRowIndex = rowRange.getMaxRowIndex();
-        for ( int ri = minRowIndex; ri <= maxRowIndex; ri++ ) {
-            model.getData().remove( minRowIndex );
+        for (int ri = minRowIndex; ri <= maxRowIndex; ri++) {
+            model.getData().remove(minRowIndex);
         }
     }
 
     @Override
-    public boolean handlesMoveColumnsTo( final List<? extends MetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException {
+    public boolean handlesMoveColumnsTo(final List<? extends MetaData> metaData) throws VetoException {
         //Moving Row data is delegated to each respective Column Synchronizer
         return false;
     }
 
     @Override
-    public void moveColumnsTo( final List<MoveColumnToMetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveColumnsTo(final List<MoveColumnToMetaData> metaData) throws VetoException {
         //Moving Row data is delegated to each respective Column Synchronizer
     }
 
     @Override
-    public boolean handlesMoveRowsTo( final List<? extends MetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException {
-        for ( MetaData md : metaData ) {
-            if ( !( md instanceof MoveRowToMetaData ) ) {
+    public boolean handlesMoveRowsTo(final List<? extends MetaData> metaData) throws VetoException {
+        for (MetaData md : metaData) {
+            if (!(md instanceof MoveRowToMetaData)) {
                 return false;
             }
         }
@@ -186,29 +185,27 @@ public class RowSynchronizer extends BaseSynchronizer<RowMetaData, RowMetaData, 
     }
 
     @Override
-    public void moveRowsTo( final List<MoveRowToMetaData> metaData ) throws ModelSynchronizer.MoveColumnVetoException {
+    public void moveRowsTo(final List<MoveRowToMetaData> metaData) throws VetoException {
         //Check operation is supported
-        if ( !handlesMoveRowsTo( metaData ) ) {
+        if (!handlesMoveRowsTo(metaData)) {
             return;
         }
 
-        for ( int idx = 0; idx < metaData.size(); idx++ ) {
-            final MoveRowToMetaData md = metaData.get( idx );
+        for (int idx = 0; idx < metaData.size(); idx++) {
+            final MoveRowToMetaData md = metaData.get(idx);
             final int sourceRowIndex = md.getSourceRowIndex();
             final int targetRowIndex = md.getTargetRowIndex();
             final List<DTCellValue52> row = md.getRow();
 
-            if ( targetRowIndex < sourceRowIndex ) {
-                model.getData().remove( sourceRowIndex );
-                model.getData().add( targetRowIndex,
-                                     row );
-
-            } else if ( targetRowIndex > sourceRowIndex ) {
-                model.getData().remove( sourceRowIndex - idx );
-                model.getData().add( targetRowIndex - idx,
-                                     row );
+            if (targetRowIndex < sourceRowIndex) {
+                model.getData().remove(sourceRowIndex);
+                model.getData().add(targetRowIndex,
+                                    row);
+            } else if (targetRowIndex > sourceRowIndex) {
+                model.getData().remove(sourceRowIndex - idx);
+                model.getData().add(targetRowIndex - idx,
+                                    row);
             }
         }
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizard.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/NewGuidedDecisionTableColumnWizard.java
@@ -33,6 +33,7 @@ import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.com
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons.DecisionTableColumnPlugin;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.client.callbacks.Callback;
+import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.ext.widgets.core.client.wizards.AbstractWizard;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardView;
@@ -200,14 +201,6 @@ public class NewGuidedDecisionTableColumnWizard extends AbstractWizard {
         super.close();
     }
 
-    private WizardView getView() {
-        return view;
-    }
-
-    public void goTo(final int index) {
-        getView().selectPage(index);
-    }
-
     public void init(final GuidedDecisionTableView.Presenter presenter) {
         this.presenter = presenter;
     }
@@ -222,6 +215,14 @@ public class NewGuidedDecisionTableColumnWizard extends AbstractWizard {
 
     public GuidedDecisionTableView.Presenter getPresenter() {
         return presenter;
+    }
+
+    public void showGenericVetoError() {
+        ErrorPopup.showMessage(translate(GuidedDecisionTableErraiConstants.NewGuidedDecisionTableColumnWizard_GenericVetoError));
+    }
+
+    public void showPatternInUseError() {
+        ErrorPopup.showMessage(translate(GuidedDecisionTableErraiConstants.NewGuidedDecisionTableColumnWizard_UpdatePatternInUseVetoError));
     }
 
     private String translate(final String key,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionRetractFactPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionRetractFactPlugin.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -31,6 +32,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryActionRetractFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
@@ -92,8 +94,13 @@ public class ActionRetractFactPlugin extends BaseDecisionTableColumnPlugin imple
         if (isNewColumn()) {
             presenter.appendColumn(editingCol());
         } else {
-            presenter.updateColumn(originalCol(),
-                                   editingCol());
+            try {
+                presenter.updateColumn(originalCol(),
+                                       editingCol());
+            } catch (VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPlugin.java
@@ -37,6 +37,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasFieldPage;
@@ -169,8 +170,13 @@ public class ActionSetFactPlugin extends BaseDecisionTableColumnPlugin implement
         if (isNewColumn()) {
             presenter.appendColumn(editingCol());
         } else {
-            presenter.updateColumn(originalCol(),
-                                   editingCol());
+            try {
+                presenter.updateColumn(originalCol(),
+                                       editingCol());
+            } catch (ModelSynchronizer.VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemPlugin.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -29,6 +30,7 @@ import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasWorkItemPage;
@@ -255,12 +257,16 @@ public class ActionWorkItemPlugin extends BaseDecisionTableColumnPlugin implemen
 
     @Override
     public Boolean generateColumn() {
-
         if (isNewColumn()) {
             presenter.appendColumn(editingCol());
         } else {
-            presenter.updateColumn(originalCol(),
-                                   editingCol());
+            try {
+                presenter.updateColumn(originalCol(),
+                                       editingCol());
+            } catch (ModelSynchronizer.VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPlugin.java
@@ -41,6 +41,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BRLRuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasFieldPage;
@@ -369,8 +370,13 @@ public class ActionWorkItemSetFieldPlugin extends BaseDecisionTableColumnPlugin 
         if (isNewColumn()) {
             presenter.appendColumn(actionCol52);
         } else {
-            presenter.updateColumn(originalCol(),
-                                   actionCol52);
+            try {
+                presenter.updateColumn(originalCol(),
+                                       editingCol());
+            } catch (ModelSynchronizer.VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLActionColumnPlugin.java
@@ -43,6 +43,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasRuleModellerPage;
@@ -149,8 +150,13 @@ public class BRLActionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
         if (isNewColumn()) {
             presenter.appendColumn(editingCol());
         } else {
-            presenter.updateColumn(originalCol(),
-                                   editingCol());
+            try {
+                presenter.updateColumn(originalCol(),
+                                       editingCol());
+            } catch (ModelSynchronizer.VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
@@ -44,11 +44,13 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
-import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.RuleModelCloneVisitor;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasAdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.commons.HasRuleModellerPage;
@@ -132,8 +134,16 @@ public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin impl
         if (isNewColumn()) {
             presenter.appendColumn(editingCol());
         } else {
-            presenter.updateColumn(getOriginalColumn(),
-                                   editingCol());
+            try {
+                presenter.updateColumn(getOriginalColumn(),
+                                       editingCol());
+            } catch (VetoUpdatePatternInUseException veto) {
+                wizard.showPatternInUseError();
+                return false;
+            } catch (VetoException veto) {
+                wizard.showGenericVetoError();
+                return false;
+            }
         }
 
         return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ConditionColumnPlugin.java
@@ -44,6 +44,8 @@ import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.models.guided.dtable.shared.model.adaptors.FactPatternPattern52Adaptor;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.Validator;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.CellUtilities;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
@@ -162,7 +164,15 @@ public class ConditionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
     @Override
     public Boolean generateColumn() {
         prepareValues();
-        appendColumn();
+        try {
+            appendColumn();
+        } catch (VetoUpdatePatternInUseException veto) {
+            wizard.showPatternInUseError();
+            return false;
+        } catch (VetoException veto) {
+            wizard.showGenericVetoError();
+            return false;
+        }
 
         return true;
     }
@@ -172,7 +182,7 @@ public class ConditionColumnPlugin extends BaseDecisionTableColumnPlugin impleme
         return Type.BASIC;
     }
 
-    void appendColumn() {
+    void appendColumn() throws VetoException {
         if (isNewColumn()) {
             presenter.appendColumn(editingPattern(),
                                    editingCol());

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/BaseDecisionTableColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/BaseDecisionTableColumnPlugin.java
@@ -17,13 +17,12 @@
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.commons;
 
 import java.util.Optional;
+
 import javax.enterprise.event.Event;
 
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/BaseDecisionTableColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/BaseDecisionTableColumnPlugin.java
@@ -22,6 +22,8 @@ import javax.enterprise.event.Event;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
@@ -98,13 +100,13 @@ public abstract class BaseDecisionTableColumnPlugin implements DecisionTableColu
                                          args);
     }
 
-    private void setupFinishCommand() {
-        wizard.setFinishCommand(this::generateColumn);
-    }
-
     private void setupCommands() {
         setupFinishCommand();
         setupCloseCommand();
+    }
+
+    private void setupFinishCommand() {
+        wizard.setFinishCommand(this::generateColumn);
     }
 
     private void setupCloseCommand() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/DecisionTableColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/DecisionTableColumnPlugin.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/DecisionTableColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/commons/DecisionTableColumnPlugin.java
@@ -21,8 +21,6 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
@@ -199,7 +199,7 @@ ValueOptionsPage.DefaultValueDescription=(optional) Enter or select one of the p
                                          automatically in a new row. You can also select any previously configured Data Enumerations in the project as a default value. \
                                          If the default value is not specified, the table cell will be blank by default.
 ValueOptionsPage.BindingDescription=(optional) Define a binding for the previously selected field, if needed. (Example: For pattern <b>LoanApplication [application]</b>, field <b>amount</b>, \
-                                    and operator <b>equal to<b>, if binding is set to <b>$amount<b>, the end condition will be <b>application : LoanApplication($amount : amount == [value])</b>).
+                                    and operator <b>equal to</b>, if binding is set to <b>$amount</b>, the end condition will be <b>application : LoanApplication($amount : amount == [value])</b>).
 WorkItemPage.WorkItem=Work Item
 ActionInsertFactPlugin.SetTheValueOfAField=Set the value of a field
 ActionRetractFactPlugin.DeleteAnExistingFact=Delete an existing fact
@@ -212,6 +212,9 @@ ConditionColumnPlugin.AddConditionColumn=Add a Condition
 MetaDataColumnPlugin.AddMetadataColumn=Add a Metadata column
 NewGuidedDecisionTableColumnWizard.AddNewColumn=Add a new column
 NewGuidedDecisionTableColumnWizard.EditColumn=Edit column
+NewGuidedDecisionTableColumnWizard.GenericVetoError=Cannot update column. Operation was vetoed.
+NewGuidedDecisionTableColumnWizard.UpdatePatternInUseVetoError=<p>Cannot update column as it defines a Pattern used by one or more Actions.</p><p>Please delete the Action, or Actions, first and try again.</p>
+NewGuidedDecisionTableColumnWizard.DeletePatternInUseVetoError0=<p>Cannot delete column '{0}' as it defines a Pattern used by one or more Actions.</p><p>Please delete the Action, or Actions, first and try again.</p>
 BRLConditionColumnPlugin.AddConditionBRL=Add a Condition BRL fragment
 BRLActionColumnPlugin.AddActionBRL=Add an Action BRL fragment
 PatternToDeletePage.Pattern=Pattern

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImplTest.java
@@ -63,9 +63,11 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.co
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.AttributeColumnConfigRowView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.ColumnLabelWidget;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.ColumnManagementView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control.DeleteColumnManagementAnchorWidget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,8 +83,21 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedM
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 @WithClassesToStub({ColumnLabelWidget.class, GridLienzoPanel.class, DefaultGridLayer.class, GridWidget.class, RestrictedMousePanMediator.class})
@@ -131,10 +146,10 @@ public class GuidedDecisionTableModellerViewImplTest {
     private ColumnManagementView columnManagementView;
 
     @Mock
-    private VerticalPanel actionsConfigWidget;
+    private ColumnManagementView actionsConfigWidget;
 
     @Mock
-    private VerticalPanel conditionsConfigWidget;
+    private ColumnManagementView conditionsConfigWidget;
 
     @Captor
     private ArgumentCaptor<Map<String, List<BaseColumn>>> capturedGroups;
@@ -142,11 +157,22 @@ public class GuidedDecisionTableModellerViewImplTest {
     @Mock
     private ManagedInstance<AttributeColumnConfigRow> attributeColumnConfigRows;
 
+    @Mock
+    private ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets;
+
+    @Mock
+    private TranslationService translationService;
+
     private GuidedDecisionTableModellerViewImpl view;
 
     @Before
     public void setup() {
-        view = spy(new GuidedDecisionTableModellerViewImplFake());
+        view = spy(new GuidedDecisionTableModellerViewImplFake(actionsConfigWidget,
+                                                               conditionsConfigWidget,
+                                                               attributeColumnConfigRows,
+                                                               deleteColumnManagementAnchorWidgets,
+                                                               accordion,
+                                                               translationService));
 
         ApplicationPreferences.setUp(new HashMap<String, String>() {{
             put(ApplicationPreferences.DATE_FORMAT,
@@ -737,7 +763,18 @@ public class GuidedDecisionTableModellerViewImplTest {
 
     class GuidedDecisionTableModellerViewImplFake extends GuidedDecisionTableModellerViewImpl {
 
-        public GuidedDecisionTableModellerViewImplFake() {
+        public GuidedDecisionTableModellerViewImplFake(final ColumnManagementView actionsPanel,
+                                                       final ColumnManagementView conditionsPanel,
+                                                       final ManagedInstance<AttributeColumnConfigRow> attributeColumnConfigRows,
+                                                       final ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets,
+                                                       final GuidedDecisionTableAccordion guidedDecisionTableAccordion,
+                                                       final TranslationService translationService) {
+            super(actionsPanel,
+                  conditionsPanel,
+                  attributeColumnConfigRows,
+                  deleteColumnManagementAnchorWidgets,
+                  guidedDecisionTableAccordion,
+                  translationService);
             this.gridPanel = mockGridPanel;
             this.pinnedModeIndicator = GuidedDecisionTableModellerViewImplTest.this.pinnedModeIndicator;
             doReturn(mock(AttributeColumnConfigRow.class)).when(attributeColumnConfigRows).get();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterAttributesAndMetadataTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterAttributesAndMetadataTest.java
@@ -24,7 +24,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,8 +32,13 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseGuidedDecisionTablePresenterTest {
@@ -67,7 +72,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void appendAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendAttributeColumn() throws VetoException {
         reset(modellerPresenter);
 
         final AttributeCol52 column = new AttributeCol52();
@@ -84,7 +89,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void appendMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendMetadataColumn() throws VetoException {
         reset(modellerPresenter);
 
         final MetadataCol52 column = new MetadataCol52();
@@ -101,7 +106,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void deleteAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteAttributeColumn() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
         column.setAttribute(RuleAttributeWidget.AUTO_FOCUS_ATTR);
         dtPresenter.appendColumn(column);
@@ -116,7 +121,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void deleteMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteMetadataColumn() throws VetoException {
         final MetadataCol52 column = new MetadataCol52();
         column.setMetadata("metadata");
         dtPresenter.appendColumn(column);
@@ -131,7 +136,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void updateAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateAttributeColumn() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
         column.setAttribute(RuleAttributeWidget.AUTO_FOCUS_ATTR);
         dtPresenter.appendColumn(column);
@@ -151,7 +156,7 @@ public class GuidedDecisionTablePresenterAttributesAndMetadataTest extends BaseG
     }
 
     @Test
-    public void updateMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateMetadataColumn() throws VetoException {
         final MetadataCol52 column = new MetadataCol52();
         column.setMetadata("metadata");
         dtPresenter.appendColumn(column);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -30,11 +30,8 @@ import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.google.gwt.user.client.Command;
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.kie.soup.project.datamodel.oracle.DataType;
-import org.kie.soup.project.datamodel.oracle.DropDownData;
 import org.drools.workbench.models.datamodel.rule.ActionFieldValue;
 import org.drools.workbench.models.datamodel.rule.ActionInsertFact;
-import org.drools.workbench.models.datamodel.rule.FactPattern;
 import org.drools.workbench.models.datamodel.rule.FieldNatureType;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
@@ -52,7 +49,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableLinkManager.LinkFoundCallback;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
@@ -83,8 +80,23 @@ import org.uberfire.mvp.PlaceRequest;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.CURRENT_USER;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.NOBODY;
 import static org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access.LockedBy.OTHER_USER;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePresenterTest {
@@ -875,87 +887,6 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void canConditionBeDeletedWithSingleChildColumnWithAction() {
-        final Pattern52 pattern = new Pattern52();
-        pattern.setFactType("FactType1");
-        pattern.setBoundName("$fact");
-        final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField("field1");
-        pattern.getChildColumns().add(condition1);
-
-        dtPresenter.getModel().getConditions().add(pattern);
-
-        final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType("FactType1");
-        action.setBoundName("$fact");
-        action.setFactField("field");
-
-        dtPresenter.getModel().getActionCols().add(action);
-
-        assertFalse(dtPresenter.canConditionBeDeleted(condition1));
-    }
-
-    @Test
-    public void canConditionBeDeletedWithSingleChildColumnWithNoAction() {
-        final Pattern52 pattern = new Pattern52();
-        pattern.setFactType("FactType1");
-        final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField("field1");
-        pattern.getChildColumns().add(condition1);
-
-        dtPresenter.getModel().getConditions().add(pattern);
-
-        assertTrue(dtPresenter.canConditionBeDeleted(condition1));
-    }
-
-    @Test
-    public void canConditionBeDeletedWithMultipleChildColumns() {
-        final Pattern52 pattern = new Pattern52();
-        pattern.setFactType("FactType1");
-        final ConditionCol52 condition1 = new ConditionCol52();
-        condition1.setFactField("field1");
-        pattern.getChildColumns().add(condition1);
-        final ConditionCol52 condition2 = new ConditionCol52();
-        condition2.setFactField("field2");
-        pattern.getChildColumns().add(condition2);
-
-        dtPresenter.getModel().getConditions().add(pattern);
-
-        assertTrue(dtPresenter.canConditionBeDeleted(condition1));
-    }
-
-    @Test
-    public void canBRLFragmentConditionBeDeletedWithAction() {
-        final FactPattern fp = new FactPattern("FactType1");
-        fp.setBoundName("$fact");
-        final BRLConditionColumn column = new BRLConditionColumn();
-        column.getDefinition().add(fp);
-
-        dtPresenter.getModel().getConditions().add(column);
-
-        final ActionInsertFactCol52 action = new ActionInsertFactCol52();
-        action.setFactType("FactType1");
-        action.setBoundName("$fact");
-        action.setFactField("field");
-
-        dtPresenter.getModel().getActionCols().add(action);
-
-        assertFalse(dtPresenter.canConditionBeDeleted(column));
-    }
-
-    @Test
-    public void canBRLFragmentConditionBeDeletedWithNoAction() {
-        final FactPattern fp = new FactPattern("FactType1");
-        fp.setBoundName("$fact");
-        final BRLConditionColumn column = new BRLConditionColumn();
-        column.getDefinition().add(fp);
-
-        dtPresenter.getModel().getConditions().add(column);
-
-        assertTrue(dtPresenter.canConditionBeDeleted(column));
-    }
-
-    @Test
     public void getValueListLookups() {
         final AttributeCol52 attribute = new AttributeCol52();
         attribute.setAttribute(RuleAttributeWidget.ENABLED_ATTR);
@@ -1081,7 +1012,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void appendPatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendPatternAndConditionColumn() throws VetoException {
         reset(modellerPresenter);
 
         final Pattern52 pattern = new Pattern52();
@@ -1103,7 +1034,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void appendConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendConditionColumn() throws VetoException {
         reset(modellerPresenter);
 
         final ConditionCol52 condition = new ConditionCol52();
@@ -1121,7 +1052,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void appendActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendActionColumn() throws VetoException {
         reset(modellerPresenter);
 
         final ActionInsertFactCol52 action = new ActionInsertFactCol52();
@@ -1142,7 +1073,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void appendRow() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendRow() throws VetoException {
         reset(synchronizer,
               modellerPresenter);
 
@@ -1155,7 +1086,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void deleteConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteConditionColumn() throws VetoException {
         final Pattern52 pattern = new Pattern52();
         pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
@@ -1175,7 +1106,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void deleteActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteActionColumn() throws VetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
         column.setFactType("FactType");
         column.setFactField("field");
@@ -1214,7 +1145,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void updatePatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updatePatternAndConditionColumn() throws VetoException {
         final Pattern52 pattern = new Pattern52();
         pattern.setFactType("FactType");
         pattern.setBoundName("$f");
@@ -1247,7 +1178,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void updateConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateConditionColumn() throws VetoException {
         final Pattern52 pattern = new Pattern52();
         pattern.setFactType("FactType");
         final ConditionCol52 condition = new ConditionCol52();
@@ -1272,7 +1203,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void updateActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateActionColumn() throws VetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
         column.setFactType("FactType");
         column.setFactField("field");
@@ -1466,7 +1397,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onDeleteSelectedColumnsWithSelections() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedColumnsWithSelections() throws VetoException {
         final AttributeCol52 column = new AttributeCol52() {
 
             {
@@ -1486,7 +1417,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onDeleteSelectedColumnsWithoutSelections() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedColumnsWithoutSelections() throws VetoException {
         dtPresenter.onDeleteSelectedColumns();
 
         verify(synchronizer,
@@ -1494,7 +1425,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onDeleteSelectedRowsWithSelections() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedRowsWithSelections() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1512,7 +1443,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onDeleteSelectedRowsWithNoSelections() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedRowsWithNoSelections() throws VetoException {
         dtPresenter.onDeleteSelectedRows();
 
         verify(synchronizer,
@@ -1520,7 +1451,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowAboveNoRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowAboveNoRowSelected() throws VetoException {
         dtPresenter.onInsertRowAbove();
 
         verify(synchronizer,
@@ -1528,7 +1459,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowAboveSingleRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowAboveSingleRowSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1540,7 +1471,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowAboveMultipleRowsSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowAboveMultipleRowsSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1554,7 +1485,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowBelowNoRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowBelowNoRowSelected() throws VetoException {
         dtPresenter.onInsertRowBelow();
 
         verify(synchronizer,
@@ -1562,7 +1493,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowBelowSingleRowSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowBelowSingleRowSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1574,7 +1505,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onInsertRowBelowMultipleRowsSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowBelowMultipleRowsSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1588,7 +1519,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onOtherwiseCellNoCellSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onOtherwiseCellNoCellSelected() throws VetoException {
         dtPresenter.onOtherwiseCell();
 
         verify(synchronizer,
@@ -1597,7 +1528,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onOtherwiseCellSingleCellSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onOtherwiseCellSingleCellSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);
@@ -1610,7 +1541,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void onOtherwiseCellMultipleCellsSelected() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onOtherwiseCellMultipleCellsSelected() throws VetoException {
         final GridData uiModel = dtPresenter.getUiModel();
         uiModel.selectCell(0,
                            0);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
@@ -45,7 +45,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanage
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.impl.GridWidgetColumnFactoryImpl;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.MoveColumnVetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.EnumLoaderUtilities;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.guvnor.common.services.shared.metadata.model.Overview;
@@ -53,7 +53,6 @@ import org.gwtbootstrap3.client.ui.html.Text;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
@@ -67,10 +66,14 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.security.authz.AuthorizationManager;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @WithClassesToStub({Text.class, DateTimeFormat.class})
 @RunWith(GwtMockitoTestRunner.class)
@@ -132,7 +135,7 @@ public class GuidedDecisionTablePresenter_AuditLogTest {
     private List<BaseColumnFieldDiff> diffs;
 
     @Before
-    public void setup() throws MoveColumnVetoException {
+    public void setup() throws VetoException {
         setupPresenter();
 
         for (Entry<String, Boolean> entry : model.getAuditLog().getAuditLogFilter().getAcceptedTypes().entrySet()) {
@@ -214,7 +217,7 @@ public class GuidedDecisionTablePresenter_AuditLogTest {
     }
 
     @Test
-    public void updateColumnAddsToLog() throws MoveColumnVetoException {
+    public void updateColumnAddsToLog() throws VetoException {
         dtPresenter.updateColumn(new ActionCol52(),
                                  new ActionCol52());
         dtPresenter.updateColumn(new AttributeCol52(),

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_ReadOnlyTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_ReadOnlyTest.java
@@ -25,13 +25,17 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisionTablePresenterTest {
@@ -43,7 +47,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendAttributeColumn() throws VetoException {
         dtPresenter.appendColumn(mock(AttributeCol52.class));
 
         verify(synchronizer,
@@ -51,7 +55,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendMetadataColumn() throws VetoException {
         dtPresenter.appendColumn(mock(MetadataCol52.class));
 
         verify(synchronizer,
@@ -59,7 +63,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendPatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendPatternAndConditionColumn() throws VetoException {
         dtPresenter.appendColumn(mock(Pattern52.class),
                                  mock(ConditionCol52.class));
 
@@ -69,7 +73,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendConditionColumn() throws VetoException {
         dtPresenter.appendColumn(mock(ConditionCol52.class));
 
         verify(synchronizer,
@@ -77,7 +81,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendActionColumn() throws VetoException {
         dtPresenter.appendColumn(mock(ActionCol52.class));
 
         verify(synchronizer,
@@ -85,7 +89,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void appendRow() throws ModelSynchronizer.MoveColumnVetoException {
+    public void appendRow() throws VetoException {
         dtPresenter.onAppendRow();
 
         verify(synchronizer,
@@ -93,7 +97,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void deleteAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteAttributeColumn() throws VetoException {
         dtPresenter.deleteColumn(mock(AttributeCol52.class));
 
         verify(synchronizer,
@@ -101,7 +105,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void deleteMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteMetadataColumn() throws VetoException {
         dtPresenter.deleteColumn(mock(MetadataCol52.class));
 
         verify(synchronizer,
@@ -109,7 +113,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void deleteConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteConditionColumn() throws VetoException {
         dtPresenter.deleteColumn(mock(ConditionCol52.class));
 
         verify(synchronizer,
@@ -117,7 +121,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void deleteActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void deleteActionColumn() throws VetoException {
         dtPresenter.deleteColumn(mock(ActionCol52.class));
 
         verify(synchronizer,
@@ -125,7 +129,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void updateAttributeColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateAttributeColumn() throws VetoException {
         dtPresenter.updateColumn(mock(AttributeCol52.class),
                                  mock(AttributeCol52.class));
 
@@ -135,7 +139,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void updateMetadataColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateMetadataColumn() throws VetoException {
         dtPresenter.updateColumn(mock(MetadataCol52.class),
                                  mock(MetadataCol52.class));
 
@@ -145,7 +149,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void updatePatternAndConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updatePatternAndConditionColumn() throws VetoException {
         dtPresenter.updateColumn(mock(Pattern52.class),
                                  mock(ConditionCol52.class),
                                  mock(Pattern52.class),
@@ -159,7 +163,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void updateConditionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateConditionColumn() throws VetoException {
         dtPresenter.updateColumn(mock(ConditionCol52.class),
                                  mock(ConditionCol52.class));
 
@@ -169,7 +173,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void updateActionColumn() throws ModelSynchronizer.MoveColumnVetoException {
+    public void updateActionColumn() throws VetoException {
         dtPresenter.updateColumn(mock(ActionCol52.class),
                                  mock(ActionCol52.class));
 
@@ -268,7 +272,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void onDeleteSelectedColumns() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedColumns() throws VetoException {
         dtPresenter.onDeleteSelectedColumns();
 
         verify(synchronizer,
@@ -276,7 +280,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void onDeleteSelectedRows() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onDeleteSelectedRows() throws VetoException {
         dtPresenter.onDeleteSelectedRows();
 
         verify(synchronizer,
@@ -284,7 +288,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void onInsertRowAbove() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowAbove() throws VetoException {
         dtPresenter.onInsertRowAbove();
 
         verify(synchronizer,
@@ -292,7 +296,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void onInsertRowBelow() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onInsertRowBelow() throws VetoException {
         dtPresenter.onInsertRowBelow();
 
         verify(synchronizer,
@@ -300,7 +304,7 @@ public class GuidedDecisionTablePresenter_ReadOnlyTest extends BaseGuidedDecisio
     }
 
     @Test
-    public void onOtherwiseCell() throws ModelSynchronizer.MoveColumnVetoException {
+    public void onOtherwiseCell() throws VetoException {
         dtPresenter.onOtherwiseCell();
 
         verify(synchronizer,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRowTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRowTest.java
@@ -80,7 +80,6 @@ public class AttributeColumnConfigRowTest {
     @Mock
     CheckBox hideColumnCheckBox;
 
-
     @Before
     public void setUp() throws Exception {
         columnConfigRow = new AttributeColumnConfigRow();
@@ -100,12 +99,12 @@ public class AttributeColumnConfigRowTest {
     public void testInit() throws Exception {
         columnConfigRow.init(attributeColumn, presenter);
 
-        verify(view).setVerticalAlignment( HasVerticalAlignment.ALIGN_MIDDLE );
+        verify(view).setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
         verify(view).addColumnLabel(attributeColumn);
     }
 
     @Test
-    public void testInitUseRowNumberCheckBox() {
+    public void testInitUseRowNumberCheckBox() throws Exception {
         when(useRowNumberCheckBox.getValue()).thenReturn(true);
         columnConfigRow.init(attributeColumn, presenter);
         verify(view).addUseRowNumberCheckBox(eq(attributeColumn), eq(true), clickCaptor.capture());

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementViewTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementViewTest.java
@@ -46,7 +46,6 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +71,10 @@ import static org.mockito.Mockito.verify;
 public class ColumnManagementViewTest {
 
     @Mock
-    private GuidedDecisionTableModellerView.Presenter presenter;
+    private GuidedDecisionTableModellerView modellerView;
+
+    @Mock
+    private GuidedDecisionTableModellerView.Presenter modellerPresenter;
 
     @Mock
     private GuidedDecisionTableView.Presenter decisionTablePresenter;
@@ -86,19 +88,16 @@ public class ColumnManagementViewTest {
     @Mock
     private ManagedInstance<DeleteColumnManagementAnchorWidget> deleteColumnManagementAnchorWidgets;
 
-    @Mock
-    private TranslationService translationService;
-
     private ColumnManagementView view;
 
     @Before
     public void setUp() throws Exception {
         doReturn(deleteWidget).when(deleteColumnManagementAnchorWidgets).get();
 
-        view = spy(new ColumnManagementView(deleteColumnManagementAnchorWidgets,
-                                            translationService));
-        view.init(presenter);
+        view = spy(new ColumnManagementView(deleteColumnManagementAnchorWidgets));
+        view.init(modellerPresenter);
 
+        doReturn(modellerView).when(modellerPresenter).getView();
         doReturn(horizontalPanel).when(view).newHorizontalPanel();
     }
 
@@ -136,7 +135,7 @@ public class ColumnManagementViewTest {
         final ColumnLabelWidget columnLabel = mockColumnLabelWidget();
 
         doReturn(columnLabel).when(view).newColumnLabelWidget(anyString());
-        doReturn(true).when(presenter).isActiveDecisionTableEditable();
+        doReturn(true).when(modellerPresenter).isActiveDecisionTableEditable();
 
         view.renderColumns(columnGroups);
 
@@ -205,7 +204,7 @@ public class ColumnManagementViewTest {
         final ColumnLabelWidget columnLabel = mockColumnLabelWidget();
 
         doReturn(columnLabel).when(view).newColumnLabelWidget(anyString());
-        doReturn(true).when(presenter).isActiveDecisionTableEditable();
+        doReturn(true).when(modellerPresenter).isActiveDecisionTableEditable();
         doReturn("brl one").when(conditionColumnOne).getHeader();
         doReturn("brl two").when(conditionColumnTwo).getHeader();
 
@@ -274,7 +273,7 @@ public class ColumnManagementViewTest {
         final ColumnLabelWidget columnLabel = mockColumnLabelWidget();
 
         doReturn(columnLabel).when(view).newColumnLabelWidget(anyString());
-        doReturn(true).when(presenter).isActiveDecisionTableEditable();
+        doReturn(true).when(modellerPresenter).isActiveDecisionTableEditable();
         doReturn("one").when(brlActionColumn).getHeader();
         doReturn("two").when(actionInsertFactColumn).getHeader();
         doReturn("three").when(retractFactColumn).getHeader();
@@ -379,7 +378,7 @@ public class ColumnManagementViewTest {
                     final String columnHeader = "column header";
                     final ArgumentCaptor<Command> commandCaptor = ArgumentCaptor.forClass(Command.class);
 
-                    doReturn(decisionTablePresenter).when(presenter).getActiveDecisionTable();
+                    doReturn(decisionTablePresenter).when(modellerPresenter).getActiveDecisionTable();
                     doReturn(columnHeader).when(column).getHeader();
 
                     view.removeCondition(column);
@@ -407,9 +406,9 @@ public class ColumnManagementViewTest {
                     final String columnHeader = "column header";
                     final ArgumentCaptor<Command> commandCaptor = ArgumentCaptor.forClass(Command.class);
 
-                    doReturn(decisionTablePresenter).when(presenter).getActiveDecisionTable();
+                    doReturn(decisionTablePresenter).when(modellerPresenter).getActiveDecisionTable();
                     doReturn(columnHeader).when(column).getHeader();
-                    doNothing().when(view).showUnableToDeleteColumnMessage(column);
+                    doNothing().when(modellerView).showUnableToDeleteColumnMessage(column);
 
                     try {
                         doThrow(VetoDeletePatternInUseException.class).when(decisionTablePresenter).deleteColumn(eq(column));
@@ -421,7 +420,7 @@ public class ColumnManagementViewTest {
 
                         commandCaptor.getValue().execute();
 
-                        verify(view).showUnableToDeleteColumnMessage(eq(column));
+                        verify(modellerView).showUnableToDeleteColumnMessage(eq(column));
                     } catch (VetoException veto) {
                     }
                     reset(view);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
@@ -26,7 +26,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.Ba
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -61,7 +61,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
         column.setHeader("col1");
         column.setBoundName("$a");
@@ -81,7 +81,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testAppendBoolean() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendBoolean() throws VetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
         column.setHeader("col1");
         column.setBoundName("$a");
@@ -108,7 +108,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final ActionInsertFactCol52 column = spy(new ActionInsertFactCol52());
         column.setHeader("col1");
         column.setBoundName("$a");
@@ -144,7 +144,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final ActionInsertFactCol52 column = new ActionInsertFactCol52();
         column.setHeader("col1");
         column.setBoundName("$a");
@@ -166,7 +166,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final ActionInsertFactCol52 column1 = new ActionInsertFactCol52();
         column1.setBoundName("$a");
         column1.setFactType("Applicant");
@@ -262,7 +262,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final ActionInsertFactCol52 column1 = new ActionInsertFactCol52();
         column1.setBoundName("$a");
         column1.setFactType("Applicant");
@@ -358,7 +358,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final ActionInsertFactCol52 column1 = new ActionInsertFactCol52();
         column1.setBoundName("$a");
         column1.setFactType("Applicant");

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
@@ -22,18 +22,20 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactC
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseSingletonDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BoundFactUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final ActionRetractFactCol52 column = new ActionRetractFactCol52();
         column.setHeader("col1");
 
@@ -50,7 +52,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final ActionRetractFactCol52 column = spy(new ActionRetractFactCol52());
         column.setHeader("col1");
 
@@ -80,7 +82,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final ActionRetractFactCol52 column = new ActionRetractFactCol52();
         column.setHeader("col1");
 
@@ -99,7 +101,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final ActionRetractFactCol52 column1 = new ActionRetractFactCol52();
         column1.setHeader("retract1");
         final ActionRetractFactCol52 column2 = new ActionRetractFactCol52();
@@ -181,7 +183,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final ActionRetractFactCol52 column1 = new ActionRetractFactCol52();
         column1.setHeader("retract1");
         final ActionRetractFactCol52 column2 = new ActionRetractFactCol52();
@@ -263,7 +265,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final ActionRetractFactCol52 column1 = new ActionRetractFactCol52();
         column1.setHeader("retract1");
         final ActionRetractFactCol52 column2 = new ActionRetractFactCol52();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
@@ -28,7 +28,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.Ba
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -63,7 +63,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -98,7 +98,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppendBoolean() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendBoolean() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -140,7 +140,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -190,7 +190,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -229,7 +229,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -337,7 +337,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -445,7 +445,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemExecuteColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemExecuteColumnSynchronizerTest.java
@@ -23,7 +23,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol5
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -53,7 +53,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final ActionWorkItemCol52 column = new ActionWorkItemCol52();
         column.setHeader("col1");
 
@@ -70,7 +70,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final ActionWorkItemCol52 column = spy(new ActionWorkItemCol52());
         column.setHeader("col1");
 
@@ -100,7 +100,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final ActionWorkItemCol52 column = new ActionWorkItemCol52();
         column.setHeader("col1");
 
@@ -119,7 +119,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final ActionWorkItemCol52 column1 = new ActionWorkItemCol52();
         column1.setHeader("wid1");
         final ActionWorkItemCol52 column2 = new ActionWorkItemCol52();
@@ -201,7 +201,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final ActionWorkItemCol52 column1 = new ActionWorkItemCol52();
         column1.setHeader("wid1");
         final ActionWorkItemCol52 column2 = new ActionWorkItemCol52();
@@ -283,7 +283,7 @@ public class ActionWorkItemExecuteColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final ActionWorkItemCol52 column1 = new ActionWorkItemCol52();
         column1.setHeader("wid1");
         final ActionWorkItemCol52 column2 = new ActionWorkItemCol52();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
@@ -27,21 +27,23 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchronizerTest {
 
     private static final String WORK_ITEM_NAME = "WorkItemDefinition";
 
     @Before
-    public void setupWorkItemExecution() throws ModelSynchronizer.MoveColumnVetoException {
+    public void setupWorkItemExecution() throws VetoException {
         final ActionWorkItemCol52 column = new ActionWorkItemCol52();
         final PortableWorkDefinition pwd = new PortableWorkDefinition();
         pwd.setName(WORK_ITEM_NAME);
@@ -52,7 +54,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final ActionWorkItemInsertFactCol52 column = new ActionWorkItemInsertFactCol52();
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -70,7 +72,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testAppendMultipleColumns() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendMultipleColumns() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setHeader("col1");
@@ -101,7 +103,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final ActionWorkItemInsertFactCol52 column = spy(new ActionWorkItemInsertFactCol52());
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -133,7 +135,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final ActionWorkItemInsertFactCol52 column = new ActionWorkItemInsertFactCol52();
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -153,7 +155,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setBoundName("$a");
@@ -243,7 +245,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setBoundName("$a");
@@ -333,7 +335,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setBoundName("$a");
@@ -424,7 +426,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testMoveColumnTo_MoveWorkItemInsertFactColRight_WithFollowingInsertFactCol() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveWorkItemInsertFactColRight_WithFollowingInsertFactCol() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setBoundName("$a");
@@ -468,7 +470,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testMoveColumnTo_MoveInsertFactColLeft_WithPrecedingWorkItemInsertFactCol() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveInsertFactColLeft_WithPrecedingWorkItemInsertFactCol() throws VetoException {
         final ActionWorkItemInsertFactCol52 column1 = new ActionWorkItemInsertFactCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setBoundName("$a");

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
@@ -28,7 +28,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
@@ -48,7 +48,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     private static final String WORK_ITEM_NAME = "WorkItemDefinition";
 
     @Before
-    public void setupWorkItemExecution() throws ModelSynchronizer.MoveColumnVetoException {
+    public void setupWorkItemExecution() throws VetoException {
         final ActionWorkItemCol52 column = new ActionWorkItemCol52();
         final PortableWorkDefinition pwd = new PortableWorkDefinition();
         pwd.setName(WORK_ITEM_NAME);
@@ -74,7 +74,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final ActionWorkItemSetFieldCol52 column = new ActionWorkItemSetFieldCol52();
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -92,7 +92,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testAppendMultipleColumns() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendMultipleColumns() throws VetoException {
         final ActionWorkItemSetFieldCol52 column1 = new ActionWorkItemSetFieldCol52();
         column1.setWorkItemName(WORK_ITEM_NAME);
         column1.setHeader("col1");
@@ -123,7 +123,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final ActionWorkItemSetFieldCol52 column = spy(new ActionWorkItemSetFieldCol52());
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -155,7 +155,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final ActionWorkItemSetFieldCol52 column = new ActionWorkItemSetFieldCol52();
         column.setWorkItemName(WORK_ITEM_NAME);
         column.setHeader("col1");
@@ -176,7 +176,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -278,7 +278,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");
@@ -380,7 +380,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         //Add a Pattern to be updated
         final Pattern52 pattern = new Pattern52();
         pattern.setBoundName("$a");

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
@@ -28,7 +28,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.Bo
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.SalienceUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl.BaseSynchronizer.MoveColumnToMetaData;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.junit.Test;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
         column.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
 
@@ -67,7 +67,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate1() throws VetoException {
         final AttributeCol52 column = spy(new AttributeCol52());
         column.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
 
@@ -96,7 +96,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate2() throws VetoException {
         final AttributeCol52 column = spy(new AttributeCol52());
         column.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
 
@@ -128,7 +128,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdateSalienceRowNumber() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdateSalienceRowNumber() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
@@ -196,7 +196,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
         column.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
 
@@ -215,7 +215,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final AttributeCol52 column1 = new AttributeCol52();
         column1.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
         final AttributeCol52 column2 = new AttributeCol52();
@@ -297,7 +297,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final AttributeCol52 column1 = new AttributeCol52();
         column1.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
         final AttributeCol52 column2 = new AttributeCol52();
@@ -379,7 +379,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final AttributeCol52 column1 = new AttributeCol52();
         column1.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
         final AttributeCol52 column2 = new AttributeCol52();
@@ -461,7 +461,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveLeft() throws VetoException {
         final AttributeCol52 column1 = new AttributeCol52();
         column1.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
         final AttributeCol52 column2 = new AttributeCol52();
@@ -515,7 +515,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveRight() throws VetoException {
         final AttributeCol52 column1 = new AttributeCol52();
         column1.setAttribute(RuleAttributeWidget.SALIENCE_ATTR);
         final AttributeCol52 column2 = new AttributeCol52();
@@ -568,14 +568,14 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws VetoException {
         final AttributeColumnSynchronizer synchronizer = new AttributeColumnSynchronizer();
 
         assertFalse(synchronizer.handlesMoveColumnsTo(Collections.emptyList()));
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws VetoException {
         final MoveColumnToMetaData md0 = mock(MoveColumnToMetaData.class);
         final MoveColumnToMetaData md1 = mock(MoveColumnToMetaData.class);
         final AttributeColumnSynchronizer synchronizer = new AttributeColumnSynchronizer();
@@ -587,7 +587,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithSingleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithSingleMetadata() throws VetoException {
         final MoveColumnToMetaData md0 = mock(MoveColumnToMetaData.class);
         final AttributeColumnSynchronizer synchronizer = new AttributeColumnSynchronizer();
         when(md0.getColumn()).thenReturn(mock(AttributeCol52.class));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizerTest.java
@@ -27,7 +27,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDif
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.LongUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -35,9 +35,11 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.drools.workbench.screens.guided.rule.client.util.ModelFieldUtil.modelField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -70,7 +72,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend1() throws VetoException {
         //Single Column, single variable
         final BRLActionColumn column = new BRLActionColumn();
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
@@ -94,7 +96,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend2() throws VetoException {
         //Single Column, multiple variables
         final BRLActionColumn column = new BRLActionColumn();
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
@@ -134,7 +136,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate1() throws VetoException {
         //Single Column, single variable
         final BRLActionColumn column = spy(new BRLActionColumn());
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
@@ -190,7 +192,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate2() throws VetoException {
         //Single Column, multiple variables
         final BRLActionColumn column = spy(new BRLActionColumn());
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
@@ -253,7 +255,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate3() throws VetoException {
         //Single Column, multiple variables
         final BRLActionColumn column = spy(new BRLActionColumn());
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
@@ -316,7 +318,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final BRLActionColumn column = new BRLActionColumn();
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn("$age",
                                                                              DataType.TYPE_NUMERIC_INTEGER,
@@ -354,7 +356,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveBRLActionVariableColumnTo() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveBRLActionVariableColumnTo() throws VetoException {
         final BRLActionColumn column1 = new BRLActionColumn();
         final BRLActionVariableColumn column1v0 = new BRLActionVariableColumn("$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
@@ -474,7 +476,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveBRLActionBlockTo() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveBRLActionBlockTo() throws VetoException {
         final BRLActionColumn column1 = new BRLActionColumn();
         final BRLActionVariableColumn column1v0 = new BRLActionVariableColumn("$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
@@ -596,7 +598,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveActionBefore() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveActionBefore() throws VetoException {
         final BRLActionColumn column1 = new BRLActionColumn();
         final BRLActionVariableColumn column1v0 = new BRLActionVariableColumn("$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
@@ -715,7 +717,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveActionAfter() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveActionAfter() throws VetoException {
         final ActionInsertFactCol52 column1 = new ActionInsertFactCol52();
         column1.setHeader("country");
         column1.setBoundName("$a");

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
@@ -17,19 +17,26 @@
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DescriptionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.models.guided.dtable.shared.model.RowNumberCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.LongUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -37,9 +44,12 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.drools.workbench.screens.guided.rule.client.util.ModelFieldUtil.modelField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -72,7 +82,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend1() throws VetoException {
         //Single Column, single variable
         final BRLConditionColumn column = new BRLConditionColumn();
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
@@ -100,7 +110,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend2() throws VetoException {
         //Single Column, multiple variables
         final BRLConditionColumn column = new BRLConditionColumn();
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
@@ -141,7 +151,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate1() throws VetoException {
         //Single Column, single variable
         final BRLConditionColumn column = spy(new BRLConditionColumn());
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
@@ -204,7 +214,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate2() throws VetoException {
         //Single Column, multiple variables
         final BRLConditionColumn column = spy(new BRLConditionColumn());
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
@@ -267,7 +277,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate3() throws VetoException {
         //Single Column, multiple variables
         final BRLConditionColumn column = spy(new BRLConditionColumn());
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
@@ -333,7 +343,64 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkBRLFragmentConditionCannotBeUpdatedWhenBindingIsUsedInAction() throws VetoException {
+        final BRLConditionColumn column = new BRLConditionColumn();
+        column.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{
+            setBoundName("$a");
+        }}));
+        final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
+                                                                                   DataType.TYPE_NUMERIC_INTEGER,
+                                                                                   "Applicant",
+                                                                                   "age");
+        column.getChildColumns().add(columnV0);
+        column.setHeader("col1");
+        columnV0.setHeader("col1v0");
+
+        modelSynchronizer.appendColumn(column);
+
+        final ActionSetFieldCol52 action = new ActionSetFieldCol52() {{
+            setBoundName("$a");
+            setFactField("age");
+            setHeader("action1");
+        }};
+
+        modelSynchronizer.appendColumn(action);
+
+        try {
+            final BRLConditionColumn editedColumn = new BRLConditionColumn();
+            editedColumn.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{
+                setBoundName("$a2");
+            }}));
+            final BRLConditionVariableColumn editedColumnV0 = new BRLConditionVariableColumn("$age",
+                                                                                             DataType.TYPE_NUMERIC_INTEGER,
+                                                                                             "Applicant",
+                                                                                             "age");
+            editedColumn.getChildColumns().add(editedColumnV0);
+            editedColumn.setHeader("col1");
+            editedColumnV0.setHeader("col1v0");
+
+            modelSynchronizer.updateColumn(column,
+                                           editedColumn);
+
+            fail("Deletion of the column should have been vetoed.");
+        } catch (VetoUpdatePatternInUseException veto) {
+            //This is expected
+        } catch (VetoException veto) {
+            fail("VetoUpdatePatternInUseException was expected.");
+        }
+
+        assertEquals(4,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+        assertEquals(columnV0,
+                     model.getExpandedColumns().get(2));
+        assertEquals(action,
+                     model.getExpandedColumns().get(3));
+    }
+
+    @Test
+    public void testDelete() throws VetoException {
         final BRLConditionColumn column = new BRLConditionColumn();
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
                                                                                    DataType.TYPE_NUMERIC_INTEGER,
@@ -371,7 +438,82 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveBRLConditionVariableColumnTo() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkBRLFragmentConditionCannotBeDeletedWithAction() throws VetoException {
+        final BRLConditionColumn column = new BRLConditionColumn();
+        column.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{
+            setBoundName("$a");
+        }}));
+        final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
+                                                                                   DataType.TYPE_NUMERIC_INTEGER,
+                                                                                   "Applicant",
+                                                                                   "age");
+        column.getChildColumns().add(columnV0);
+        column.setHeader("col1");
+        columnV0.setHeader("col1v0");
+
+        modelSynchronizer.appendColumn(column);
+
+        final ActionSetFieldCol52 action = new ActionSetFieldCol52() {{
+            setBoundName("$a");
+            setFactField("age");
+            setHeader("action1");
+        }};
+
+        modelSynchronizer.appendColumn(action);
+
+        try {
+            modelSynchronizer.deleteColumn(column);
+
+            fail("Deletion of the column should have been vetoed.");
+        } catch (VetoDeletePatternInUseException veto) {
+            //This is expected
+        } catch (VetoException veto) {
+            fail("VetoDeletePatternInUseException was expected.");
+        }
+
+        assertEquals(4,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+        assertEquals(columnV0,
+                     model.getExpandedColumns().get(2));
+        assertEquals(action,
+                     model.getExpandedColumns().get(3));
+    }
+
+    @Test
+    public void checkBRLFragmentConditionCanBeDeletedWithNoAction() throws VetoException {
+        final BRLConditionColumn column = new BRLConditionColumn();
+        final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
+                                                                                   DataType.TYPE_NUMERIC_INTEGER,
+                                                                                   "Applicant",
+                                                                                   "age");
+        final BRLConditionVariableColumn columnV1 = new BRLConditionVariableColumn("$name",
+                                                                                   DataType.TYPE_STRING,
+                                                                                   "Applicant",
+                                                                                   "name");
+        column.getChildColumns().add(columnV0);
+        column.getChildColumns().add(columnV1);
+        column.setHeader("col1");
+        columnV0.setHeader("col1v0");
+        columnV1.setHeader("col1v1");
+
+        modelSynchronizer.appendColumn(column);
+
+        try {
+            modelSynchronizer.deleteColumn(column);
+        } catch (VetoException veto) {
+            fail("Deletion should have been permitted.");
+        }
+
+        assertEquals(2,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+    }
+
+    @Test
+    public void testMoveBRLConditionVariableColumnTo() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new BRLConditionColumn();
         final BRLConditionVariableColumn column1v0 = new BRLConditionVariableColumn("$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
@@ -491,7 +633,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveBRLConditionBlockTo() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveBRLConditionBlockTo() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new BRLConditionColumn();
         final BRLConditionVariableColumn column1v0 = new BRLConditionVariableColumn("$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
@@ -617,7 +759,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMovePatternBefore() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMovePatternBefore() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new BRLConditionColumn();
         final BRLConditionVariableColumn column1v0 = new BRLConditionVariableColumn("$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
@@ -741,7 +883,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMovePatternAfter() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMovePatternAfter() throws VetoException {
         final Pattern52 column1 = new Pattern52();
         column1.setFactType("Address");
         final ConditionCol52 column1v0 = new ConditionCol52();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
@@ -21,14 +21,20 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DescriptionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.models.guided.dtable.shared.model.RowNumberCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.ModelField;
@@ -36,9 +42,14 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 import static org.drools.workbench.screens.guided.rule.client.util.ModelFieldUtil.modelField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -91,22 +102,30 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         return condition;
     }
 
-    private Pattern52 boundApplicantPattern(String boundName) {
+    private Pattern52 boundApplicantPattern(final String boundName) {
         Pattern52 pattern = new Pattern52();
         pattern.setBoundName(boundName);
         pattern.setFactType("Applicant");
         return pattern;
     }
 
-    private Pattern52 boundAddressPattern(String boundName) {
+    private Pattern52 boundAddressPattern(final String boundName) {
         Pattern52 pattern = new Pattern52();
         pattern.setBoundName(boundName);
         pattern.setFactType("Address");
         return pattern;
     }
 
+    private ActionCol52 actionUpdatePattern(final String boundName) {
+        final ActionSetFieldCol52 action = new ActionSetFieldCol52();
+        action.setBoundName(boundName);
+        action.setFactField("age");
+        action.setHeader("action1");
+        return action;
+    }
+
     @Test
-    public void testOtherwise() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testOtherwise() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -132,7 +151,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend1() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -154,7 +173,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend2() throws VetoException {
         //Single Pattern, multiple Conditions
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -191,7 +210,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppend3() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend3() throws VetoException {
         //Multiple Patterns, multiple Conditions
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
@@ -236,7 +255,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppendNegated() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendNegated() throws VetoException {
         final Pattern52 pattern = new Pattern52();
         pattern.setNegated(true);
         pattern.setFactType("Applicant");
@@ -276,7 +295,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testAppendBoolean() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendBoolean() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -310,7 +329,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate1() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
@@ -355,7 +374,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate2() throws VetoException {
         //Single Pattern, multiple Conditions
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
@@ -403,7 +422,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate3() throws VetoException {
         //Multiple Patterns, multiple Conditions
         final Pattern52 pattern1 = spy(boundApplicantPattern("$a"));
 
@@ -455,7 +474,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate4() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate4() throws VetoException {
         //Multiple Patterns, multiple Conditions
         final Pattern52 pattern1 = spy(boundApplicantPattern("$a"));
 
@@ -500,7 +519,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate5() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate5() throws VetoException {
         final Pattern52 pattern1 = spy(boundApplicantPattern("$a"));
 
         final ConditionCol52 condition1 = spy(ageEqualsCondition());
@@ -543,7 +562,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate6() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate6() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
@@ -584,7 +603,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdateToNegated() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdateToNegated() throws VetoException {
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
         final ConditionCol52 condition = spy(ageEqualsCondition());
@@ -613,7 +632,42 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkAddToValueListPreservesData() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkConditionCannotBeUpdatedWhenBindingIsUsedInAction() throws VetoException {
+        final Pattern52 pattern = boundApplicantPattern("$a");
+        final ConditionCol52 condition = ageEqualsCondition();
+        final ActionCol52 action = actionUpdatePattern("$a");
+
+        modelSynchronizer.appendColumn(pattern,
+                                       condition);
+        modelSynchronizer.appendColumn(action);
+
+        try {
+            final Pattern52 editedPattern = boundApplicantPattern("$a2");
+            final ConditionCol52 editedCondition = nameEqualsCondition();
+            modelSynchronizer.updateColumn(pattern,
+                                           condition,
+                                           editedPattern,
+                                           editedCondition);
+
+            fail("Update of the column should have been vetoed.");
+        } catch (VetoUpdatePatternInUseException veto) {
+            //This is expected
+        } catch (VetoException veto) {
+            fail("VetoUpdatePatternInUseException was expected.");
+        }
+
+        assertEquals(4,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+        assertEquals(condition,
+                     model.getExpandedColumns().get(2));
+        assertEquals(action,
+                     model.getExpandedColumns().get(3));
+    }
+
+    @Test
+    public void checkAddToValueListPreservesData() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
@@ -670,7 +724,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkRemoveFromValueListClearsData() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkRemoveFromValueListClearsData() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
@@ -723,7 +777,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete1() throws VetoException {
         //Single Pattern, single Condition
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -753,7 +807,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete2() throws VetoException {
         //Single Pattern, multiple Conditions
         final Pattern52 pattern = boundApplicantPattern("$a");
 
@@ -789,7 +843,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete3() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete3() throws VetoException {
         //Multiple Patterns, multiple Conditions
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
@@ -836,7 +890,82 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveLeftNegatedPattern() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkConditionCannotBeDeletedWithSingleChildColumnWithAction() throws VetoException {
+        final Pattern52 pattern = boundApplicantPattern("$a");
+        final ConditionCol52 condition = ageEqualsCondition();
+        final ActionCol52 action = actionUpdatePattern("$a");
+
+        modelSynchronizer.appendColumn(pattern,
+                                       condition);
+        modelSynchronizer.appendColumn(action);
+
+        try {
+            modelSynchronizer.deleteColumn(condition);
+
+            fail("Deletion of the column should have been vetoed.");
+        } catch (VetoDeletePatternInUseException veto) {
+            //This is expected
+        } catch (VetoException veto) {
+            fail("VetoDeletePatternInUseException was expected.");
+        }
+
+        assertEquals(4,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+        assertEquals(condition,
+                     model.getExpandedColumns().get(2));
+        assertEquals(action,
+                     model.getExpandedColumns().get(3));
+    }
+
+    @Test
+    public void checkConditionCanBeDeletedWithSingleChildColumnWithNoAction() throws VetoException {
+        final Pattern52 pattern = boundApplicantPattern("$a");
+        final ConditionCol52 condition = ageEqualsCondition();
+
+        modelSynchronizer.appendColumn(pattern,
+                                       condition);
+
+        try {
+            modelSynchronizer.deleteColumn(condition);
+        } catch (VetoException veto) {
+            fail("Deletion should have been permitted.");
+        }
+
+        assertEquals(2,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+    }
+
+    @Test
+    public void checkConditionCanBeDeletedWithMultipleChildColumns() throws VetoException {
+        final Pattern52 pattern = boundApplicantPattern("$a");
+        final ConditionCol52 condition1 = ageEqualsCondition();
+        final ConditionCol52 condition2 = nameEqualsCondition();
+
+        modelSynchronizer.appendColumn(pattern,
+                                       condition1);
+        modelSynchronizer.appendColumn(pattern,
+                                       condition2);
+
+        try {
+            modelSynchronizer.deleteColumn(condition2);
+        } catch (VetoException veto) {
+            fail("Deletion should have been permitted.");
+        }
+
+        assertEquals(3,
+                     model.getExpandedColumns().size());
+        assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+        assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+        assertEquals(condition1,
+                     model.getExpandedColumns().get(2));
+    }
+
+    @Test
+    public void testMoveLeftNegatedPattern() throws VetoException {
         final Pattern52 pattern = new Pattern52();
         pattern.setNegated(true);
         pattern.setFactType("Applicant");
@@ -925,7 +1054,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final Pattern52 pattern = boundApplicantPattern("$a");
 
         final ConditionCol52 column1 = ageEqualsCondition();
@@ -1012,7 +1141,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final Pattern52 pattern = boundApplicantPattern("$a");
 
         final ConditionCol52 column1 = ageEqualsCondition();
@@ -1099,7 +1228,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds_OutOfConditions() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds_OutOfConditions() throws VetoException {
         final Pattern52 pattern = boundApplicantPattern("$a");
 
         final ConditionCol52 column1 = ageEqualsCondition();
@@ -1186,7 +1315,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds_OutOfPattern() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds_OutOfPattern() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();
@@ -1310,7 +1439,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_SingleColumnPattern() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_SingleColumnPattern() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();
@@ -1402,7 +1531,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveLeft() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();
@@ -1567,7 +1696,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveLeft_MidPoint() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveLeft_MidPoint() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();
@@ -1807,7 +1936,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveRight() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();
@@ -1974,7 +2103,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveRight_MidPoint() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveRight_MidPoint() throws VetoException {
         final Pattern52 pattern1 = boundApplicantPattern("$a");
 
         final ConditionCol52 column1p1 = ageEqualsCondition();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizerTest.java
@@ -22,18 +22,21 @@ import java.util.Collections;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final LimitedEntryBRLActionColumn column = new LimitedEntryBRLActionColumn();
         column.setHeader("col1");
 
@@ -50,7 +53,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final LimitedEntryBRLActionColumn column = new LimitedEntryBRLActionColumn();
         column.setHeader("col1");
 
@@ -76,7 +79,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final LimitedEntryBRLActionColumn column = new LimitedEntryBRLActionColumn();
         column.setHeader("col1");
 
@@ -95,7 +98,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final LimitedEntryBRLActionColumn column1 = new LimitedEntryBRLActionColumn();
         column1.setHeader("age");
         final LimitedEntryBRLActionColumn column2 = new LimitedEntryBRLActionColumn();
@@ -177,7 +180,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final LimitedEntryBRLActionColumn column1 = new LimitedEntryBRLActionColumn();
         column1.setHeader("age");
         final LimitedEntryBRLActionColumn column2 = new LimitedEntryBRLActionColumn();
@@ -259,7 +262,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final LimitedEntryBRLActionColumn column1 = new LimitedEntryBRLActionColumn();
         column1.setHeader("age");
         final LimitedEntryBRLActionColumn column2 = new LimitedEntryBRLActionColumn();
@@ -341,14 +344,14 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws VetoException {
         final LimitedEntryBRLActionColumnSynchronizer synchronizer = new LimitedEntryBRLActionColumnSynchronizer();
 
         assertFalse(synchronizer.handlesMoveColumnsTo(Collections.emptyList()));
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final BaseSynchronizer.MoveColumnToMetaData md1 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final LimitedEntryBRLActionColumnSynchronizer synchronizer = new LimitedEntryBRLActionColumnSynchronizer();
@@ -362,7 +365,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithSingleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithSingleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final LimitedEntryBRLActionColumnSynchronizer synchronizer = new LimitedEntryBRLActionColumnSynchronizer();
         when(md0.getColumn()).thenReturn(mock(LimitedEntryBRLActionColumn.class));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizerTest.java
@@ -24,18 +24,21 @@ import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final LimitedEntryBRLConditionColumn column = new LimitedEntryBRLConditionColumn();
         column.setHeader("col1");
 
@@ -52,7 +55,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate() throws VetoException {
         final LimitedEntryBRLConditionColumn column = new LimitedEntryBRLConditionColumn();
         column.setHeader("col1");
 
@@ -78,7 +81,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final LimitedEntryBRLConditionColumn column = new LimitedEntryBRLConditionColumn();
         column.setHeader("col1");
 
@@ -97,7 +100,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new LimitedEntryBRLConditionColumn();
         column1.setHeader("age");
         final CompositeColumn<BRLConditionVariableColumn> column2 = new LimitedEntryBRLConditionColumn();
@@ -179,7 +182,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new LimitedEntryBRLConditionColumn();
         column1.setHeader("age");
         final CompositeColumn<BRLConditionVariableColumn> column2 = new LimitedEntryBRLConditionColumn();
@@ -261,7 +264,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final CompositeColumn<BRLConditionVariableColumn> column1 = new LimitedEntryBRLConditionColumn();
         column1.setHeader("age");
         final CompositeColumn<BRLConditionVariableColumn> column2 = new LimitedEntryBRLConditionColumn();
@@ -343,14 +346,14 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws VetoException {
         final LimitedEntryBRLConditionColumnSynchronizer synchronizer = new LimitedEntryBRLConditionColumnSynchronizer();
 
         assertFalse(synchronizer.handlesMoveColumnsTo(Collections.emptyList()));
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final BaseSynchronizer.MoveColumnToMetaData md1 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final LimitedEntryBRLConditionColumnSynchronizer synchronizer = new LimitedEntryBRLConditionColumnSynchronizer();
@@ -364,7 +367,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithSingleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithSingleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final LimitedEntryBRLConditionColumnSynchronizer synchronizer = new LimitedEntryBRLConditionColumnSynchronizer();
         when(md0.getColumn()).thenReturn(mock(LimitedEntryBRLConditionColumn.class));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizerTest.java
@@ -23,18 +23,23 @@ import java.util.List;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         final MetadataCol52 column = new MetadataCol52();
         column.setMetadata("smurf");
 
@@ -52,7 +57,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate1() throws VetoException {
         final MetadataCol52 column = spy(new MetadataCol52());
         column.setMetadata("smurf");
 
@@ -80,7 +85,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testUpdate2() throws VetoException {
         final MetadataCol52 column = spy(new MetadataCol52());
         column.setMetadata("smurf");
 
@@ -111,7 +116,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testDelete() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDelete() throws VetoException {
         final MetadataCol52 column = new MetadataCol52();
         column.setMetadata("smurf");
 
@@ -130,7 +135,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveLeft() throws VetoException {
         final MetadataCol52 column1 = new MetadataCol52();
         column1.setMetadata("metadata1");
         final MetadataCol52 column2 = new MetadataCol52();
@@ -212,7 +217,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_MoveRight() throws VetoException {
         final MetadataCol52 column1 = new MetadataCol52();
         column1.setMetadata("metadata1");
         final MetadataCol52 column2 = new MetadataCol52();
@@ -294,7 +299,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnTo_OutOfBounds() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnTo_OutOfBounds() throws VetoException {
         final MetadataCol52 column1 = new MetadataCol52();
         column1.setMetadata("metadata1");
         final MetadataCol52 column2 = new MetadataCol52();
@@ -376,7 +381,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveLeft() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveLeft() throws VetoException {
         final MetadataCol52 column1 = new MetadataCol52();
         column1.setMetadata("metadata1");
         final MetadataCol52 column2 = new MetadataCol52();
@@ -430,7 +435,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void testMoveColumnsTo_MoveRight() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveColumnsTo_MoveRight() throws VetoException {
         final MetadataCol52 column1 = new MetadataCol52();
         column1.setMetadata("metadata1");
         final MetadataCol52 column2 = new MetadataCol52();
@@ -484,14 +489,14 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithEmptyMetadata() throws VetoException {
         final MetaDataColumnSynchronizer synchronizer = new MetaDataColumnSynchronizer();
 
         assertFalse(synchronizer.handlesMoveColumnsTo(Collections.emptyList()));
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithMultipleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final BaseSynchronizer.MoveColumnToMetaData md1 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final MetaDataColumnSynchronizer synchronizer = new MetaDataColumnSynchronizer();
@@ -505,7 +510,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
-    public void checkHandlesMoveColumnsToWithSingleMetadata() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkHandlesMoveColumnsToWithSingleMetadata() throws VetoException {
         final BaseSynchronizer.MoveColumnToMetaData md0 = mock(BaseSynchronizer.MoveColumnToMetaData.class);
         final MetaDataColumnSynchronizer synchronizer = new MetaDataColumnSynchronizer();
         when(md0.getColumn()).thenReturn(mock(MetadataCol52.class));

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerTest.java
@@ -19,89 +19,91 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.mvp.ParameterizedCommand;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ModelSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testSetCells() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testSetCells() throws VetoException {
         modelSynchronizer.appendRow();
 
-        uiModel.setCell( 0,
-                         1,
-                         new BaseGridCellValue<String>( "value" ) );
+        uiModel.setCell(0,
+                        1,
+                        new BaseGridCellValue<String>("value"));
 
-        assertEquals( "value",
-                      model.getData().get( 0 ).get( 1 ).getStringValue() );
-        assertEquals( "value",
-                      uiModel.getCell( 0,
-                                       1 ).getValue().getValue() );
+        assertEquals("value",
+                     model.getData().get(0).get(1).getStringValue());
+        assertEquals("value",
+                     uiModel.getCell(0,
+                                     1).getValue().getValue());
     }
 
     @Test
-    public void testDeleteCells() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDeleteCells() throws VetoException {
         modelSynchronizer.appendRow();
 
-        uiModel.setCell( 0,
-                         1,
-                         new BaseGridCellValue<String>( "value" ) );
-        assertEquals( "value",
-                      model.getData().get( 0 ).get( 1 ).getStringValue() );
-        assertEquals( "value",
-                      uiModel.getCell( 0,
-                                       1 ).getValue().getValue() );
+        uiModel.setCell(0,
+                        1,
+                        new BaseGridCellValue<String>("value"));
+        assertEquals("value",
+                     model.getData().get(0).get(1).getStringValue());
+        assertEquals("value",
+                     uiModel.getCell(0,
+                                     1).getValue().getValue());
 
-        uiModel.deleteCell( 0,
-                            1 );
+        uiModel.deleteCell(0,
+                           1);
 
-        assertNull( model.getData().get( 0 ).get( 1 ).getStringValue() );
-        assertNull( uiModel.getCell( 0,
-                                     1 ) );
+        assertNull(model.getData().get(0).get(1).getStringValue());
+        assertNull(uiModel.getCell(0,
+                                   1));
     }
 
     @Test
-    public void testInitialisationOfBooleanCellsWithDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
-        setupBooleanColumn( ( c ) -> c.setDefaultValue( new DTCellValue52( true ) ) );
+    public void testInitialisationOfBooleanCellsWithDefaultValue() throws VetoException {
+        setupBooleanColumn((c) -> c.setDefaultValue(new DTCellValue52(true)));
 
         modelSynchronizer.appendRow();
 
-        assertTrue( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
-        assertTrue( (Boolean) uiModel.getCell( 0,
-                                               2 ).getValue().getValue() );
+        assertTrue(model.getData().get(0).get(2).getBooleanValue());
+        assertTrue((Boolean) uiModel.getCell(0,
+                                             2).getValue().getValue());
     }
 
     @Test
-    public void testInitialisationOfBooleanCellsWithNullDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
-        setupBooleanColumn( ( c ) -> c.setDefaultValue( new DTCellValue52( (Boolean) null ) ) );
+    public void testInitialisationOfBooleanCellsWithNullDefaultValue() throws VetoException {
+        setupBooleanColumn((c) -> c.setDefaultValue(new DTCellValue52((Boolean) null)));
 
         modelSynchronizer.appendRow();
 
-        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
-        assertFalse( (Boolean) uiModel.getCell( 0,
-                                                2 ).getValue().getValue() );
+        assertFalse(model.getData().get(0).get(2).getBooleanValue());
+        assertFalse((Boolean) uiModel.getCell(0,
+                                              2).getValue().getValue());
     }
 
     @Test
-    public void testInitialisationOfBooleanCellsWithoutDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
-        setupBooleanColumn( ( c ) -> {/*Nothing*/ } );
+    public void testInitialisationOfBooleanCellsWithoutDefaultValue() throws VetoException {
+        setupBooleanColumn((c) -> {/*Nothing*/ });
 
         modelSynchronizer.appendRow();
 
-        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
-        assertFalse( (Boolean) uiModel.getCell( 0,
-                                                2 ).getValue().getValue() );
+        assertFalse(model.getData().get(0).get(2).getBooleanValue());
+        assertFalse((Boolean) uiModel.getCell(0,
+                                              2).getValue().getValue());
     }
 
-    private void setupBooleanColumn( final ParameterizedCommand<AttributeCol52> cmdInit ) throws ModelSynchronizer.MoveColumnVetoException {
+    private void setupBooleanColumn(final ParameterizedCommand<AttributeCol52> cmdInit) throws VetoException {
         final AttributeCol52 booleanColumn = new AttributeCol52();
-        booleanColumn.setAttribute( GuidedDecisionTable52.ENABLED_ATTR );
-        cmdInit.execute( booleanColumn );
-        modelSynchronizer.appendColumn( booleanColumn );
+        booleanColumn.setAttribute(GuidedDecisionTable52.ENABLED_ATTR);
+        cmdInit.execute(booleanColumn);
+        modelSynchronizer.appendColumn(booleanColumn);
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/RowSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/RowSynchronizerTest.java
@@ -23,461 +23,462 @@ import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RowSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
-    public void testAppend() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppend() throws VetoException {
         modelSynchronizer.appendRow();
 
-        assertEquals( 1,
-                      model.getData().size() );
-        assertEquals( 1,
-                      uiModel.getRowCount() );
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      uiModel.getRow( 0 ).getHeight(),
-                      0.0 );
+        assertEquals(1,
+                     model.getData().size());
+        assertEquals(1,
+                     uiModel.getRowCount());
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     uiModel.getRow(0).getHeight(),
+                     0.0);
     }
 
     @Test
-    public void testInsert() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testInsert() throws VetoException {
         modelSynchronizer.appendRow();
-        modelSynchronizer.insertRow( 0 );
+        modelSynchronizer.insertRow(0);
 
-        assertEquals( 2,
-                      model.getData().size() );
-        assertEquals( 2,
-                      uiModel.getRowCount() );
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      uiModel.getRow( 0 ).getHeight(),
-                      0.0 );
-        assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
-                      uiModel.getRow( 1 ).getHeight(),
-                      0.0 );
+        assertEquals(2,
+                     model.getData().size());
+        assertEquals(2,
+                     uiModel.getRowCount());
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     uiModel.getRow(0).getHeight(),
+                     0.0);
+        assertEquals(GuidedDecisionTableView.ROW_HEIGHT,
+                     uiModel.getRow(1).getHeight(),
+                     0.0);
     }
 
     @Test
-    public void testDeleteUnmergedData() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDeleteUnmergedData() throws VetoException {
         modelSynchronizer.appendRow();
-        modelSynchronizer.deleteRow( 0 );
+        modelSynchronizer.deleteRow(0);
 
-        assertEquals( 0,
-                      model.getData().size() );
-        assertEquals( 0,
-                      uiModel.getRowCount() );
+        assertEquals(0,
+                     model.getData().size());
+        assertEquals(0,
+                     uiModel.getRowCount());
     }
 
     @Test
-    public void testDeleteMergedData_Block() throws ModelSynchronizer.MoveColumnVetoException {
-        uiModel.setMerged( true );
+    public void testDeleteMergedData_Block() throws VetoException {
+        uiModel.setMerged(true);
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
-        uiModel.setCell( 0,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "a" ) );
-        uiModel.setCell( 1,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "a" ) );
-        uiModel.setCell( 2,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "b" ) );
-        uiModel.collapseCell( 0,
-                              1 );
+        uiModel.setCell(0,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("a"));
+        uiModel.setCell(1,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("a"));
+        uiModel.setCell(2,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("b"));
+        uiModel.collapseCell(0,
+                             1);
 
-        modelSynchronizer.deleteRow( 0 );
+        modelSynchronizer.deleteRow(0);
 
-        assertEquals( 1,
-                      model.getData().size() );
-        assertEquals( 1,
-                      uiModel.getRowCount() );
+        assertEquals(1,
+                     model.getData().size());
+        assertEquals(1,
+                     uiModel.getRowCount());
     }
 
     @Test
-    public void testDeleteMergedData_WholeBlock() throws ModelSynchronizer.MoveColumnVetoException {
-        uiModel.setMerged( true );
+    public void testDeleteMergedData_WholeBlock() throws VetoException {
+        uiModel.setMerged(true);
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
-        uiModel.setCell( 0,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "a" ) );
-        uiModel.setCell( 1,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "a" ) );
-        uiModel.setCell( 2,
-                         1,
-                         new GuidedDecisionTableUiCell<String>( "a" ) );
-        uiModel.collapseCell( 0,
-                              1 );
+        uiModel.setCell(0,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("a"));
+        uiModel.setCell(1,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("a"));
+        uiModel.setCell(2,
+                        1,
+                        new GuidedDecisionTableUiCell<String>("a"));
+        uiModel.collapseCell(0,
+                             1);
 
-        modelSynchronizer.deleteRow( 0 );
+        modelSynchronizer.deleteRow(0);
 
-        assertEquals( 0,
-                      model.getData().size() );
-        assertEquals( 0,
-                      uiModel.getRowCount() );
+        assertEquals(0,
+                     model.getData().size());
+        assertEquals(0,
+                     uiModel.getRowCount());
     }
 
     @Test
-    public void testMoveRowMoveUpTopBlock() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowMoveUpTopBlock() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 0,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow2 );
-                            }} );
+        uiModel.moveRowsTo(0,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow2);
+                           }});
 
-        assertEquals( uiRow2,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow0,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow1,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow2,
+                     uiModel.getRow(0));
+        assertEquals(uiRow0,
+                     uiModel.getRow(1));
+        assertEquals(uiRow1,
+                     uiModel.getRow(2));
 
-        assertEquals( row2,
-                      model.getData().get( 0 ) );
-        assertEquals( row0,
-                      model.getData().get( 1 ) );
-        assertEquals( row1,
-                      model.getData().get( 2 ) );
+        assertEquals(row2,
+                     model.getData().get(0));
+        assertEquals(row0,
+                     model.getData().get(1));
+        assertEquals(row1,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testMoveRowMoveUpMidBlock() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowMoveUpMidBlock() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 1,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow2 );
-                            }} );
+        uiModel.moveRowsTo(1,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow2);
+                           }});
 
-        assertEquals( uiRow0,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow2,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow1,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow0,
+                     uiModel.getRow(0));
+        assertEquals(uiRow2,
+                     uiModel.getRow(1));
+        assertEquals(uiRow1,
+                     uiModel.getRow(2));
 
-        assertEquals( row0,
-                      model.getData().get( 0 ) );
-        assertEquals( row2,
-                      model.getData().get( 1 ) );
-        assertEquals( row1,
-                      model.getData().get( 2 ) );
+        assertEquals(row0,
+                     model.getData().get(0));
+        assertEquals(row2,
+                     model.getData().get(1));
+        assertEquals(row1,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testMoveRowsMoveUp() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowsMoveUp() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 0,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow1 );
-                                add( uiRow2 );
-                            }} );
+        uiModel.moveRowsTo(0,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow1);
+                               add(uiRow2);
+                           }});
 
-        assertEquals( uiRow1,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow2,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow0,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow1,
+                     uiModel.getRow(0));
+        assertEquals(uiRow2,
+                     uiModel.getRow(1));
+        assertEquals(uiRow0,
+                     uiModel.getRow(2));
 
-        assertEquals( row1,
-                      model.getData().get( 0 ) );
-        assertEquals( row2,
-                      model.getData().get( 1 ) );
-        assertEquals( row0,
-                      model.getData().get( 2 ) );
+        assertEquals(row1,
+                     model.getData().get(0));
+        assertEquals(row2,
+                     model.getData().get(1));
+        assertEquals(row0,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testMoveRowMoveDownEndBlock() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowMoveDownEndBlock() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 2,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow0 );
-                            }} );
+        uiModel.moveRowsTo(2,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow0);
+                           }});
 
-        assertEquals( uiRow1,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow2,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow0,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow1,
+                     uiModel.getRow(0));
+        assertEquals(uiRow2,
+                     uiModel.getRow(1));
+        assertEquals(uiRow0,
+                     uiModel.getRow(2));
 
-        assertEquals( row1,
-                      model.getData().get( 0 ) );
-        assertEquals( row2,
-                      model.getData().get( 1 ) );
-        assertEquals( row0,
-                      model.getData().get( 2 ) );
+        assertEquals(row1,
+                     model.getData().get(0));
+        assertEquals(row2,
+                     model.getData().get(1));
+        assertEquals(row0,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testMoveRowMoveDownMidBlock() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowMoveDownMidBlock() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 1,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow0 );
-                            }} );
+        uiModel.moveRowsTo(1,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow0);
+                           }});
 
-        assertEquals( uiRow1,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow0,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow2,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow1,
+                     uiModel.getRow(0));
+        assertEquals(uiRow0,
+                     uiModel.getRow(1));
+        assertEquals(uiRow2,
+                     uiModel.getRow(2));
 
-        assertEquals( row1,
-                      model.getData().get( 0 ) );
-        assertEquals( row0,
-                      model.getData().get( 1 ) );
-        assertEquals( row2,
-                      model.getData().get( 2 ) );
+        assertEquals(row1,
+                     model.getData().get(0));
+        assertEquals(row0,
+                     model.getData().get(1));
+        assertEquals(row2,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testMoveRowsMoveDown() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowsMoveDown() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        final List<DTCellValue52> row0 = model.getData().get( 0 );
-        final List<DTCellValue52> row1 = model.getData().get( 1 );
-        final List<DTCellValue52> row2 = model.getData().get( 2 );
+        final List<DTCellValue52> row0 = model.getData().get(0);
+        final List<DTCellValue52> row1 = model.getData().get(1);
+        final List<DTCellValue52> row2 = model.getData().get(2);
 
-        uiModel.moveRowsTo( 2,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow0 );
-                                add( uiRow1 );
-                            }} );
+        uiModel.moveRowsTo(2,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow0);
+                               add(uiRow1);
+                           }});
 
-        assertEquals( uiRow2,
-                      uiModel.getRow( 0 ) );
-        assertEquals( uiRow0,
-                      uiModel.getRow( 1 ) );
-        assertEquals( uiRow1,
-                      uiModel.getRow( 2 ) );
+        assertEquals(uiRow2,
+                     uiModel.getRow(0));
+        assertEquals(uiRow0,
+                     uiModel.getRow(1));
+        assertEquals(uiRow1,
+                     uiModel.getRow(2));
 
-        assertEquals( row2,
-                      model.getData().get( 0 ) );
-        assertEquals( row0,
-                      model.getData().get( 1 ) );
-        assertEquals( row1,
-                      model.getData().get( 2 ) );
+        assertEquals(row2,
+                     model.getData().get(0));
+        assertEquals(row0,
+                     model.getData().get(1));
+        assertEquals(row1,
+                     model.getData().get(2));
     }
 
     @Test
-    public void testAppendRowNumbers() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testAppendRowNumbers() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        assertEquals( 1,
-                      uiModel.getRow( 0 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 2,
-                      uiModel.getRow( 1 ).getCells().get( 0 ).getValue().getValue() );
+        assertEquals(1,
+                     uiModel.getRow(0).getCells().get(0).getValue().getValue());
+        assertEquals(2,
+                     uiModel.getRow(1).getCells().get(0).getValue().getValue());
 
-        assertEquals( 1,
-                      model.getData().get( 0 ).get( 0 ).getNumericValue() );
-        assertEquals( 2,
-                      model.getData().get( 1 ).get( 0 ).getNumericValue() );
+        assertEquals(1,
+                     model.getData().get(0).get(0).getNumericValue());
+        assertEquals(2,
+                     model.getData().get(1).get(0).getNumericValue());
     }
 
     @Test
-    public void testInsertRowNumbers() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testInsertRowNumbers() throws VetoException {
         modelSynchronizer.appendRow();
-        modelSynchronizer.insertRow( 0 );
+        modelSynchronizer.insertRow(0);
 
-        assertEquals( 1,
-                      uiModel.getRow( 0 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 2,
-                      uiModel.getRow( 1 ).getCells().get( 0 ).getValue().getValue() );
+        assertEquals(1,
+                     uiModel.getRow(0).getCells().get(0).getValue().getValue());
+        assertEquals(2,
+                     uiModel.getRow(1).getCells().get(0).getValue().getValue());
 
-        assertEquals( 1,
-                      model.getData().get( 0 ).get( 0 ).getNumericValue() );
-        assertEquals( 2,
-                      model.getData().get( 1 ).get( 0 ).getNumericValue() );
+        assertEquals(1,
+                     model.getData().get(0).get(0).getNumericValue());
+        assertEquals(2,
+                     model.getData().get(1).get(0).getNumericValue());
     }
 
     @Test
-    public void testDeleteRowNumbers() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testDeleteRowNumbers() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
-        modelSynchronizer.deleteRow( 0 );
+        modelSynchronizer.deleteRow(0);
 
-        assertEquals( 1,
-                      uiModel.getRow( 0 ).getCells().get( 0 ).getValue().getValue() );
+        assertEquals(1,
+                     uiModel.getRow(0).getCells().get(0).getValue().getValue());
 
-        assertEquals( 1,
-                      model.getData().get( 0 ).get( 0 ).getNumericValue() );
+        assertEquals(1,
+                     model.getData().get(0).get(0).getNumericValue());
     }
 
     @Test
-    public void testMoveRowsMoveDownCheckRowNumbers() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowsMoveDownCheckRowNumbers() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow0 = uiModel.getRow( 0 );
-        final GridRow uiRow1 = uiModel.getRow( 1 );
+        final GridRow uiRow0 = uiModel.getRow(0);
+        final GridRow uiRow1 = uiModel.getRow(1);
 
-        uiModel.moveRowsTo( 2,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow0 );
-                                add( uiRow1 );
-                            }} );
+        uiModel.moveRowsTo(2,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow0);
+                               add(uiRow1);
+                           }});
 
-        assertEquals( 1,
-                      uiModel.getRow( 0 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 2,
-                      uiModel.getRow( 1 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 3,
-                      uiModel.getRow( 2 ).getCells().get( 0 ).getValue().getValue() );
+        assertEquals(1,
+                     uiModel.getRow(0).getCells().get(0).getValue().getValue());
+        assertEquals(2,
+                     uiModel.getRow(1).getCells().get(0).getValue().getValue());
+        assertEquals(3,
+                     uiModel.getRow(2).getCells().get(0).getValue().getValue());
 
-        assertEquals( 1,
-                      model.getData().get( 0 ).get( 0 ).getNumericValue() );
-        assertEquals( 2,
-                      model.getData().get( 1 ).get( 0 ).getNumericValue() );
-        assertEquals( 3,
-                      model.getData().get( 2 ).get( 0 ).getNumericValue() );
+        assertEquals(1,
+                     model.getData().get(0).get(0).getNumericValue());
+        assertEquals(2,
+                     model.getData().get(1).get(0).getNumericValue());
+        assertEquals(3,
+                     model.getData().get(2).get(0).getNumericValue());
     }
 
     @Test
-    public void testMoveRowsMoveUpCheckRowNumbers() throws ModelSynchronizer.MoveColumnVetoException {
+    public void testMoveRowsMoveUpCheckRowNumbers() throws VetoException {
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
         modelSynchronizer.appendRow();
 
-        final GridRow uiRow1 = uiModel.getRow( 1 );
-        final GridRow uiRow2 = uiModel.getRow( 2 );
+        final GridRow uiRow1 = uiModel.getRow(1);
+        final GridRow uiRow2 = uiModel.getRow(2);
 
-        uiModel.moveRowsTo( 0,
-                            new ArrayList<GridRow>() {{
-                                add( uiRow1 );
-                                add( uiRow2 );
-                            }} );
+        uiModel.moveRowsTo(0,
+                           new ArrayList<GridRow>() {{
+                               add(uiRow1);
+                               add(uiRow2);
+                           }});
 
-        assertEquals( 1,
-                      uiModel.getRow( 0 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 2,
-                      uiModel.getRow( 1 ).getCells().get( 0 ).getValue().getValue() );
-        assertEquals( 3,
-                      uiModel.getRow( 2 ).getCells().get( 0 ).getValue().getValue() );
+        assertEquals(1,
+                     uiModel.getRow(0).getCells().get(0).getValue().getValue());
+        assertEquals(2,
+                     uiModel.getRow(1).getCells().get(0).getValue().getValue());
+        assertEquals(3,
+                     uiModel.getRow(2).getCells().get(0).getValue().getValue());
 
-        assertEquals( 1,
-                      model.getData().get( 0 ).get( 0 ).getNumericValue() );
-        assertEquals( 2,
-                      model.getData().get( 1 ).get( 0 ).getNumericValue() );
-        assertEquals( 3,
-                      model.getData().get( 2 ).get( 0 ).getNumericValue() );
+        assertEquals(1,
+                     model.getData().get(0).get(0).getNumericValue());
+        assertEquals(2,
+                     model.getData().get(1).get(0).getNumericValue());
+        assertEquals(3,
+                     model.getData().get(2).get(0).getNumericValue());
     }
 
     @Test
-    public void checkBooleanDefaultValueTrue() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkBooleanDefaultValueTrue() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
-        column.setAttribute( RuleAttributeWidget.ENABLED_ATTR );
-        column.setDefaultValue( new DTCellValue52( true ) );
+        column.setAttribute(RuleAttributeWidget.ENABLED_ATTR);
+        column.setDefaultValue(new DTCellValue52(true));
 
-        modelSynchronizer.appendColumn( column );
+        modelSynchronizer.appendColumn(column);
 
         modelSynchronizer.appendRow();
 
-        assertTrue( (Boolean) uiModel.getRow( 0 ).getCells().get( 2 ).getValue().getValue() );
+        assertTrue((Boolean) uiModel.getRow(0).getCells().get(2).getValue().getValue());
 
-        assertTrue( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertTrue(model.getData().get(0).get(2).getBooleanValue());
     }
 
     @Test
-    public void checkBooleanDefaultValueFalse() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkBooleanDefaultValueFalse() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
-        column.setAttribute( RuleAttributeWidget.ENABLED_ATTR );
-        column.setDefaultValue( new DTCellValue52( false ) );
+        column.setAttribute(RuleAttributeWidget.ENABLED_ATTR);
+        column.setDefaultValue(new DTCellValue52(false));
 
-        modelSynchronizer.appendColumn( column );
+        modelSynchronizer.appendColumn(column);
 
         modelSynchronizer.appendRow();
 
-        assertFalse( (Boolean) uiModel.getRow( 0 ).getCells().get( 2 ).getValue().getValue() );
+        assertFalse((Boolean) uiModel.getRow(0).getCells().get(2).getValue().getValue());
 
-        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertFalse(model.getData().get(0).get(2).getBooleanValue());
     }
 
     @Test
-    public void checkBooleanDefaultValueNotSet() throws ModelSynchronizer.MoveColumnVetoException {
+    public void checkBooleanDefaultValueNotSet() throws VetoException {
         final AttributeCol52 column = new AttributeCol52();
-        column.setAttribute( RuleAttributeWidget.ENABLED_ATTR );
+        column.setAttribute(RuleAttributeWidget.ENABLED_ATTR);
 
-        modelSynchronizer.appendColumn( column );
+        modelSynchronizer.appendColumn(column);
 
         modelSynchronizer.appendRow();
 
-        assertFalse( (Boolean) uiModel.getRow( 0 ).getCells().get( 2 ).getValue().getValue() );
+        assertFalse((Boolean) uiModel.getRow(0).getCells().get(2).getValue().getValue());
 
-        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertFalse(model.getData().get(0).get(2).getBooleanValue());
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionRetractFactPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionRetractFactPluginTest.java
@@ -26,6 +26,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryActionRetractFactCol52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.PatternToDeletePage;
@@ -39,11 +40,23 @@ import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ActionRetractFactPluginTest {
+
+    @Mock
+    private NewGuidedDecisionTableColumnWizard wizard;
 
     @Mock
     private PatternToDeletePage patternToDeletePage;
@@ -81,8 +94,6 @@ public class ActionRetractFactPluginTest {
 
     @Test
     public void testInit() throws Exception {
-        final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
-
         model.setTableFormat(GuidedDecisionTable52.TableFormat.LIMITED_ENTRY);
         doReturn(model).when(presenter).getModel();
         doReturn(presenter).when(wizard).getPresenter();
@@ -143,6 +154,17 @@ public class ActionRetractFactPluginTest {
 
         verify(presenter).updateColumn(originalCol,
                                        editingCol);
+    }
+
+    @Test
+    public void testGenerateColumnWhenColumnIsNotNewAndVetoed() throws Exception {
+        doReturn(false).when(plugin).isNewColumn();
+        doThrow(VetoException.class).when(presenter).updateColumn(any(ActionCol52.class),
+                                                                  any(ActionCol52.class));
+
+        assertFalse(plugin.generateColumn());
+
+        verify(wizard).showGenericVetoError();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionSetFactPluginTest.java
@@ -36,6 +36,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.FieldPage;
@@ -66,6 +67,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -158,6 +160,17 @@ public class ActionSetFactPluginTest {
 
         assertTrue(success);
         verify(presenter).appendColumn(actionCol52);
+    }
+
+    @Test
+    public void testGenerateColumnWhenColumnIsNotNewAndVetoed() throws Exception {
+        doReturn(false).when(plugin).isNewColumn();
+        doThrow(VetoException.class).when(presenter).updateColumn(any(ActionCol52.class),
+                                                                  any(ActionCol52.class));
+
+        assertFalse(plugin.generateColumn());
+
+        verify(wizard).showGenericVetoError();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemPluginTest.java
@@ -28,6 +28,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol5
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.WorkItemPage;
@@ -40,11 +41,24 @@ import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ActionWorkItemPluginTest {
+
+    @Mock
+    private NewGuidedDecisionTableColumnWizard wizard;
 
     @Mock
     private AdditionalInfoPage<ActionWorkItemPlugin> additionalInfoPage;
@@ -388,6 +402,17 @@ public class ActionWorkItemPluginTest {
 
         verify(presenter).updateColumn(column,
                                        editingCol);
+    }
+
+    @Test
+    public void testGenerateColumnWhenColumnIsNotNewAndVetoed() throws Exception {
+        doReturn(false).when(plugin).isNewColumn();
+        doThrow(VetoException.class).when(presenter).updateColumn(any(ActionCol52.class),
+                                                                  any(ActionCol52.class));
+
+        assertFalse(plugin.generateColumn());
+
+        verify(wizard).showGenericVetoError();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/ActionWorkItemSetFieldPluginTest.java
@@ -43,6 +43,8 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
+import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.FieldPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.PatternPage;
@@ -69,6 +71,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -78,6 +81,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ActionWorkItemSetFieldPluginTest {
+
+    @Mock
+    private NewGuidedDecisionTableColumnWizard wizard;
 
     @Mock
     private PatternWrapper patternWrapper;
@@ -307,6 +313,17 @@ public class ActionWorkItemSetFieldPluginTest {
                                        editingColumn);
         verify(translationService,
                never()).format(any());
+    }
+
+    @Test
+    public void testGenerateColumnWhenColumnIsNotNewAndVetoed() throws Exception {
+        doReturn(false).when(plugin).isNewColumn();
+        doThrow(VetoException.class).when(presenter).updateColumn(any(ActionCol52.class),
+                                                                  any(ActionCol52.class));
+
+        assertFalse(plugin.generateColumn());
+
+        verify(wizard).showGenericVetoError();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPluginTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPluginTest.java
@@ -33,6 +33,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLCon
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoUpdatePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.AdditionalInfoPage;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.RuleModellerPage;
@@ -46,8 +47,20 @@ import org.uberfire.ext.widgets.core.client.wizards.WizardPage;
 import org.uberfire.ext.widgets.core.client.wizards.WizardPageStatusChangeEvent;
 import org.uberfire.mocks.EventSourceMock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 @WithClassesToStub(BRLRuleModel.class)
@@ -171,6 +184,17 @@ public class BRLConditionColumnPluginTest {
                                        editingCol);
         verify(translationService,
                never()).format(any());
+    }
+
+    @Test
+    public void testGenerateColumnWhenColumnIsNotNewAndVetoed() throws Exception {
+        doReturn(false).when(plugin).isNewColumn();
+        doThrow(VetoUpdatePatternInUseException.class).when(presenter).updateColumn(any(BRLConditionColumn.class),
+                                                                                    any(BRLConditionColumn.class));
+
+        assertFalse(plugin.generateColumn());
+
+        verify(wizard).showPatternInUseError();
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3409

This PR prevents "Conditions" or "BRL Condition Fragments" from being updated if the change means a bound variable used on the RHS becomes unavailable. Similar checks already existed for deleting columns but not updates. I also moved all said checks to the respective _Synchronizers_ for consistency (with how moving columns/rows is prevented should _new state_ be invalid).