### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/pom.xml
@@ -26,10 +26,6 @@
       <artifactId>kie-soup-project-datamodel-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-project-datamodel-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
     </dependency>


### PR DESCRIPTION
Fixing the following warning

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.drools:drools-wb-guided-dtable-editor-backend:jar:7.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-project-datamodel-api:jar -> duplicate declaration of version (?) @ org.drools:drools-wb-guided-dtable-editor-backend:[unknown-version], /home/hrk/Devel/github.com/kiegroup/drools-wb/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/pom.xml, line 28, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

@psiroky After I fix all of these warnings across kiegroup repos, do you think it would be worth enabling enforcer rule in droolsjbpm-build-bootstrap which prevents these (as in https://maven.apache.org/enforcer/enforcer-rules/banDuplicatePomDependencyVersions.html) or would it piss people off unnecessarily?