### PR TITLE
Drools 2082 static code analysis

### DIFF
--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Callback.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Callback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/CancellableRepeatingCommand.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/CancellableRepeatingCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Reporter.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Reporter.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client;
 
 import java.util.Set;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Status.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/Status.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/StatusUpdate.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/StatusUpdate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/checks/util/NullEqualityOperator.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/checks/util/NullEqualityOperator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/AnalyzerConfiguration.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/AnalyzerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/CheckConfiguration.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/CheckConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/DateTimeFormatProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/DateTimeFormatProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/RunnerType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/configuration/RunnerType.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.configuration;
 
 public enum RunnerType {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Action.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Action.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ActionSuperType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ActionSuperType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Actions.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Actions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,11 @@ package org.drools.workbench.services.verifier.api.client.index;
 
 import java.util.Collection;
 
+import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
 import org.drools.workbench.services.verifier.api.client.index.matchers.KeyMatcher;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
-import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
 import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
 
 public class Actions {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/BRLAction.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/BRLAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/BRLCondition.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/BRLCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Column.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Column.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Columns.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Columns.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,8 +19,8 @@ import java.util.Collection;
 
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
-import org.drools.workbench.services.verifier.api.client.maps.IndexedKeyTreeMap;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
+import org.drools.workbench.services.verifier.api.client.maps.IndexedKeyTreeMap;
 
 public class Columns {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Condition.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Condition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ConditionSuperType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ConditionSuperType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Conditions.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Conditions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,11 +18,11 @@ package org.drools.workbench.services.verifier.api.client.index;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
+import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
 
 public class Conditions {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/DataType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/DataType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Field.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Field.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldAction.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldCondition.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Fields.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Fields.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldsBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/FieldsBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Index.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Index.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.index;
 
 public interface Index {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/IndexImpl.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/IndexImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/MapBy.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/MapBy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,8 +18,8 @@ package org.drools.workbench.services.verifier.api.client.index;
 import java.util.HashMap;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 
 public class MapBy<KeyType, ValueType> {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Matchers.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Matchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectField.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectField.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.drools.workbench.services.verifier.api.client.index;
 
+package org.drools.workbench.services.verifier.api.client.index;
 
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectFields.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectFields.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectTypes.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/ObjectTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,12 +19,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
+import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 
 public class ObjectTypes {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Pattern.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Pattern.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Patterns.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Patterns.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,12 +19,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
 import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
 import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
-import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 
 public class Patterns {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/RetractAction.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/RetractAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Rule.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Rule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Rules.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Rules.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,10 @@ package org.drools.workbench.services.verifier.api.client.index;
 
 import java.util.Collection;
 
-import org.drools.workbench.services.verifier.api.client.maps.IndexedKeyTreeMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.index.select.Listen;
 import org.drools.workbench.services.verifier.api.client.index.select.Select;
+import org.drools.workbench.services.verifier.api.client.maps.IndexedKeyTreeMap;
 
 public class Rules {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Where.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/Where.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/IndexKey.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/IndexKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Key.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Key.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/KeyType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/KeyType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UUIDKey.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UUIDKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UUIDKeyProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UUIDKeyProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UpdatableKey.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/UpdatableKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Value.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Value.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Values.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/keys/Values.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ComparableMatchers.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ComparableMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ExactMatcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ExactMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/FieldMatchers.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/FieldMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/FromMatcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/FromMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@
  */
 package org.drools.workbench.services.verifier.api.client.index.matchers;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 
 public class FromMatcher
         extends Matcher {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/KeyMatcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/KeyMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/Matcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/Matcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ToMatcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/ToMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@
  */
 package org.drools.workbench.services.verifier.api.client.index.matchers;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 
 public class ToMatcher
         extends Matcher {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/UUIDMatcher.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/UUIDMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/UUIDMatchers.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/matchers/UUIDMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/query/Query.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/query/Query.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.index.query;
 
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/query/QueryableIndex.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/query/QueryableIndex.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.index.query;
 
 import org.drools.workbench.services.verifier.api.client.index.Columns;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/AllListener.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/AllListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/ChangeHelper.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/ChangeHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@
  */
 package org.drools.workbench.services.verifier.api.client.index.select;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapChangeHandler;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapChangeHandler;
 
 class ChangeHelper<T> {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/ExactMatcherSearch.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/ExactMatcherSearch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 
 public class ExactMatcherSearch<T> {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/FirstListener.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/FirstListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/LastListener.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/LastListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/Listen.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/Listen.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/QueryCallback.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/QueryCallback.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.index.select;
 
 public interface QueryCallback<T> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/Select.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/index/select/Select.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ import org.drools.workbench.services.verifier.api.client.index.matchers.ToMatche
 import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.*;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 public class Select<T> {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ArrayListSubMapProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ArrayListSubMapProvider.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.maps;
 
 import java.util.ArrayList;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ArrayMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ArrayMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/IndexedKeyTreeMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/IndexedKeyTreeMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorList.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,11 +18,11 @@ package org.drools.workbench.services.verifier.api.client.maps;
 
 import java.util.ArrayList;
 
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
 import org.drools.workbench.services.verifier.api.client.relations.IsOverlapping;
 import org.drools.workbench.services.verifier.api.client.relations.IsRedundant;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/InspectorMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,13 +19,13 @@ package org.drools.workbench.services.verifier.api.client.maps;
 import java.util.Collection;
 import java.util.Set;
 
+import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
+import org.drools.workbench.services.verifier.api.client.index.keys.Key;
+import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasConflicts;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasRedundancy;
 import org.drools.workbench.services.verifier.api.client.maps.util.RedundancyResult;
-import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.index.keys.Key;
-import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.relations.Conflict;
 import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
 import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyChangeListener.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyChangeListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyDefinition.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
 
 package org.drools.workbench.services.verifier.api.client.maps;
 
-import static org.kie.soup.commons.validation.PortablePreconditions.*;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
 public class KeyDefinition
         implements Comparable<KeyDefinition> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/LeafInspectorList.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/LeafInspectorList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@
 
 package org.drools.workbench.services.verifier.api.client.maps;
 
+import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasConflicts;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasRedundancy;
 import org.drools.workbench.services.verifier.api.client.maps.util.RedundancyResult;
-import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.relations.Conflict;
 import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
 import org.drools.workbench.services.verifier.api.client.relations.IsRedundant;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapChangeHandler.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapChangeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
  */
 
 package org.drools.workbench.services.verifier.api.client.maps;
-
 
 import java.util.ArrayList;
 import java.util.List;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiSet.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/MultiSet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/NewSubMapProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/NewSubMapProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/RawMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/RawMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/RetractHandler.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/RetractHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/UUIDKeySet.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/UUIDKeySet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/UpdatableInspectorList.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/UpdatableInspectorList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,9 +20,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
-import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 
 public class UpdatableInspectorList<InspectorType extends HasUUID, InspectedType extends HasUUID>
         extends InspectorList<InspectorType> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasConflicts.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasConflicts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,6 @@
  */
 
 package org.drools.workbench.services.verifier.api.client.maps.util;
-
 
 import org.drools.workbench.services.verifier.api.client.relations.Conflict;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasIndex.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasIndex.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,6 @@
  */
 
 package org.drools.workbench.services.verifier.api.client.maps.util;
-
-import org.drools.workbench.services.verifier.api.client.index.Matchers;
-import org.drools.workbench.services.verifier.api.client.index.keys.IndexKey;
 
 public interface HasIndex {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasKeys.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasKeys.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasRedundancy.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasRedundancy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasUUID.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/HasUUID.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/RedundancyResult.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/maps/util/RedundancyResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Conflict.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Conflict.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/ConflictResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/ConflictResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Conflicts.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Conflicts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/HumanReadable.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/HumanReadable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.relations;
 
 public interface HumanReadable {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsConflicting.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsConflicting.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.relations;
 
 import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsDeficient.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsDeficient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsOverlapping.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsOverlapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsRedundant.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsRedundant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsSubsuming.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/IsSubsuming.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Operator.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Operator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Relation.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/Relation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionBlocker.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionBlocker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionBlockers.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionBlockers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/relations/SubsumptionResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@
 
 package org.drools.workbench.services.verifier.api.client.relations;
 
-import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 
 public class SubsumptionResolver {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/CheckType.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/CheckType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Explanation.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Explanation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ExplanationProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ExplanationProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ImpossibleMatchIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ImpossibleMatchIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@
 package org.drools.workbench.services.verifier.api.client.reporting;
 
 import java.util.Set;
+
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issues.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issues.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.reporting;
 
 import java.util.Set;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/MultipleValuesForOneActionIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/MultipleValuesForOneActionIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/NoteBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/NoteBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/RedundantConditionsIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/RedundantConditionsIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Severity.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Severity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/SingleHitLostIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/SingleHitLostIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,12 +49,18 @@ public class SingleHitLostIssue
 
     @Override
     public boolean equals( final Object o ) {
-        if ( this == o ) return true;
-        if ( o == null || getClass() != o.getClass() ) return false;
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
 
         final SingleHitLostIssue that = (SingleHitLostIssue) o;
 
-        if ( firstItem != null ? !firstItem.equals( that.firstItem ) : that.firstItem != null ) return false;
+        if ( firstItem != null ? !firstItem.equals( that.firstItem ) : that.firstItem != null ) {
+            return false;
+        }
         return secondItem != null ? secondItem.equals( that.secondItem ) : that.secondItem == null;
 
     }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/TableBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/TableBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Util.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Util.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ValueForActionIsSetTwiceIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ValueForActionIsSetTwiceIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ValueForFactFieldIsSetTwiceIssue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ValueForFactFieldIsSetTwiceIssue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/AnalyzerResources.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/AnalyzerResources.java
@@ -3,15 +3,16 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.drools.workbench.services.verifier.api.client.resources;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/css/AnalysisCssResources.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/css/AnalysisCssResources.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/i18n/AnalysisConstants.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/resources/i18n/AnalysisConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/AnalyzerConfigurationMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/AnalyzerConfigurationMock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/MarshallingTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/MarshallingTest.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client;
 
 import java.util.Collections;
@@ -31,7 +32,8 @@ import org.jboss.errai.marshalling.server.ServerMarshalling;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class MarshallingTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/cache/Util.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/cache/Util.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,11 +20,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
-import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
+import org.drools.workbench.services.verifier.api.client.index.keys.Value;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class Util {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ActionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ActionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class ActionTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ConditionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ConditionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class ConditionTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ConditionsListenerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/ConditionsListenerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,13 +15,16 @@
  */
 package org.drools.workbench.services.verifier.api.client.index;
 
+import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.index.select.AllListener;
-import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 public class ConditionsListenerTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/KeyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/KeyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@ package org.drools.workbench.services.verifier.api.client.index.keys;
 import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class KeyTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValueNullTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValueNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,8 @@ package org.drools.workbench.services.verifier.api.client.index.keys;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ValueNullTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValueTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValueTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,7 @@ package org.drools.workbench.services.verifier.api.client.index.keys;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class ValueTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValuesTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/keys/ValuesTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,8 @@ package org.drools.workbench.services.verifier.api.client.index.keys;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ValuesTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/query/QueryableIndexTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/query/QueryableIndexTest.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.api.client.index.query;
 
 import java.util.Collection;
@@ -34,11 +35,12 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class QuaryableIndexTest {
+public class QueryableIndexTest {
 
     private QueryableIndex queryableIndex;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ExactMatcherSearchTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ExactMatcherSearchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ExactMatcherSearchTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAddTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAddTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,16 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ListenAddTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAddToEmptyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAddToEmptyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,15 +19,16 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ListenAddToEmptyTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAllTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenAllTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,16 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ListenAllTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenRemoveTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/ListenRemoveTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,16 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ListenRemoveTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectEmptyMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectEmptyMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,13 +17,14 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 
 import java.util.Collection;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SelectEmptyMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectExactMatcherNegateTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectExactMatcherNegateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,17 +19,17 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith( Parameterized.class )
 public class SelectExactMatcherNegateTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectExactMatcherTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectExactMatcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,15 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class SelectExactMatcherTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectKeyMatcherTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectKeyMatcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,15 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 import java.util.Collection;
 import java.util.List;
 
+import org.drools.workbench.services.verifier.api.client.index.keys.Value;
+import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
 import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
 import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
-import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class SelectKeyMatcherTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectNoMatchesTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectNoMatchesTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,17 +17,18 @@ package org.drools.workbench.services.verifier.api.client.index.select;
 
 import java.util.Collection;
 
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
+import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
-import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SelectNoMatchesTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectNullTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectWithNegativeExactMatcherWhenTheValueIsNotInTheMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/index/select/SelectWithNegativeExactMatcherWhenTheValueIsNotInTheMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,19 +19,19 @@ import java.util.Collection;
 import java.util.List;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
-import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
-import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.ExactMatcher;
+import org.drools.workbench.services.verifier.api.client.maps.KeyDefinition;
+import org.drools.workbench.services.verifier.api.client.maps.KeyTreeMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMap;
+import org.drools.workbench.services.verifier.api.client.maps.MultiMapFactory;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class SelectWithNegativeExactMatcherWhenTheValueIsNotInTheMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMapPreExistingDataTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMapPreExistingDataTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,8 @@ import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ChangeHandledMultiMapPreExistingDataTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/ChangeHandledMultiMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,9 @@ import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ChangeHandledMultiMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/IndexedKeyTreeMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/IndexedKeyTreeMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@
 
 package org.drools.workbench.services.verifier.api.client.maps;
 
+import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.index.keys.IndexKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.UpdatableKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasIndex;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class IndexedKeyTreeMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyDefinitionBuilderTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyDefinitionBuilderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,8 @@ package org.drools.workbench.services.verifier.api.client.maps;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class KeyDefinitionBuilderTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapMergeTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapMergeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,15 +21,15 @@ import java.util.Collections;
 import java.util.List;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.matchers.Matcher;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class KeyTreeMapMergeTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapMultiValueKeyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapMultiValueKeyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,17 +20,18 @@ import java.util.List;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.cache.Util;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.UpdatableKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class KeyTreeMapMultiValueKeyTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,19 +18,23 @@ package org.drools.workbench.services.verifier.api.client.maps;
 
 import java.util.List;
 
+import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.cache.Util;
+import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
+import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.UpdatableKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Value;
-import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KeyTreeMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapUUIDKeyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KeyTreeMapUUIDKeyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,10 @@
 package org.drools.workbench.services.verifier.api.client.maps;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KnownKeysKeyTreeMapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/KnownKeysKeyTreeMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,15 @@
 
 package org.drools.workbench.services.verifier.api.client.maps;
 
+import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
-import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class KnownKeysKeyTreeMapTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapFactoryTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/MultiMapFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,8 @@ package org.drools.workbench.services.verifier.api.client.maps;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MultiMapFactoryTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/UpdatableInspectorListTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/maps/UpdatableInspectorListTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,16 +19,16 @@ package org.drools.workbench.services.verifier.api.client.maps;
 import java.util.ArrayList;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
+import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
-import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class UpdatableInspectorListTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/OperatorTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/OperatorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,9 @@
 
 package org.drools.workbench.services.verifier.api.client.relations;
 
-import org.drools.workbench.services.verifier.api.client.relations.Operator;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class OperatorTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolverConflictsTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolverConflictsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,17 +17,21 @@
 package org.drools.workbench.services.verifier.api.client.relations;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
-import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class RelationResolverConflictsTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolverSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/test/java/org/drools/workbench/services/verifier/api/client/relations/RelationResolverSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,17 +17,21 @@
 package org.drools.workbench.services.verifier.api.client.relations;
 
 import org.drools.workbench.services.verifier.api.client.AnalyzerConfigurationMock;
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
-import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class RelationResolverSubsumptionTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/plugin/backend/VerifierWebWorkerServlet.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/plugin/backend/VerifierWebWorkerServlet.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.backend;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/AnalyzerBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/AnalyzerBuilder.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import java.util.Date;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/CellUpdateManagerBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/CellUpdateManagerBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/CheckConfigurationProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/CheckConfigurationProvider.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/DTableUpdateManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/DTableUpdateManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/NullEqualityOperatorCellUpdateManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/NullEqualityOperatorCellUpdateManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/Poster.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/Poster.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import org.drools.workbench.services.verifier.api.client.Status;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/Receiver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/Receiver.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import java.util.Set;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/RegularCellUpdateManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/RegularCellUpdateManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@ package org.drools.workbench.services.verifier.webworker.client;
 
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
-import org.drools.workbench.services.verifier.plugin.client.builders.ActionBuilder;
 import org.drools.workbench.services.verifier.api.client.index.Action;
 import org.drools.workbench.services.verifier.api.client.index.Condition;
 import org.drools.workbench.services.verifier.api.client.index.Index;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.plugin.client.Coordinate;
+import org.drools.workbench.services.verifier.plugin.client.builders.ActionBuilder;
 
 public class RegularCellUpdateManager
         extends CellUpdateManagerBase {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/UpdateException.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/UpdateException.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 public class UpdateException

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/VerifierWebWorker.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/client/VerifierWebWorker.java
@@ -3,15 +3,17 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import com.google.gwt.core.client.EntryPoint;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/linker/VerifierLinker.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/java/org/drools/workbench/services/verifier/webworker/linker/VerifierLinker.java
@@ -3,15 +3,17 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 package org.drools.workbench.services.verifier.webworker.linker;
 
 import com.google.gwt.core.ext.LinkerContext;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/plugin/backend/VerifierWebWorkerServletTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/plugin/backend/VerifierWebWorkerServletTest.java
@@ -1,21 +1,23 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.backend;
 
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -27,7 +29,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VerifierWebWorkerServletTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/AnalyzerUpdateTestBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/AnalyzerUpdateTestBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/CheckConfigurationProviderTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/CheckConfigurationProviderTest.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import java.util.Set;
@@ -22,7 +23,8 @@ import org.drools.workbench.services.verifier.api.client.configuration.CheckConf
 import org.drools.workbench.services.verifier.api.client.reporting.CheckType;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CheckConfigurationProviderTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DataBuilderProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DataBuilderProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerAddRowScenarioTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerAddRowScenarioTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertOnlyContains;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(GwtMockitoTestRunner.class)

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerConflictResolverLimitedDTableTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerConflictResolverLimitedDTableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerConflictResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerConflictResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,8 @@ import org.drools.workbench.services.verifier.api.client.reporting.Severity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerConflictResolverTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerDeficiencyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerDeficiencyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,8 @@ import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerDeficiencyTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerMultipleIssuesFromFileTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerMultipleIssuesFromFileTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerRangeCheckTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerRangeCheckTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerRedundancyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerRedundancyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSingleHitTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSingleHitTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSubsumptionResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSubsumptionResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,8 @@ import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerSubsumptionResolverTest extends AnalyzerUpdateTestBase {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,8 @@ import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerSubsumptionTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,8 +29,12 @@ import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
-import static org.junit.Assert.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertOnlyContains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerUniqueHitPolicyTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerUniqueHitPolicyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,6 @@
  */
 
 package org.drools.workbench.services.verifier.webworker.client;
-
-import java.util.HashSet;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerUpdateTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerUpdateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,9 +22,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.ExtendedGuidedDecisionTableBuilder.*;
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
-import static org.junit.Assert.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.ExtendedGuidedDecisionTableBuilder.createActionSetField;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.ExtendedGuidedDecisionTableBuilder.createBRLConditionColumn;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerUpdateTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerWhiteListTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/DecisionTableAnalyzerWhiteListTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertOnlyContains;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DecisionTableAnalyzerWhiteListTest

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/ExplanationTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/ExplanationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@ import org.drools.workbench.services.verifier.api.client.reporting.Explanation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ExplanationTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/RangeCheckFromFileTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/RangeCheckFromFileTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/ReceiverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/ReceiverTest.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -30,7 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ReceiverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/SpeedTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/SpeedTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ import org.kie.soup.project.datamodel.oracle.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class SpeedTest extends AnalyzerUpdateTestBase {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/Util.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/Util.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerIsNullTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerIsNullTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DTableUpdateManagerIsNullTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerRetractTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerRetractTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DTableUpdateManagerRetractTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/cache/util/DTableUpdateManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,8 @@ import org.mockito.Mock;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anySet;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DTableUpdateManagerTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/fromfile/BRLFragmentsAnalyzerFromFileTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/fromfile/BRLFragmentsAnalyzerFromFileTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/fromfile/DecisionTableAnalyzerFromFileTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/fromfile/DecisionTableAnalyzerFromFileTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.*;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertDoesNotContain;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertOnlyContains;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.assertResultIsEmpty;
+import static org.drools.workbench.services.verifier.webworker.client.testutil.TestUtil.loadResource;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(GwtMockitoTestRunner.class)

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AbstractDecisionTableBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AbstractDecisionTableBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerConfigurationMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerConfigurationMock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@ package org.drools.workbench.services.verifier.webworker.client.testutil;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.configuration.CheckConfiguration;
 import org.drools.workbench.services.verifier.api.client.configuration.RunnerType;
 import org.drools.workbench.services.verifier.webworker.client.CheckConfigurationProvider;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/AnalyzerProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/DateTimeFormatProviderMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/DateTimeFormatProviderMock.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client.testutil;
 
 import java.util.Date;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/DecisionTableAnalyzerBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/DecisionTableAnalyzerBuilder.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client.testutil;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -29,7 +30,7 @@ import org.drools.workbench.services.verifier.plugin.client.builders.ModelMetaDa
 import org.drools.workbench.services.verifier.plugin.client.builders.VerifierColumnUtilities;
 import org.drools.workbench.services.verifier.webworker.client.DTableUpdateManager;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class DecisionTableAnalyzerBuilder {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/ExtendedGuidedDecisionTableBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/ExtendedGuidedDecisionTableBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class ExtendedGuidedDecisionTableBuilder
         extends AbstractDecisionTableBuilder {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/LimitedGuidedDecisionTableBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/LimitedGuidedDecisionTableBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/TestUtil.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/TestUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,11 +29,10 @@ import org.drools.workbench.services.verifier.api.client.reporting.Issue;
 import org.drools.workbench.services.verifier.api.client.reporting.Severity;
 import org.drools.workbench.services.verifier.webworker.client.fromfile.DecisionTableAnalyzerFromFileTest;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestUtil {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/UUIDKeyProviderMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/test/java/org/drools/workbench/services/verifier/webworker/client/testutil/UUIDKeyProviderMock.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.webworker.client.testutil;
 
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKeyProvider;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/Coordinate.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/Coordinate.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/DTableUpdateManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/DTableUpdateManager.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client;
 
 import java.util.List;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/Logger.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/Logger.java
@@ -1,17 +1,17 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.drools.workbench.services.verifier.plugin.client;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/DeleteColumns.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/DeleteColumns.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/FactTypes.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/FactTypes.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import java.util.HashSet;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/HeaderMetaData.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/HeaderMetaData.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import java.util.Map;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/Initialize.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/Initialize.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/MakeRule.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/MakeRule.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/ModelMetaData.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/ModelMetaData.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/NewColumn.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/NewColumn.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/RemoveRule.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/RemoveRule.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/RequestStatus.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/RequestStatus.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.jboss.errai.common.client.api.annotations.Portable;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/Update.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/Update.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import java.util.List;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/WebWorkerException.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/WebWorkerException.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/WebWorkerLogMessage.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/api/WebWorkerLogMessage.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.api;
 
 import org.jboss.errai.common.client.api.annotations.MapsTo;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ActionBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ActionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.soup.project.datamodel.oracle.DataType;
 
-import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.*;
+import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.getRealCellValue;
 
 public class ActionBuilder {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BRLConditionBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BRLConditionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BuildException.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BuildException.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 public class BuildException

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BuilderFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BuilderFactory.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/CellBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/CellBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ import org.drools.workbench.services.verifier.api.client.index.Pattern;
 import org.drools.workbench.services.verifier.api.client.index.Rule;
 import org.kie.soup.commons.validation.PortablePreconditions;
 
-import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.*;
+import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.getRealCellValue;
 
 public class CellBuilder {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnUtilitiesBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnUtilitiesBase.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnUtilitiesException.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ColumnUtilitiesException.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 public class ColumnUtilitiesException

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ConditionBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ConditionBuilder.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import java.util.List;
@@ -25,7 +26,7 @@ import org.drools.workbench.services.verifier.api.client.index.Pattern;
 import org.drools.workbench.services.verifier.api.client.index.Rule;
 import org.kie.soup.commons.validation.PortablePreconditions;
 
-import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.*;
+import static org.drools.workbench.services.verifier.plugin.client.builders.Utils.getRealCellValue;
 
 public class ConditionBuilder {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/FieldConditionBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/FieldConditionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/FieldResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/FieldResolver.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/IndexBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/IndexBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ModelMetaDataEnhancer.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ModelMetaDataEnhancer.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import java.util.HashMap;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/PatternResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/PatternResolver.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/RuleBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/RuleBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ToString.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ToString.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import java.util.List;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/Utils.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/Utils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,19 +15,13 @@
  */
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
-import java.util.List;
-
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
-import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Field;
-import org.drools.workbench.services.verifier.api.client.index.Index;
 import org.drools.workbench.services.verifier.api.client.index.ObjectField;
 import org.drools.workbench.services.verifier.api.client.index.ObjectType;
-import org.drools.workbench.services.verifier.api.client.index.Pattern;
-import org.drools.workbench.services.verifier.api.client.index.Rule;
 
 public class Utils {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ValueResolveException.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ValueResolveException.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 public class ValueResolveException

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ValuesResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/ValuesResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/VerifierColumnUtilities.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/VerifierColumnUtilities.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/test/java/org/drools/workbench/services/verifier/plugin/client/builders/ModelMetaDataEnhancerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-client/src/test/java/org/drools/workbench/services/verifier/plugin/client/builders/ModelMetaDataEnhancerTest.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
 import java.util.ArrayList;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/RuleInspectorCache.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/RuleInspectorCache.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldActionsInspectorMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldActionsInspectorMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@
  */
 package org.drools.workbench.services.verifier.core.cache.inspectors;
 
-import org.drools.workbench.services.verifier.core.cache.inspectors.action.ActionsInspectorMultiMap;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Field;
+import org.drools.workbench.services.verifier.core.cache.inspectors.action.ActionsInspectorMultiMap;
 
 public class FieldActionsInspectorMultiMap
         extends ActionsInspectorMultiMap<Field> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/PatternInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/PatternInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspectorDumper.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspectorDumper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,11 @@
 package org.drools.workbench.services.verifier.core.cache.inspectors;
 
 import org.drools.workbench.services.verifier.api.client.maps.InspectorList;
+import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
 import org.drools.workbench.services.verifier.core.cache.inspectors.action.ActionInspector;
 import org.drools.workbench.services.verifier.core.cache.inspectors.action.ActionsInspectorMultiMap;
 import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionInspector;
 import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionsInspectorMultiMap;
-import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
 
 /**
  * This class is for debugging purposes. It is way easier to just dump the inspector into a string than compare the

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspectorUpdater.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/RuleInspectorUpdater.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,16 +19,16 @@ package org.drools.workbench.services.verifier.core.cache.inspectors.action;
 import java.util.Date;
 import java.util.Iterator;
 
-import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
-import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
-import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
-import org.drools.workbench.services.verifier.api.client.relations.IsRedundant;
-import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Action;
 import org.drools.workbench.services.verifier.api.client.index.keys.Key;
 import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
+import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
+import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
+import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
+import org.drools.workbench.services.verifier.api.client.relations.IsRedundant;
+import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
 
 public abstract class ActionInspector
         implements IsRedundant,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspectorFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspectorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.action;
 
-import org.drools.workbench.services.verifier.api.client.maps.InspectorFactory;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Action;
 import org.drools.workbench.services.verifier.api.client.index.FieldAction;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorFactory;
 
 public class ActionInspectorFactory
         extends InspectorFactory<ActionInspector, Action> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionsInspectorMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionsInspectorMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.action;
 
-import org.drools.workbench.services.verifier.api.client.maps.InspectorMultiMap;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorMultiMap;
 
 public class ActionsInspectorMultiMap<GroupBy extends Comparable>
         extends InspectorMultiMap<GroupBy, ActionInspector> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/BRLActionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/BRLActionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/FieldActionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/FieldActionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BRLConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BRLConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BooleanConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BooleanConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,11 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.condition;
 
-import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
-import org.drools.workbench.services.verifier.api.client.relations.Operator;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Field;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.relations.IsConflicting;
+import org.drools.workbench.services.verifier.api.client.relations.Operator;
 
 public class ComparableConditionInspector<T extends Comparable<T>>
         extends ConditionInspector<T>

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,11 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.condition;
 
+import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
+import org.drools.workbench.services.verifier.api.client.index.Condition;
+import org.drools.workbench.services.verifier.api.client.index.keys.Key;
+import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
+import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasKeys;
 import org.drools.workbench.services.verifier.api.client.maps.util.HasUUID;
 import org.drools.workbench.services.verifier.api.client.relations.HumanReadable;
@@ -23,11 +28,6 @@ import org.drools.workbench.services.verifier.api.client.relations.IsConflicting
 import org.drools.workbench.services.verifier.api.client.relations.IsOverlapping;
 import org.drools.workbench.services.verifier.api.client.relations.IsRedundant;
 import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
-import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.index.Condition;
-import org.drools.workbench.services.verifier.api.client.index.keys.Key;
-import org.drools.workbench.services.verifier.api.client.index.keys.UUIDKey;
-import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 
 public abstract class ConditionInspector<T extends Comparable<T>>
         implements IsRedundant,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionInspectorFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionInspectorFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.condition;
 
-import org.drools.workbench.services.verifier.api.client.maps.InspectorFactory;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Condition;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorFactory;
 
 public class ConditionInspectorFactory
         extends InspectorFactory<ConditionInspector, Condition> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionsInspectorMultiMap.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ConditionsInspectorMultiMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.condition;
 
-import org.drools.workbench.services.verifier.api.client.maps.InspectorMultiMap;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.ObjectField;
+import org.drools.workbench.services.verifier.api.client.maps.InspectorMultiMap;
 
 public class ConditionsInspectorMultiMap
         extends InspectorMultiMap<ObjectField, ConditionInspector> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors.condition;
 
-import org.drools.workbench.services.verifier.api.client.relations.Operator;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.relations.Operator;
 
 public class NumericIntegerConditionInspector
         extends ComparableConditionInspector<Integer> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspector.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,11 +20,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
-import org.drools.workbench.services.verifier.api.client.relations.Operator;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
+import org.drools.workbench.services.verifier.api.client.relations.IsSubsuming;
+import org.drools.workbench.services.verifier.api.client.relations.Operator;
 
 public class StringConditionInspector
         extends ComparableConditionInspector<String> {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectConflictingRowsCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectConflictingRowsCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectDeficientRowsCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectDeficientRowsCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectEmptyRowCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectEmptyRowCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectImpossibleMatchCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectImpossibleMatchCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMissingActionCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMissingActionCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMissingConditionCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMissingConditionCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMultipleValuesForOneActionCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectMultipleValuesForOneActionCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionFactFieldCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionFactFieldCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionValueCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantActionValueCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantConditionsCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantConditionsCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantRowsCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectRedundantRowsCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/SingleHitCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/SingleHitCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/SingleRangeCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/SingleRangeCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,7 +46,9 @@ import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspecto
 import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionInspector;
 import org.drools.workbench.services.verifier.core.checks.base.CheckBase;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.drools.workbench.services.verifier.api.client.relations.Operator.resolve;
 
 public class SingleRangeCheck extends CheckBase {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/Check.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/Check.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckBase.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.google.gwt.user.client.Command;
-import org.drools.workbench.services.verifier.api.client.Status;
 import org.drools.workbench.services.verifier.api.client.StatusUpdate;
 import org.drools.workbench.services.verifier.api.client.configuration.RunnerType;
 import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunner.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunner.java
@@ -1,24 +1,24 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import java.util.Set;
 
 import com.google.gwt.user.client.Command;
-import org.drools.workbench.services.verifier.api.client.Status;
 import org.drools.workbench.services.verifier.api.client.StatusUpdate;
 
 public interface CheckRunner {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunnerFactory.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunnerFactory.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import org.drools.workbench.services.verifier.api.client.configuration.RunnerType;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckStorage.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/CheckStorage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/ChecksRepeatingCommand.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/ChecksRepeatingCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/GWTCheckRunner.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/GWTCheckRunner.java
@@ -1,25 +1,25 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import java.util.Set;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Command;
-import org.drools.workbench.services.verifier.api.client.Status;
 import org.drools.workbench.services.verifier.api.client.StatusUpdate;
 
 public class GWTCheckRunner

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/JavaCheckRunner.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/JavaCheckRunner.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import java.util.Set;
 
 import com.google.gwt.user.client.Command;
-import org.drools.workbench.services.verifier.api.client.Status;
 import org.drools.workbench.services.verifier.api.client.StatusUpdate;
 
 /**

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/OneToManyCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/OneToManyCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.configuration.CheckConfiguration;
 import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;
 
 /**

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckBundle.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckBundle.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckStorage.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckStorage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,8 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;
 import org.drools.workbench.services.verifier.api.client.maps.MultiSet;
+import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;
 
 public class PairCheckStorage {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PriorityListCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/PriorityListCheck.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import java.util.List;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/SingleCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/base/SingleCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,7 @@
 
 package org.drools.workbench.services.verifier.core.checks.base;
 
-
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
-import org.drools.workbench.services.verifier.api.client.configuration.CheckConfiguration;
 import org.drools.workbench.services.verifier.api.client.reporting.CheckType;
 import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Analyzer.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Analyzer.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.main;
 
 import java.util.HashSet;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Reporter.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Reporter.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.main;
 
 import java.util.Set;

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/RuleInspectorCacheTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/RuleInspectorCacheTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class RuleInspectorCacheTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/ConditionsInspectorTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/ConditionsInspectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,23 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors;
 
-import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ComparableConditionInspector;
-import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionInspector;
 import org.drools.workbench.services.verifier.api.client.index.Column;
 import org.drools.workbench.services.verifier.api.client.index.Field;
+import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
 import org.drools.workbench.services.verifier.api.client.index.ObjectField;
 import org.drools.workbench.services.verifier.api.client.index.keys.Values;
+import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ComparableConditionInspector;
+import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionInspector;
 import org.drools.workbench.services.verifier.core.cache.inspectors.condition.ConditionsInspectorMultiMap;
-import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConditionsInspectorTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspectorRelationsTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspectorRelationsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,16 @@
 
 package org.drools.workbench.services.verifier.core.cache.inspectors;
 
-import org.drools.workbench.services.verifier.api.client.index.ObjectField;
 import org.drools.workbench.services.verifier.api.client.configuration.AnalyzerConfiguration;
 import org.drools.workbench.services.verifier.api.client.index.Field;
+import org.drools.workbench.services.verifier.api.client.index.ObjectField;
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class FieldInspectorRelationsTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspectorUpdateTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/FieldInspectorUpdateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FieldInspectorUpdateTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/PatternInspectorTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/PatternInspectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,8 +23,9 @@ import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationM
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class PatternInspectorTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspectorConflictResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/action/ActionInspectorConflictResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,8 +32,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ActionInspectorConflictResolverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BooleanConditionInspectorTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/BooleanConditionInspectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith( Parameterized.class )
 public class BooleanConditionInspectorTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspectorConflictResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspectorConflictResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class ComparableConditionInspectorConflictResolverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspectorSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/ComparableConditionInspectorSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class ComparableConditionInspectorSubsumptionTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/DateConditionInspectorSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/DateConditionInspectorSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,8 +28,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DateConditionInspectorSubsumptionTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/DoubleComparableConditionInspectorCoverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/DoubleComparableConditionInspectorCoverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class DoubleComparableConditionInspectorCoverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorConflictResolverOverlapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorConflictResolverOverlapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class NumericIntegerConditionInspectorConflictResolverOverlapTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class NumericIntegerConditionInspectorSubsumptionResolverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/NumericIntegerConditionInspectorSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class NumericIntegerConditionInspectorSubsumptionTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorConflictResolverOverlapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorConflictResolverOverlapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ import java.util.Collection;
 
 import org.drools.workbench.services.verifier.api.client.index.Column;
 import org.drools.workbench.services.verifier.api.client.index.Field;
-import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,8 +30,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class StringConditionInspectorConflictResolverOverlapTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorCoverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorCoverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ import java.util.Collection;
 
 import org.drools.workbench.services.verifier.api.client.index.Column;
 import org.drools.workbench.services.verifier.api.client.index.Field;
-import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.relations.Operator;
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class StringConditionInspectorCoverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorOverlapTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorOverlapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,8 +26,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StringConditionInspectorOverlapTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionResolverTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class StringConditionInspectorSubsumptionResolverTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorSubsumptionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ import java.util.Collection;
 
 import org.drools.workbench.services.verifier.api.client.index.Column;
 import org.drools.workbench.services.verifier.api.client.index.Field;
-import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.api.client.index.FieldCondition;
+import org.drools.workbench.services.verifier.api.client.index.keys.Values;
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class StringConditionInspectorSubsumptionTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorToHumanReadableTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/cache/inspectors/condition/StringConditionInspectorToHumanReadableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,8 +35,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class StringConditionInspectorToHumanReadableTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/AnalyzerConfigurationMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/AnalyzerConfigurationMock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/CheckRunManagerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/CheckRunManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,8 +41,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class CheckRunManagerTest {

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckFactoryTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,8 +20,9 @@ import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspecto
 import org.drools.workbench.services.verifier.core.checks.AnalyzerConfigurationMock;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class CheckFactoryTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunManagerRepeatingCommandTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunManagerRepeatingCommandTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,8 @@ import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class CheckRunManagerRepeatingCommandTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunnerFactoryTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/CheckRunnerFactoryTest.java
@@ -1,24 +1,26 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.drools.workbench.services.verifier.core.checks.base;
 
 import org.drools.workbench.services.verifier.api.client.configuration.RunnerType;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CheckRunnerFactoryTest {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckStorageListTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/test/java/org/drools/workbench/services/verifier/core/checks/base/PairCheckStorageListTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,8 +27,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith( MockitoJUnitRunner.class )
 public class PairCheckStorageListTest {


### PR DESCRIPTION
Prepare `drools-wb-verifier` module for the static code analysis that is already turned on in some other projects of kiegroup.

@manstis please have a look. 99% of changes is maked up from licences and imports organization. I think just in one file I have added `{}` for if statements.