### PR TITLE
GUVNOR-3578: Disable or Enable both column manipulation buttons

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -230,7 +230,7 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     @Override
     public void removeDecisionTable(final GuidedDecisionTableView.Presenter dtPresenter) {
         final Command afterRemovalCommand = () -> {
-            view.setEnableColumnCreation(false);
+            view.disableColumnOperationsMenu();
             view.refreshAttributeWidget(Collections.emptyList());
             view.refreshMetaDataWidget(Collections.emptyList());
             view.refreshConditionsWidget(Collections.emptyList());
@@ -428,8 +428,12 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
 
     void refreshDefinitionsPanel(final GuidedDecisionTableView.Presenter dtPresenter) {
         final GuidedDecisionTable52 model = dtPresenter.getModel();
-
-        view.setEnableColumnCreation(isColumnCreationEnabled(dtPresenter));
+        final boolean isColumnCreationEnabled = isColumnCreationEnabled(dtPresenter);
+        if (isColumnCreationEnabled) {
+            view.enableColumnOperationsMenu();
+        } else {
+            view.disableColumnOperationsMenu();
+        }
         view.refreshAttributeWidget(model.getAttributeCols());
         view.refreshMetaDataWidget(model.getMetadataCols());
         view.refreshConditionsWidget(model.getConditions());

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -70,8 +70,6 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
     void removeDecisionTable(final GuidedDecisionTableView gridWidget,
                              final Command afterRemovalCommand);
 
-    void setEnableColumnCreation(final boolean enabled);
-
     void refreshRuleInheritance(final String selectedParentRuleName,
                                 final Collection<String> availableParentRuleNames);
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -403,11 +403,6 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
     }
 
     @Override
-    public void setEnableColumnCreation(final boolean enabled) {
-        addColumn.setEnabled(enabled);
-    }
-
-    @Override
     public void refreshRuleInheritance(final String selectedParentRuleName,
                                        final Collection<String> availableParentRuleNames) {
         ruleSelector.setRuleName(selectedParentRuleName);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/AccessTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/AccessTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccessTest {
+
+    private GuidedDecisionTablePresenter.Access access;
+
+    @Before
+    public void setUp() throws Exception {
+        access = new GuidedDecisionTablePresenter.Access();
+    }
+
+    @Test
+    public void testIsEditableNotLocked() throws Exception {
+        access.setLock(GuidedDecisionTablePresenter.Access.LockedBy.NOBODY);
+
+        assertTrue(access.isEditable());
+    }
+
+    @Test
+    public void testIsEditableLockedByCurrentUser() throws Exception {
+        access.setLock(GuidedDecisionTablePresenter.Access.LockedBy.CURRENT_USER);
+
+        assertTrue(access.isEditable());
+    }
+
+    @Test
+    public void testIsEditableLockedByOtherUser() throws Exception {
+        access.setLock(GuidedDecisionTablePresenter.Access.LockedBy.OTHER_USER);
+
+        assertFalse(access.isEditable());
+    }
+
+    @Test
+    public void testIsEditableReadOnlyTableLockedByCurrentUser() throws Exception {
+        access.setReadOnly(true);
+        access.setLock(GuidedDecisionTablePresenter.Access.LockedBy.CURRENT_USER);
+
+        assertFalse(access.isEditable());
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -305,7 +305,7 @@ public class GuidedDecisionTableModellerPresenterTest {
         afterRemovalCommand.execute();
 
         verify(view,
-               times(1)).setEnableColumnCreation(eq(false));
+               times(1)).disableColumnOperationsMenu();
         verify(view,
                times(1)).refreshAttributeWidget(eq(Collections.emptyList()));
         verify(view,
@@ -897,7 +897,6 @@ public class GuidedDecisionTableModellerPresenterTest {
     @Test
     public void testIsColumnCreationEnabledWhenGuidedDecisionTableIsEditableAndHasEditableColumns() {
 
-        doReturn(model).when(dtablePresenter).getModel();
         doReturn(false).when(dtablePresenter).isReadOnly();
         doReturn(true).when(dtablePresenter).hasEditableColumns();
 
@@ -909,7 +908,6 @@ public class GuidedDecisionTableModellerPresenterTest {
     @Test
     public void testIsColumnCreationEnabledWhenGuidedDecisionTableDoesNotHaveEditableColumns() {
 
-        doReturn(model).when(dtablePresenter).getModel();
         doReturn(false).when(dtablePresenter).isReadOnly();
         doReturn(false).when(dtablePresenter).hasEditableColumns();
 
@@ -921,7 +919,6 @@ public class GuidedDecisionTableModellerPresenterTest {
     @Test
     public void testIsColumnCreationEnabledWhenGuidedDecisionTableIsNotEditable() {
 
-        doReturn(model).when(dtablePresenter).getModel();
         doReturn(true).when(dtablePresenter).isReadOnly();
         doReturn(true).when(dtablePresenter).hasEditableColumns();
 
@@ -933,7 +930,6 @@ public class GuidedDecisionTableModellerPresenterTest {
     @Test
     public void testIsColumnCreationEnabledWhenGuidedDecisionTableIsNotEditableNeitherHasEditableColumns() {
 
-        doReturn(model).when(dtablePresenter).getModel();
         doReturn(true).when(dtablePresenter).isReadOnly();
         doReturn(false).when(dtablePresenter).hasEditableColumns();
 
@@ -943,19 +939,13 @@ public class GuidedDecisionTableModellerPresenterTest {
     }
 
     @Test
-    public void testRefreshDefinitionsPanel() {
+    public void testRefreshDefinitionsPanelColumnCreationEnabled() {
+        testRefreshDefinitionsPanel(true);
+    }
 
-        doReturn(model).when(dtablePresenter).getModel();
-        doReturn(true).when(presenter).isColumnCreationEnabled(dtablePresenter);
-
-        presenter.refreshDefinitionsPanel(dtablePresenter);
-
-        verify(view).setEnableColumnCreation(true);
-        verify(view).refreshAttributeWidget(model.getAttributeCols());
-        verify(view).refreshMetaDataWidget(model.getMetadataCols());
-        verify(view).refreshConditionsWidget(model.getConditions());
-        verify(view).refreshActionsWidget(model.getActionCols());
-        verify(view).refreshColumnsNote(dtablePresenter.hasColumnDefinitions());
+    @Test
+    public void testRefreshDefinitionsPanelColumnCreationDisabled() {
+        testRefreshDefinitionsPanel(false);
     }
 
     @Test
@@ -978,5 +968,26 @@ public class GuidedDecisionTableModellerPresenterTest {
         final boolean isEnabled = presenter.isColumnCreationEnabledToActiveDecisionTable();
 
         assertTrue(isEnabled);
+    }
+
+    private void testRefreshDefinitionsPanel(final boolean columnCreationEnabled) {
+        doReturn(model).when(dtablePresenter).getModel();
+        doReturn(columnCreationEnabled).when(presenter).isColumnCreationEnabled(dtablePresenter);
+
+        presenter.refreshDefinitionsPanel(dtablePresenter);
+
+        if (columnCreationEnabled) {
+            verify(view).enableColumnOperationsMenu();
+            verify(view, never()).disableColumnOperationsMenu();
+        } else {
+            verify(view, never()).enableColumnOperationsMenu();
+            verify(view).disableColumnOperationsMenu();
+        }
+
+        verify(view).refreshAttributeWidget(model.getAttributeCols());
+        verify(view).refreshMetaDataWidget(model.getMetadataCols());
+        verify(view).refreshConditionsWidget(model.getConditions());
+        verify(view).refreshActionsWidget(model.getActionCols());
+        verify(view).refreshColumnsNote(dtablePresenter.hasColumnDefinitions());
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -1621,17 +1621,23 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
-    public void testInitialiseAccess() {
+    public void testInitialiseAccessReadOnlyTableWithEditableColumns() {
+        testInitialiseAccess(true, true);
+    }
 
-        final GuidedDecisionTablePresenter.Access access = mock(GuidedDecisionTablePresenter.Access.class);
+    @Test
+    public void testInitialiseAccessReadOnlyTableWithoutEditableColumns() {
+        testInitialiseAccess(true, false);
+    }
 
-        doReturn(access).when(dtPresenter).getAccess();
-        doReturn(true).when(dtPresenter).canEditColumns();
+    @Test
+    public void testInitialiseAccessEditableTableWithEditableColumns() {
+        testInitialiseAccess(false, true);
+    }
 
-        dtPresenter.initialiseAccess(true);
-
-        verify(access).setReadOnly(true);
-        verify(access).setHasEditableColumns(true);
+    @Test
+    public void testInitialiseAccessEditableTableWithoutEditableColumns() {
+        testInitialiseAccess(false, false);
     }
 
     @Test
@@ -1658,6 +1664,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         final boolean hasEditableColumns = dtPresenter.hasEditableColumns();
 
         assertTrue(hasEditableColumns);
+        verify(access).hasEditableColumns();
     }
 
     /*
@@ -1677,5 +1684,17 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         dtSelectionsChangedEvents.stream().map(DecisionTableSelectionsChangedEvent::getPresenter).forEach(p -> assertEquals("Invalid DecisionTableSelectionsChangedEvent detected.",
                                                                                                                             p,
                                                                                                                             dtPresenter));
+    }
+
+    private void testInitialiseAccess(final boolean readOnly, final boolean canEditColumns) {
+        final GuidedDecisionTablePresenter.Access access = mock(GuidedDecisionTablePresenter.Access.class);
+
+        doReturn(access).when(dtPresenter).getAccess();
+        doReturn(canEditColumns).when(dtPresenter).canEditColumns();
+
+        dtPresenter.initialiseAccess(readOnly);
+
+        verify(access).setReadOnly(readOnly);
+        verify(access).setHasEditableColumns(canEditColumns);
     }
 }


### PR DESCRIPTION
Opening a table was setting column manipulation buttons state just for the Add Column button. As there is probably not case, when Add Collumn button could be enabled and Edit Column button disabled (and vice versa), the Table Modeller view API was simplified by removing method that is setting state just for Add Column button.