### PR TITLE
DROOLS-2074: [Guided Decision Table] BRL Condition Update is Vetoed

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizer.java
@@ -125,7 +125,7 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
         }
 
         //Delete columns for the original definition
-        delete(originalMetaData);
+        doDelete(originalColumn);
 
         //Signal patterns changed event to Decision Table Widget
         final BoundFactsChangedEvent pce = new BoundFactsChangedEvent(rm.getLHSBoundFacts());
@@ -159,6 +159,10 @@ public class BRLConditionColumnSynchronizer extends BaseColumnSynchronizer<BaseC
             }
         }
 
+        doDelete(column);
+    }
+
+    private void doDelete(final BRLConditionColumn column) throws VetoException {
         if (column.getChildColumns().size() > 0) {
             final int iFirstColumnIndex = model.getExpandedColumns().indexOf(column.getChildColumns().get(0));
             for (int iColumnIndex = 0; iColumnIndex < column.getChildColumns().size(); iColumnIndex++) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
@@ -347,6 +347,67 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     }
 
     @Test
+    public void checkBRLFragmentConditionCanBeUpdatedWithNewConstraintOnBoundPatternUsedInAction() throws VetoException {
+        final BRLConditionColumn column = new BRLConditionColumn();
+        column.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{
+            setBoundName("$a");
+        }}));
+        final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn("$age",
+                                                                                   DataType.TYPE_NUMERIC_INTEGER,
+                                                                                   "Applicant",
+                                                                                   "age");
+        column.getChildColumns().add(columnV0);
+        column.setHeader("col1");
+        columnV0.setHeader("col1v0");
+
+        modelSynchronizer.appendColumn(column);
+
+        final ActionSetFieldCol52 action = new ActionSetFieldCol52() {{
+            setBoundName("$a");
+            setFactField("age");
+            setHeader("action1");
+        }};
+
+        modelSynchronizer.appendColumn(action);
+
+        try {
+            final BRLConditionColumn editedColumn = new BRLConditionColumn();
+            editedColumn.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{
+                setBoundName("$a");
+            }}));
+            final BRLConditionVariableColumn editedColumnV0 = new BRLConditionVariableColumn("$age",
+                                                                                             DataType.TYPE_NUMERIC_INTEGER,
+                                                                                             "Applicant",
+                                                                                             "age");
+            final BRLConditionVariableColumn editedColumnV1 = new BRLConditionVariableColumn("$name",
+                                                                                             DataType.TYPE_STRING,
+                                                                                             "Applicant",
+                                                                                             "name");
+            editedColumn.getChildColumns().add(editedColumnV0);
+            editedColumn.getChildColumns().add(editedColumnV1);
+            editedColumn.setHeader("col1");
+            editedColumnV0.setHeader("col1v0");
+            editedColumnV1.setHeader("col1v1");
+
+            modelSynchronizer.updateColumn(column,
+                                           editedColumn);
+
+            assertEquals(5,
+                         model.getExpandedColumns().size());
+            assertTrue(model.getExpandedColumns().get(0) instanceof RowNumberCol52);
+            assertTrue(model.getExpandedColumns().get(1) instanceof DescriptionCol52);
+            assertEquals(editedColumnV0,
+                         model.getExpandedColumns().get(2));
+            assertEquals(editedColumnV1,
+                         model.getExpandedColumns().get(3));
+            assertEquals(action,
+                         model.getExpandedColumns().get(4));
+        } catch (VetoException veto) {
+            fail("VetoUpdatePatternInUseException was not expected.");
+        }
+    }
+
+    @Test
     public void checkBRLFragmentConditionCannotBeUpdatedWhenBindingIsUsedInAction() throws VetoException {
         final BRLConditionColumn column = new BRLConditionColumn();
         column.setDefinition(Collections.singletonList(new FactPattern("Applicant") {{


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2074

@jomarko The issue was that an "update" to a BRL Condition is effectively an "add" (of the updated) definition and then a "delete" (of the old). The veto exception was caused because the "delete" checks if any bindings in the fragment being deleted are used in the RHS (or other LHS elements). I've simply skipped the "delete" check when invoked as part of the update. 

This is safe as the "update" first checks if any deleted bindings (difference between original bindings and updated bindings) are used in the RHS (or other LHS elements) and fails fast if any are found.