### PR TITLE
DROOLS-2076: Add reproducer test for the guided rule editor

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/pages/RuleModellerPageTest.java
@@ -16,17 +16,24 @@
 
 package org.drools.workbench.screens.guided.dtable.client.wizard.column.pages;
 
+import java.util.Collections;
+
 import com.google.gwt.junit.GWTMockUtilities;
+import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.BRLActionColumnPlugin;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.plugins.BRLConditionColumnPlugin;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleModeller;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleModellerConfiguration;
+import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
+import org.drools.workbench.screens.guided.template.client.editor.TemplateModellerWidgetFactory;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,7 +45,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -46,7 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
-@WithClassesToStub(RuleModeller.class)
+@WithClassesToStub({GuidedRuleEditorImages508.class, FlexTable.class})
 public class RuleModellerPageTest {
 
     @Mock
@@ -103,12 +112,20 @@ public class RuleModellerPageTest {
 
     @Test
     public void testRuleModeller() throws Exception {
+        when(brlActionPlugin.getRuleModel()).thenReturn(new RuleModel());
         when(brlActionPlugin.tableFormat()).thenReturn(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
+        when(brlActionPlugin.getRuleModellerActionPlugins()).thenReturn(Collections.emptyList());
+        when(brlActionPlugin.getRuleModellerConfiguration()).thenReturn(mock(RuleModellerConfiguration.class));
         when(presenter.getDataModelOracle()).thenReturn(mock(AsyncPackageDataModelOracle.class));
 
         final RuleModeller ruleModeller = brlActionPage.ruleModeller();
 
         assertNotNull(ruleModeller);
+        assertEquals(brlActionPlugin.getRuleModel(), ruleModeller.getModel());
+        assertEquals(Collections.emptyList(), ruleModeller.getActionPlugins());
+        assertEquals(presenter.getDataModelOracle(), ruleModeller.getDataModelOracle());
+        assertTrue(ruleModeller.getWidgetFactory() instanceof TemplateModellerWidgetFactory);
+        assertFalse(ruleModeller.isReadOnly());
     }
 
     @Test
@@ -126,7 +143,9 @@ public class RuleModellerPageTest {
 
     @Test
     public void testPrepareViewBrlAction() throws Exception {
+        when(brlActionPlugin.getRuleModel()).thenReturn(new RuleModel());
         when(brlActionPlugin.tableFormat()).thenReturn(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
+        when(brlActionPlugin.getRuleModellerConfiguration()).thenReturn(mock(RuleModellerConfiguration.class));
 
         brlActionPage.prepareView();
 
@@ -139,7 +158,9 @@ public class RuleModellerPageTest {
 
     @Test
     public void testPrepareViewBrlCondition() throws Exception {
+        when(brlConditionPlugin.getRuleModel()).thenReturn(new RuleModel());
         when(brlConditionPlugin.tableFormat()).thenReturn(GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY);
+        when(brlConditionPlugin.getRuleModellerConfiguration()).thenReturn(mock(RuleModellerConfiguration.class));
 
         brlConditionPage.prepareView();
 

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/pom.xml
@@ -137,11 +137,34 @@
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-datamodel-backend</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta-regexp</groupId>
+          <artifactId>jakarta-regexp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/AbstractRuleModellerSelectorPopup.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/AbstractRuleModellerSelectorPopup.java
@@ -51,7 +51,7 @@ public abstract class AbstractRuleModellerSelectorPopup extends BaseModal {
 
     protected final SimplePanel choicesPanel = GWT.create(SimplePanel.class);
     protected final FormStyleLayout layoutPanel = GWT.create(FormStyleLayout.class);
-    protected final ListBox positionCbo = GWT.create(ListBox.class);
+    protected final ListBox positionCbo = new ListBox();
     protected ListBox choices;
 
     public AbstractRuleModellerSelectorPopup(final RuleModel model,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
@@ -123,13 +123,13 @@ public class GuidedRuleEditorPresenter
 
     protected void loadContent() {
         view.showLoading();
-        service.call(getModelSuccessCallback(),
-                     getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
+        getService().call(getModelSuccessCallback(),
+                          getNoSuchFileExceptionErrorCallback()).loadContent(getVersionRecordManager().getCurrentPath());
     }
 
     @Override
     public void onSourceTabSelected() {
-        service.call(new RemoteCallback<String>() {
+        getService().call(new RemoteCallback<String>() {
             @Override
             public void callback(String source) {
                 updateSource(source);
@@ -199,7 +199,7 @@ public class GuidedRuleEditorPresenter
         return new Command() {
             @Override
             public void execute() {
-                service.call(new RemoteCallback<List<ValidationMessage>>() {
+                getService().call(new RemoteCallback<List<ValidationMessage>>() {
                     @Override
                     public void callback(final List<ValidationMessage> results) {
                         if (results == null || results.isEmpty()) {
@@ -237,11 +237,10 @@ public class GuidedRuleEditorPresenter
 
     @Override
     protected void save(String commitMessage) {
-        service.call(getSaveSuccessCallback(model.hashCode()),
-                     new HasBusyIndicatorDefaultErrorCallback(view)).save(versionRecordManager.getCurrentPath(),
-                                                                          view.getContent(),
-                                                                          metadata,
-                                                                          commitMessage);
+        getService().call(getSaveSuccessCallback(model.hashCode()),
+                          new HasBusyIndicatorDefaultErrorCallback(view)).save(versionRecordManager.getCurrentPath(),
+                                                                               view.getContent(),
+                                                                               metadata, commitMessage);
     }
 
     @OnClose
@@ -281,5 +280,12 @@ public class GuidedRuleEditorPresenter
     @WorkbenchMenu
     public Menus getMenus() {
         return menus;
+    }
+
+    /*
+     * Getter due to test purposes
+     */
+    Caller<GuidedRuleEditorService> getService() {
+        return service;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModellerConditionSelectorPopup.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModellerConditionSelectorPopup.java
@@ -15,6 +15,7 @@
  */
 package org.drools.workbench.screens.guided.rule.client.editor;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -142,7 +143,7 @@ public class RuleModellerConditionSelectorPopup extends AbstractRuleModellerSele
     }
 
     private ListBox makeChoicesListBox() {
-        choices = new ListBox(true);
+        choices = GWT.create(ListBox.class);
         choices.setPixelSize(getChoicesWidth(),
                              getChoicesHeight());
 

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenterTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.client.editor;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
+import org.drools.workbench.screens.guided.rule.model.GuidedEditorContent;
+import org.drools.workbench.screens.guided.rule.service.GuidedRuleEditorService;
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.project.datamodel.imports.Imports;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.kie.workbench.common.widgets.configresource.client.widget.bound.ImportsWidgetPresenter;
+import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView;
+import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+import org.uberfire.mocks.CallerMock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@WithClassesToStub({Text.class, BaseModal.class})
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedRuleEditorPresenterTest {
+
+    private GuidedEditorContent guidedEditorContent;
+
+    @Mock
+    private KieEditorWrapperView kieEditorWrapperView;
+
+    @Mock
+    private OverviewWidgetPresenter overviewWidgetPresenter;
+
+    @Mock
+    private ManagedInstance<RuleModellerActionPlugin> actionPluginInstance;
+
+    @Mock
+    private ImportsWidgetPresenter importsWidgetPresenter;
+
+    @Mock
+    private AsyncPackageDataModelOracleFactory oracleFactory;
+
+    @Mock
+    private GuidedRuleEditorView view;
+
+    @Mock
+    private ObservablePath resourcePath;
+
+    @Mock
+    private VersionRecordManager versionRecordManager;
+
+    @Mock
+    private GuidedRuleEditorService service;
+
+    private CallerMock<GuidedRuleEditorService> serviceCaller;
+
+    @Mock
+    private RuleModel ruleModel;
+
+    @Mock
+    private Imports imports;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracle;
+
+    @Mock
+    private PackageDataModelOracleBaselinePayload payload;
+
+    @Mock
+    private Overview overview;
+
+    @Spy
+    @InjectMocks
+    private GuidedRuleEditorPresenter presenter = new GuidedRuleEditorPresenter(view);
+
+    @Before
+    public void setUp() throws Exception {
+        guidedEditorContent = new GuidedEditorContent(ruleModel,
+                                                      overview,
+                                                      payload);
+        serviceCaller = new CallerMock<>(service);
+
+        doReturn(imports).when(ruleModel).getImports();
+
+        doReturn(oracle).when(oracleFactory).makeAsyncPackageDataModelOracle(resourcePath, ruleModel, payload);
+
+        doReturn(resourcePath).when(versionRecordManager).getCurrentPath();
+        doReturn(resourcePath).when(versionRecordManager).getPathToLatest();
+
+        doReturn(guidedEditorContent).when(service).loadContent(resourcePath);
+
+        doReturn(serviceCaller).when(presenter).getService();
+        doReturn(versionRecordManager).when(presenter).getVersionRecordManager();
+    }
+
+    @Test
+    public void testLoadContentSuccess() throws Exception {
+        presenter.loadContent();
+
+        verify(kieEditorWrapperView).clear();
+        verify(kieEditorWrapperView).addMainEditorPage(view);
+        verify(kieEditorWrapperView).addOverviewPage(any(), any());
+        verify(kieEditorWrapperView).addImportsTab(any());
+        verify(kieEditorWrapperView).addSourcePage(any());
+        verify(oracleFactory).makeAsyncPackageDataModelOracle(resourcePath, ruleModel, payload);
+        verify(overviewWidgetPresenter).setContent(overview, resourcePath);
+        verify(importsWidgetPresenter).setContent(oracle, imports, false);
+        verify(view).hideBusyIndicator();
+    }
+
+    @Test
+    public void testLoadContentFail() throws Exception {
+        doThrow(new RuntimeException()).when(service).loadContent(resourcePath);
+
+        presenter.loadContent();
+
+        verify(kieEditorWrapperView, never()).clear();
+        verify(kieEditorWrapperView, never()).addMainEditorPage(view);
+        verify(kieEditorWrapperView, never()).addOverviewPage(any(), any());
+        verify(kieEditorWrapperView, never()).addImportsTab(any());
+        verify(kieEditorWrapperView, never()).addSourcePage(any());
+        verify(oracleFactory, never()).makeAsyncPackageDataModelOracle(resourcePath, ruleModel, payload);
+        verify(overviewWidgetPresenter, never()).setContent(overview, resourcePath);
+        verify(importsWidgetPresenter, never()).setContent(oracle, imports, false);
+        verify(view).hideBusyIndicator();
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModellerConditionSelectorPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModellerConditionSelectorPopupTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.client.editor;
+
+import java.util.Collections;
+
+import javax.enterprise.inject.Instance;
+
+import com.google.gwtmockito.GwtMockito;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import com.google.gwtmockito.fakes.FakeProvider;
+import org.assertj.core.api.Assertions;
+import org.drools.workbench.models.datamodel.oracle.DSLConditionSentence;
+import org.drools.workbench.models.datamodel.rule.DSLSentence;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.jboss.errai.validation.client.dynamic.DynamicValidator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
+import org.kie.soup.project.datamodel.oracle.PackageDataModelOracle;
+import org.kie.workbench.common.services.datamodel.backend.server.builder.packages.PackageDataModelOracleBuilder;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.services.datamodel.service.IncrementalDataModelService;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.MockInstanceImpl;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@WithClassesToStub(Text.class)
+@RunWith(GwtMockitoTestRunner.class)
+public class RuleModellerConditionSelectorPopupTest {
+
+    private static final String DSL_SENTENCE_CHOICE_KEY = "dslSentence";
+    private static final String DSL_SENTENCE_CHOICE_VALUE = "DSLdslSentence";
+
+    @Mock
+    private SyncBeanDef syncBeanDef;
+
+    @Mock
+    private SyncBeanManager syncBeanManager;
+
+    @Spy
+    @InjectMocks
+    private AsyncPackageDataModelOracleFactory asyncPackageDataModelOracleFactory;
+
+    @Mock
+    private IncrementalDataModelService incrementalDataModelService;
+
+    private Caller<IncrementalDataModelService> incrementalDataModelServiceCaller;
+
+    private Instance<DynamicValidator> validatorInstance;
+
+    private AsyncPackageDataModelOracle oracle;
+
+    @Mock
+    private Path resourcePath;
+
+    @Mock
+    private ListBox choices;
+
+    @Mock
+    private RuleModel model;
+
+    @Mock
+    private RuleModeller ruleModeller;
+
+    private PackageDataModelOracleBaselinePayload dataModelPayload;
+
+    private PackageDataModelOracle dataModel;
+
+    @Captor
+    private ArgumentCaptor<String> keyCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> valueCaptor;
+
+    @Mock
+    private DSLSentence dslSentence;
+
+    @Before
+    public void setUp() throws Exception {
+        // Mock The ListBox with loaded choices
+        GwtMockito.useProviderForType(ListBox.class, new FakeProvider<ListBox>() {
+            @Override
+            public ListBox getFake(Class<?> aClass) {
+                return choices;
+            }
+        });
+
+        // Mock partially the AsyncPackageDataModelOracle
+        incrementalDataModelServiceCaller = new CallerMock<>(incrementalDataModelService);
+        validatorInstance = new MockInstanceImpl<>();
+        oracle = spy(new AsyncPackageDataModelOracleImpl(incrementalDataModelServiceCaller, validatorInstance));
+
+        // Mock partially the AsyncPackageDataModelOracleFactory
+        doReturn(syncBeanDef).when(syncBeanManager).lookupBean(AsyncPackageDataModelOracle.class);
+        doReturn(oracle).when(syncBeanDef).getInstance();
+    }
+
+    @Test
+    public void testLoadDslConditionsDslEnabledButNotPresent() throws Exception {
+        // DSL sentences enabled
+        doReturn(true).when(ruleModeller).isDSLEnabled();
+
+        // DSL Conditions not present
+        dataModel = PackageDataModelOracleBuilder.newPackageOracleBuilder(new RawMVELEvaluator()).build();
+        dataModelPayload = new PackageDataModelOracleBaselinePayload();
+        dataModelPayload.setAllPackageElements(dataModel.getAllExtensions());
+
+        asyncPackageDataModelOracleFactory.makeAsyncPackageDataModelOracle(resourcePath, dataModelPayload);
+
+        new RuleModellerConditionSelectorPopup(model, ruleModeller, 0, oracle);
+
+        verify(choices, atLeastOnce()).addItem(keyCaptor.capture(), valueCaptor.capture());
+        Assertions.assertThat(keyCaptor.getAllValues()).doesNotContain(DSL_SENTENCE_CHOICE_KEY);
+        Assertions.assertThat(valueCaptor.getAllValues()).doesNotContain(DSL_SENTENCE_CHOICE_VALUE);
+    }
+
+    @Test
+    public void testLoadDslConditionsDslEnabledAndPresent() throws Exception {
+        // DSL sentences enabled
+        doReturn(true).when(ruleModeller).isDSLEnabled();
+
+        // DSL Conditions present
+        dataModel = PackageDataModelOracleBuilder.newPackageOracleBuilder(new RawMVELEvaluator())
+                .addExtension(DSLConditionSentence.INSTANCE, Collections.singletonList(dslSentence))
+                .build();
+        dataModelPayload = new PackageDataModelOracleBaselinePayload();
+        dataModelPayload.setAllPackageElements(dataModel.getAllExtensions());
+
+        asyncPackageDataModelOracleFactory.makeAsyncPackageDataModelOracle(resourcePath, dataModelPayload);
+
+        new RuleModellerConditionSelectorPopup(model, ruleModeller, 0, oracle);
+
+        verify(choices, atLeastOnce()).addItem(keyCaptor.capture(), valueCaptor.capture());
+        Assertions.assertThat(keyCaptor.getAllValues()).contains(DSL_SENTENCE_CHOICE_KEY);
+        Assertions.assertThat(valueCaptor.getAllValues()).contains(DSL_SENTENCE_CHOICE_VALUE);
+    }
+
+    @Test
+    public void testLoadDslConditionsPresentButDslDisabled() throws Exception {
+        // DSL sentences disabled
+        doReturn(false).when(ruleModeller).isDSLEnabled();
+
+        // DSL Conditions present
+        dataModel = PackageDataModelOracleBuilder.newPackageOracleBuilder(new RawMVELEvaluator())
+                .addExtension(DSLConditionSentence.INSTANCE, Collections.singletonList(dslSentence))
+                .build();
+        dataModelPayload = new PackageDataModelOracleBaselinePayload();
+        dataModelPayload.setAllPackageElements(dataModel.getAllExtensions());
+
+        asyncPackageDataModelOracleFactory.makeAsyncPackageDataModelOracle(resourcePath, dataModelPayload);
+
+        new RuleModellerConditionSelectorPopup(model, ruleModeller, 0, oracle);
+
+        verify(choices, atLeastOnce()).addItem(keyCaptor.capture(), valueCaptor.capture());
+        Assertions.assertThat(keyCaptor.getAllValues()).doesNotContain(DSL_SENTENCE_CHOICE_KEY);
+        Assertions.assertThat(valueCaptor.getAllValues()).doesNotContain(DSL_SENTENCE_CHOICE_VALUE);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/pom.xml
@@ -141,6 +141,23 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+    </dependency>
+
+
   </dependencies>
 
 </project>

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenter.java
@@ -61,7 +61,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.Menus;
 
 @Dependent
-@WorkbenchEditor(identifier = "GuidedRuleTemplateEditor", supportedTypes = { GuidedRuleTemplateResourceType.class })
+@WorkbenchEditor(identifier = "GuidedRuleTemplateEditor", supportedTypes = {GuidedRuleTemplateResourceType.class})
 public class GuidedRuleTemplateEditorPresenter
         extends KieEditor {
 
@@ -97,87 +97,87 @@ public class GuidedRuleTemplateEditorPresenter
     private Caller<RuleNamesService> ruleNamesService;
 
     @Inject
-    public GuidedRuleTemplateEditorPresenter( final GuidedRuleTemplateEditorView baseView ) {
-        super( baseView );
+    public GuidedRuleTemplateEditorPresenter(final GuidedRuleTemplateEditorView baseView) {
+        super(baseView);
         view = baseView;
     }
 
     @OnStartup
-    public void onStartup( final ObservablePath path,
-                           final PlaceRequest place ) {
-        super.init( path,
-                    place,
-                    type );
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest place) {
+        super.init(path,
+                   place,
+                   type);
     }
 
     protected void loadContent() {
         view.showLoading();
-        service.call( getModelSuccessCallback(),
-                      getNoSuchFileExceptionErrorCallback() ).loadContent( versionRecordManager.getCurrentPath() );
+        getService().call(getModelSuccessCallback(),
+                          getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
     }
 
     private RemoteCallback<GuidedTemplateEditorContent> getModelSuccessCallback() {
         return new RemoteCallback<GuidedTemplateEditorContent>() {
 
             @Override
-            public void callback( final GuidedTemplateEditorContent content ) {
+            public void callback(final GuidedTemplateEditorContent content) {
                 //Path is set to null when the Editor is closed (which can happen before async calls complete).
-                if ( versionRecordManager.getCurrentPath() == null ) {
+                if (versionRecordManager.getCurrentPath() == null) {
                     return;
                 }
 
-                resetEditorPages( content.getOverview() );
+                resetEditorPages(content.getOverview());
                 addSourcePage();
 
-                addPage( new PageImpl( dataView,
-                                       GuidedTemplateEditorConstants.INSTANCE.Data() ) {
+                addPage(new PageImpl(dataView,
+                                     GuidedTemplateEditorConstants.INSTANCE.Data()) {
 
                     @Override
                     public void onFocus() {
-                        dataView.setContent( model,
-                                             oracle,
-                                             eventBus,
-                                             isReadOnly );
+                        dataView.setContent(model,
+                                            oracle,
+                                            eventBus,
+                                            isReadOnly);
                     }
 
                     @Override
                     public void onLostFocus() {
                         // Nothing to do here
                     }
-                } );
+                });
 
-                addImportsTab( importsWidget );
+                addImportsTab(importsWidget);
 
                 model = content.getModel();
                 final PackageDataModelOracleBaselinePayload dataModel = content.getDataModel();
-                oracle = oracleFactory.makeAsyncPackageDataModelOracle( versionRecordManager.getCurrentPath(),
-                                                                        model,
-                                                                        dataModel );
+                oracle = oracleFactory.makeAsyncPackageDataModelOracle(versionRecordManager.getCurrentPath(),
+                                                                       model,
+                                                                       dataModel);
 
-                view.setContent( model,
-                                 oracle,
-                                 ruleNamesService,
-                                 eventBus,
-                                 isReadOnly );
-                importsWidget.setContent( oracle,
-                                          model.getImports(),
-                                          isReadOnly );
+                view.setContent(model,
+                                oracle,
+                                ruleNamesService,
+                                eventBus,
+                                isReadOnly);
+                importsWidget.setContent(oracle,
+                                         model.getImports(),
+                                         isReadOnly);
 
-                createOriginalHash( model );
+                createOriginalHash(model);
                 view.hideBusyIndicator();
             }
         };
     }
 
-    public void handleImportAddedEvent( @Observes ImportAddedEvent event ) {
-        if ( !event.getDataModelOracle().equals( this.oracle ) ) {
+    public void handleImportAddedEvent(@Observes ImportAddedEvent event) {
+        if (!event.getDataModelOracle().equals(this.oracle)) {
             return;
         }
         view.refresh();
     }
 
-    public void handleImportRemovedEvent( @Observes ImportRemovedEvent event ) {
-        if ( !event.getDataModelOracle().equals( this.oracle ) ) {
+    public void handleImportRemovedEvent(@Observes ImportRemovedEvent event) {
+        if (!event.getDataModelOracle().equals(this.oracle)) {
             return;
         }
         view.refresh();
@@ -187,50 +187,50 @@ public class GuidedRuleTemplateEditorPresenter
         return new Command() {
             @Override
             public void execute() {
-                service.call( new RemoteCallback<List<ValidationMessage>>() {
+                getService().call(new RemoteCallback<List<ValidationMessage>>() {
                     @Override
-                    public void callback( final List<ValidationMessage> results ) {
-                        if ( results == null || results.isEmpty() ) {
-                            notification.fire( new NotificationEvent( CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
-                                                                      NotificationEvent.NotificationType.SUCCESS ) );
+                    public void callback(final List<ValidationMessage> results) {
+                        if (results == null || results.isEmpty()) {
+                            notification.fire(new NotificationEvent(CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
+                                                                    NotificationEvent.NotificationType.SUCCESS));
                         } else {
-                            validationPopup.showMessages( results );
+                            validationPopup.showMessages(results);
                         }
                     }
-                } ).validate( versionRecordManager.getCurrentPath(),
-                              view.getContent() );
+                }).validate(versionRecordManager.getCurrentPath(),
+                            view.getContent());
             }
         };
     }
 
     @Override
-    protected void save( String commitMessage ) {
-        service.call( getSaveSuccessCallback( model.hashCode() ),
-                      new HasBusyIndicatorDefaultErrorCallback( view ) ).save( versionRecordManager.getCurrentPath(),
+    protected void save(String commitMessage) {
+        getService().call(getSaveSuccessCallback(model.hashCode()),
+                          new HasBusyIndicatorDefaultErrorCallback(view)).save(versionRecordManager.getCurrentPath(),
                                                                                view.getContent(),
                                                                                metadata,
-                                                                               commitMessage );
+                                                                               commitMessage);
     }
 
     @Override
     public void onSourceTabSelected() {
-        service.call( new RemoteCallback<String>() {
+        getService().call(new RemoteCallback<String>() {
             @Override
-            public void callback( String source ) {
-                updateSource( source );
+            public void callback(String source) {
+                updateSource(source);
             }
-        } ).toSource( versionRecordManager.getCurrentPath(), model );
+        }).toSource(versionRecordManager.getCurrentPath(), model);
     }
 
     @OnClose
     public void onClose() {
         this.versionRecordManager.clear();
-        this.oracleFactory.destroy( oracle );
+        this.oracleFactory.destroy(oracle);
     }
 
     @OnMayClose
     public boolean mayClose() {
-        return super.mayClose( view.getContent() );
+        return super.mayClose(view.getContent());
     }
 
     @WorkbenchPartTitle
@@ -253,4 +253,10 @@ public class GuidedRuleTemplateEditorPresenter
         return menus;
     }
 
+    /*
+     * Getter due to test purposes
+     */
+    Caller<GuidedRuleTemplateEditorService> getService() {
+        return service;
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.template.client.editor;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.guided.template.shared.TemplateModel;
+import org.drools.workbench.screens.guided.template.model.GuidedTemplateEditorContent;
+import org.drools.workbench.screens.guided.template.service.GuidedRuleTemplateEditorService;
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.widgets.client.callbacks.CommandDrivenErrorCallback;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.kie.workbench.common.widgets.configresource.client.widget.bound.ImportsWidgetPresenter;
+import org.kie.workbench.common.widgets.metadata.client.KieEditorWrapperView;
+import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.mocks.CallerMock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub(CommandDrivenErrorCallback.class)
+public class GuidedRuleTemplateEditorPresenterTest {
+
+    @Mock
+    private AsyncPackageDataModelOracleFactory oracleFactory;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracle;
+
+    @Mock
+    private ObservablePath path;
+
+    @Mock
+    private KieEditorWrapperView kieView;
+
+    @Mock
+    private OverviewWidgetPresenter overviewPresenter;
+
+    @Mock
+    private ImportsWidgetPresenter importsWidgetPresenter;
+
+    @Mock
+    private GuidedRuleTemplateEditorView view;
+
+    @Mock
+    private VersionRecordManager versionRecordManager;
+
+    @Mock
+    private GuidedRuleTemplateEditorService service;
+
+    @Mock
+    private Overview overview;
+
+    @Mock
+    private TemplateModel templateModel;
+
+    @Mock
+    private PackageDataModelOracleBaselinePayload payload;
+
+    @Mock
+    private GuidedTemplateEditorContent content;
+
+    private Caller<GuidedRuleTemplateEditorService> serviceCaller;
+
+    @Spy
+    @InjectMocks
+    private GuidedRuleTemplateEditorPresenter presenter = new GuidedRuleTemplateEditorPresenter(view);
+
+    @Before
+    public void setUp() throws Exception {
+        doReturn(templateModel).when(content).getModel();
+        doReturn(overview).when(content).getOverview();
+        doReturn(payload).when(content).getDataModel();
+
+        serviceCaller = new CallerMock<>(service);
+
+        doReturn(serviceCaller).when(presenter).getService();
+
+        doReturn(oracle).when(oracleFactory).makeAsyncPackageDataModelOracle(path, templateModel, payload);
+
+        doReturn(path).when(versionRecordManager).getCurrentPath();
+    }
+
+    @Test
+    public void testLoadContentSuccess() throws Exception {
+        doReturn(content).when(service).loadContent(eq(path));
+        presenter.loadContent();
+
+        verify(view).setContent(eq(templateModel),
+                                eq(oracle),
+                                any(),
+                                notNull(EventBus.class),
+                                eq(false));
+    }
+
+    @Test
+    public void testLoadContentFail() throws Exception {
+        doThrow(new RuntimeException()).when(service).loadContent(eq(path));
+        presenter.loadContent();
+
+        verify(view, never()).setContent(any(TemplateModel.class),
+                                         any(AsyncPackageDataModelOracle.class),
+                                         any(Caller.class),
+                                         any(EventBus.class),
+                                         anyBoolean());
+    }
+}

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
@@ -147,6 +147,12 @@
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ant</groupId>
+          <artifactId>ant</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR adds reproducer test that assert DSL sentences are loaded
correctly into given popups:
- Colum Wizard in Guided decision table editor
- Guided Rule editor
- Guided Rule Template editor

@manstis I would like to ask you for review.