### PR TITLE
DROOLS-2149: Row and column can be added to read only table

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/BaseMenu.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/BaseMenu.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 
 /**
  * Base Menu implementation for MenuItems that need to be aware of Decision Table and Decision Table Cell selections.
@@ -40,6 +41,11 @@ public abstract class BaseMenu implements BaseMenuView.BaseMenuPresenter {
     public void onDecisionTableSelectionsChangedEvent(final DecisionTableSelectionsChangedEvent event) {
         final GuidedDecisionTableView.Presenter dtPresenter = event.getPresenter();
         activeDecisionTable = dtPresenter;
+        initialise();
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final RefreshMenusEvent event) {
         initialise();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/BaseMenuView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/BaseMenuView.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 import com.google.gwt.dom.client.Element;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.uberfire.client.mvp.UberView;
 
 public interface BaseMenuView<M extends BaseMenu> extends UberView<M> {
@@ -27,15 +28,15 @@ public interface BaseMenuView<M extends BaseMenu> extends UberView<M> {
 
         void initialise();
 
-        void onDecisionTableSelectedEvent( final DecisionTableSelectedEvent event );
+        void onDecisionTableSelectedEvent(final DecisionTableSelectedEvent event);
 
-        void onDecisionTableSelectionsChangedEvent( final DecisionTableSelectionsChangedEvent event );
+        void onDecisionTableSelectionsChangedEvent(final DecisionTableSelectionsChangedEvent event);
 
+        void onRefreshMenusEvent(final RefreshMenusEvent event);
     }
 
-    void enableElement( final Element element,
-                        final boolean enabled );
+    void enableElement(final Element element,
+                       final boolean enabled);
 
-    boolean isDisabled( final Element element );
-
+    boolean isDisabled(final Element element);
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenu.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenu.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipboard;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @Dependent
@@ -38,25 +39,30 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
     private Clipboard clipboard;
 
     @Inject
-    public CellContextMenu( final CellContextMenuView view,
-                            final Clipboard clipboard ) {
+    public CellContextMenu(final CellContextMenuView view,
+                           final Clipboard clipboard) {
         this.view = view;
         this.clipboard = clipboard;
     }
 
     @PostConstruct
     void setup() {
-        view.init( this );
+        view.init(this);
     }
 
     @Override
-    public void onDecisionTableSelectedEvent( final @Observes DecisionTableSelectedEvent event ) {
-        super.onDecisionTableSelectedEvent( event );
+    public void onDecisionTableSelectedEvent(final @Observes DecisionTableSelectedEvent event) {
+        super.onDecisionTableSelectedEvent(event);
     }
 
     @Override
-    public void onDecisionTableSelectionsChangedEvent( final @Observes DecisionTableSelectionsChangedEvent event ) {
-        super.onDecisionTableSelectionsChangedEvent( event );
+    public void onDecisionTableSelectionsChangedEvent(final @Observes DecisionTableSelectionsChangedEvent event) {
+        super.onDecisionTableSelectionsChangedEvent(event);
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final @Observes RefreshMenusEvent event) {
+        super.onRefreshMenusEvent(event);
     }
 
     @Override
@@ -65,10 +71,10 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
     }
 
     @Override
-    public void show( final int mx,
-                      final int my ) {
-        view.show( mx,
-                   my );
+    public void show(final int mx,
+                     final int my) {
+        view.show(mx,
+                  my);
     }
 
     @Override
@@ -78,21 +84,21 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void initialise() {
-        if ( activeDecisionTable == null || !activeDecisionTable.getAccess().isEditable() ) {
+        if (activeDecisionTable == null || !activeDecisionTable.getAccess().isEditable()) {
             disableMenuItems();
             return;
         }
         final List<GridData.SelectedCell> selections = activeDecisionTable.getView().getModel().getSelectedCells();
-        if ( selections == null || selections.isEmpty() ) {
+        if (selections == null || selections.isEmpty()) {
             disableMenuItems();
             return;
         }
-        enableMenuItems( selections );
+        enableMenuItems(selections);
     }
 
     @Override
     public void onCut() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onCut();
         }
         hide();
@@ -100,7 +106,7 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onCopy() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onCopy();
         }
         hide();
@@ -108,7 +114,7 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onPaste() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onPaste();
         }
         hide();
@@ -116,26 +122,25 @@ public class CellContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onDeleteSelectedCells() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onDeleteSelectedCells();
         }
         hide();
     }
 
     private void disableMenuItems() {
-        view.enableCutMenuItem( false );
-        view.enableCopyMenuItem( false );
-        view.enablePasteMenuItem( false );
-        view.enableDeleteCellMenuItem( false );
+        view.enableCutMenuItem(false);
+        view.enableCopyMenuItem(false);
+        view.enablePasteMenuItem(false);
+        view.enableDeleteCellMenuItem(false);
     }
 
-    private void enableMenuItems( final List<GridData.SelectedCell> selections ) {
+    private void enableMenuItems(final List<GridData.SelectedCell> selections) {
         final boolean enabled = selections.size() > 0;
 
-        view.enableCutMenuItem( enabled );
-        view.enableCopyMenuItem( enabled );
-        view.enablePasteMenuItem( clipboard.hasData() );
-        view.enableDeleteCellMenuItem( enabled );
+        view.enableCutMenuItem(enabled);
+        view.enableCopyMenuItem(enabled);
+        view.enablePasteMenuItem(clipboard.hasData());
+        view.enableDeleteCellMenuItem(enabled);
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
@@ -31,6 +31,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipbo
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableErraiConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -148,6 +149,11 @@ public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
     @Override
     public void onDecisionTableSelectionsChangedEvent(final @Observes DecisionTableSelectionsChangedEvent event) {
         super.onDecisionTableSelectionsChangedEvent(event);
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final @Observes RefreshMenusEvent event) {
+        super.onRefreshMenusEvent(event);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
@@ -32,6 +32,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -107,6 +108,11 @@ public class InsertMenuBuilder extends BaseMenu implements MenuFactory.CustomMen
     @Override
     public void onDecisionTableSelectionsChangedEvent(final @Observes DecisionTableSelectionsChangedEvent event) {
         super.onDecisionTableSelectionsChangedEvent(event);
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final @Observes RefreshMenusEvent event) {
+        super.onRefreshMenusEvent(event);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenu.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenu.java
@@ -30,6 +30,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipboard;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 @Dependent
@@ -40,25 +41,30 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
     private Clipboard clipboard;
 
     @Inject
-    public RowContextMenu( final RowContextMenuView view,
-                           final Clipboard clipboard ) {
+    public RowContextMenu(final RowContextMenuView view,
+                          final Clipboard clipboard) {
         this.view = view;
         this.clipboard = clipboard;
     }
 
     @PostConstruct
     void setup() {
-        view.init( this );
+        view.init(this);
     }
 
     @Override
-    public void onDecisionTableSelectedEvent( final @Observes DecisionTableSelectedEvent event ) {
-        super.onDecisionTableSelectedEvent( event );
+    public void onDecisionTableSelectedEvent(final @Observes DecisionTableSelectedEvent event) {
+        super.onDecisionTableSelectedEvent(event);
     }
 
     @Override
-    public void onDecisionTableSelectionsChangedEvent( final @Observes DecisionTableSelectionsChangedEvent event ) {
-        super.onDecisionTableSelectionsChangedEvent( event );
+    public void onDecisionTableSelectionsChangedEvent(final @Observes DecisionTableSelectionsChangedEvent event) {
+        super.onDecisionTableSelectionsChangedEvent(event);
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final @Observes RefreshMenusEvent event) {
+        super.onRefreshMenusEvent(event);
     }
 
     @Override
@@ -67,10 +73,10 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
     }
 
     @Override
-    public void show( final int mx,
-                      final int my ) {
-        view.show( mx,
-                   my );
+    public void show(final int mx,
+                     final int my) {
+        view.show(mx,
+                  my);
     }
 
     @Override
@@ -80,27 +86,27 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void initialise() {
-        if ( activeDecisionTable == null || !activeDecisionTable.getAccess().isEditable() ) {
+        if (activeDecisionTable == null || !activeDecisionTable.getAccess().isEditable()) {
             disableMenuItems();
             return;
         }
         final List<GridData.SelectedCell> selections = activeDecisionTable.getView().getModel().getSelectedCells();
-        if ( selections == null || selections.isEmpty() ) {
+        if (selections == null || selections.isEmpty()) {
             disableMenuItems();
             return;
         }
         final Map<Integer, Boolean> rowUsage = new HashMap<>();
-        for ( GridData.SelectedCell sc : selections ) {
-            rowUsage.put( sc.getRowIndex(),
-                          true );
+        for (GridData.SelectedCell sc : selections) {
+            rowUsage.put(sc.getRowIndex(),
+                         true);
         }
         enableMenuItemsForClipboard();
-        enableMenuItemsForRowOperations( rowUsage.keySet().size() == 1 );
+        enableMenuItemsForRowOperations(rowUsage.keySet().size() == 1);
     }
 
     @Override
     public void onCut() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onCut();
         }
         hide();
@@ -108,7 +114,7 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onCopy() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onCopy();
         }
         hide();
@@ -116,7 +122,7 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onPaste() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onPaste();
         }
         hide();
@@ -124,7 +130,7 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onInsertRowAbove() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onInsertRowAbove();
         }
         hide();
@@ -132,7 +138,7 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onInsertRowBelow() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onInsertRowBelow();
         }
         hide();
@@ -140,31 +146,30 @@ public class RowContextMenu extends BaseMenu implements IsWidget,
 
     @Override
     public void onDeleteSelectedRows() {
-        if ( activeDecisionTable != null ) {
+        if (activeDecisionTable != null) {
             activeDecisionTable.onDeleteSelectedRows();
         }
         hide();
     }
 
     private void disableMenuItems() {
-        view.enableCutMenuItem( false );
-        view.enableCopyMenuItem( false );
-        view.enablePasteMenuItem( false );
-        view.enableInsertRowAboveMenuItem( false );
-        view.enableInsertRowBelowMenuItem( false );
-        view.enableDeleteRowMenuItem( false );
+        view.enableCutMenuItem(false);
+        view.enableCopyMenuItem(false);
+        view.enablePasteMenuItem(false);
+        view.enableInsertRowAboveMenuItem(false);
+        view.enableInsertRowBelowMenuItem(false);
+        view.enableDeleteRowMenuItem(false);
     }
 
     private void enableMenuItemsForClipboard() {
-        view.enableCutMenuItem( true );
-        view.enableCopyMenuItem( true );
-        view.enablePasteMenuItem( clipboard.hasData() );
+        view.enableCutMenuItem(true);
+        view.enableCopyMenuItem(true);
+        view.enablePasteMenuItem(clipboard.hasData());
     }
 
-    private void enableMenuItemsForRowOperations( final boolean isSingleRow ) {
-        view.enableInsertRowAboveMenuItem( isSingleRow );
-        view.enableInsertRowBelowMenuItem( isSingleRow );
-        view.enableDeleteRowMenuItem( true );
+    private void enableMenuItemsForRowOperations(final boolean isSingleRow) {
+        view.enableInsertRowAboveMenuItem(isSingleRow);
+        view.enableInsertRowBelowMenuItem(isSingleRow);
+        view.enableDeleteRowMenuItem(true);
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilder.java
@@ -28,6 +28,7 @@ import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDe
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTablePinnedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.uberfire.ext.widgets.common.client.menu.MenuItemDividerView;
@@ -140,6 +141,11 @@ public class ViewMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuB
     public void onDecisionTableSelectedEvent(final @Observes DecisionTableSelectedEvent event) {
         super.onDecisionTableSelectedEvent(event);
         enableZoomMenu(event.getPresenter().isPresent());
+    }
+
+    @Override
+    public void onRefreshMenusEvent(final @Observes RefreshMenusEvent event) {
+        super.onRefreshMenusEvent(event);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -68,6 +68,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanager.GuidedDecisionTableLockManager;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
@@ -137,6 +138,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
     private final Event<RefreshMetaDataPanelEvent> refreshMetaDataPanelEvent;
     private final Event<RefreshConditionsPanelEvent> refreshConditionsPanelEvent;
     private final Event<RefreshActionsPanelEvent> refreshActionsPanelEvent;
+    private final Event<RefreshMenusEvent> refreshMenusEvent;
     private final Event<NotificationEvent> notificationEvent;
     private final GridWidgetCellFactory gridWidgetCellFactory;
     private final GridWidgetColumnFactory gridWidgetColumnFactory;
@@ -190,6 +192,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                                         final Event<RefreshMetaDataPanelEvent> refreshMetaDataPanelEvent,
                                         final Event<RefreshConditionsPanelEvent> refreshConditionsPanelEvent,
                                         final Event<RefreshActionsPanelEvent> refreshActionsPanelEvent,
+                                        final Event<RefreshMenusEvent> refreshMenusEvent,
                                         final Event<NotificationEvent> notificationEvent,
                                         final GridWidgetCellFactory gridWidgetCellFactory,
                                         final GridWidgetColumnFactory gridWidgetColumnFactory,
@@ -215,6 +218,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         this.refreshMetaDataPanelEvent = refreshMetaDataPanelEvent;
         this.refreshConditionsPanelEvent = refreshConditionsPanelEvent;
         this.refreshActionsPanelEvent = refreshActionsPanelEvent;
+        this.refreshMenusEvent = refreshMenusEvent;
         this.notificationEvent = notificationEvent;
         this.gridWidgetCellFactory = gridWidgetCellFactory;
         this.gridWidgetColumnFactory = gridWidgetColumnFactory;
@@ -625,6 +629,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
                 access.setLock(NOBODY);
             }
             refreshColumnsPage();
+            refreshMenus();
         }
     }
 
@@ -633,6 +638,10 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         refreshMetaDataPanelEvent.fire(new RefreshMetaDataPanelEvent(this, model.getMetadataCols()));
         refreshConditionsPanelEvent.fire(new RefreshConditionsPanelEvent(this, model.getConditions()));
         refreshActionsPanelEvent.fire(new RefreshActionsPanelEvent(this, model.getActionCols()));
+    }
+
+    void refreshMenus() {
+        refreshMenusEvent.fire(new RefreshMenusEvent());
     }
 
     void onIssueSelectedEvent(final @Observes IssueSelectedEvent event) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/events/cdi/RefreshMenusEvent.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/events/cdi/RefreshMenusEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi;
+
+public class RefreshMenusEvent {
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenuTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenuTest.java
@@ -28,6 +28,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Before;
@@ -42,6 +43,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.Gr
 
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,177 +70,183 @@ public class CellContextMenuTest {
     @SuppressWarnings("unchecked")
     public void setup() {
         model = new GuidedDecisionTable52();
-        uiModel = new GuidedDecisionTableUiModel( mock( ModelSynchronizer.class ) );
+        uiModel = new GuidedDecisionTableUiModel(mock(ModelSynchronizer.class));
         clipboard = new DefaultClipboard();
 
-        when( dtPresenter.getView() ).thenReturn( dtPresenterView );
-        when( dtPresenter.getModel() ).thenReturn( model );
-        when( dtPresenter.getAccess() ).thenReturn( access );
-        when( dtPresenterView.getModel() ).thenReturn( uiModel );
+        when(dtPresenter.getView()).thenReturn(dtPresenterView);
+        when(dtPresenter.getModel()).thenReturn(model);
+        when(dtPresenter.getAccess()).thenReturn(access);
+        when(dtPresenterView.getModel()).thenReturn(uiModel);
 
-        uiModel.appendColumn( new BaseGridColumn<String>( mock( GridColumn.HeaderMetaData.class ),
-                                                          mock( GridColumnRenderer.class ),
-                                                          100 ) );
-        uiModel.appendColumn( new BaseGridColumn<String>( mock( GridColumn.HeaderMetaData.class ),
-                                                          mock( GridColumnRenderer.class ),
-                                                          100 ) );
-        uiModel.appendColumn( new BaseGridColumn<String>( mock( GridColumn.HeaderMetaData.class ),
-                                                          mock( GridColumnRenderer.class ),
-                                                          100 ) );
-        uiModel.appendRow( new BaseGridRow() );
+        uiModel.appendColumn(new BaseGridColumn<String>(mock(GridColumn.HeaderMetaData.class),
+                                                        mock(GridColumnRenderer.class),
+                                                        100));
+        uiModel.appendColumn(new BaseGridColumn<String>(mock(GridColumn.HeaderMetaData.class),
+                                                        mock(GridColumnRenderer.class),
+                                                        100));
+        uiModel.appendColumn(new BaseGridColumn<String>(mock(GridColumn.HeaderMetaData.class),
+                                                        mock(GridColumnRenderer.class),
+                                                        100));
+        uiModel.appendRow(new BaseGridRow());
 
-        menu = new CellContextMenu( view,
-                                    clipboard );
+        menu = spy(new CellContextMenu(view,
+                                       clipboard));
         menu.setup();
     }
 
     @Test
     public void testOnDecisionTableSelectedEventWithNoSelections() {
-        menu.onDecisionTableSelectedEvent( new DecisionTableSelectedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectedEvent(new DecisionTableSelectedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( false ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(false));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(false));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(false));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(false));
     }
 
     @Test
     public void testOnDecisionTableSelectedEventWithSelections() {
-        model.getMetadataCols().add( new MetadataCol52() );
-        model.getData().add( new ArrayList<DTCellValue52>() {{
-            add( new DTCellValue52( 1 ) );
-            add( new DTCellValue52( "descr" ) );
-            add( new DTCellValue52( "md" ) );
-        }} );
+        model.getMetadataCols().add(new MetadataCol52());
+        model.getData().add(new ArrayList<DTCellValue52>() {{
+            add(new DTCellValue52(1));
+            add(new DTCellValue52("descr"));
+            add(new DTCellValue52("md"));
+        }});
 
-        uiModel.selectCell( 0,
-                            2 );
+        uiModel.selectCell(0,
+                           2);
 
-        menu.onDecisionTableSelectedEvent( new DecisionTableSelectedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectedEvent(new DecisionTableSelectedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( true ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(true));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(true));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(false));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(true));
     }
 
     @Test
     public void testOnDecisionTableSelectedEventWithSelectionsWithClipboardPopulated() {
-        model.getMetadataCols().add( new MetadataCol52() );
-        model.getData().add( new ArrayList<DTCellValue52>() {{
-            add( new DTCellValue52( 1 ) );
-            add( new DTCellValue52( "descr" ) );
-            add( new DTCellValue52( "md" ) );
-        }} );
+        model.getMetadataCols().add(new MetadataCol52());
+        model.getData().add(new ArrayList<DTCellValue52>() {{
+            add(new DTCellValue52(1));
+            add(new DTCellValue52("descr"));
+            add(new DTCellValue52("md"));
+        }});
 
-        uiModel.selectCell( 0,
-                            2 );
-        clipboard.setData( new HashSet<Clipboard.ClipboardData>() {{
-            add( new DefaultClipboard.ClipboardDataImpl( 0,
-                                                         2,
-                                                         model.getData().get( 0 ).get( 2 ) ) );
-        }} );
+        uiModel.selectCell(0,
+                           2);
+        clipboard.setData(new HashSet<Clipboard.ClipboardData>() {{
+            add(new DefaultClipboard.ClipboardDataImpl(0,
+                                                       2,
+                                                       model.getData().get(0).get(2)));
+        }});
 
-        menu.onDecisionTableSelectedEvent( new DecisionTableSelectedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectedEvent(new DecisionTableSelectedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( true ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(true));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(true));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(true));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(true));
     }
 
     @Test
     public void testOnDecisionTableSelectionsChangedEventWithNoSelections() {
-        menu.onDecisionTableSelectionsChangedEvent( new DecisionTableSelectionsChangedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectionsChangedEvent(new DecisionTableSelectionsChangedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( false ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(false));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(false));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(false));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(false));
     }
 
     @Test
     public void testOnDecisionTableSelectionsChangedEventWithSelections() {
-        model.getMetadataCols().add( new MetadataCol52() );
-        model.getData().add( new ArrayList<DTCellValue52>() {{
-            add( new DTCellValue52( 1 ) );
-            add( new DTCellValue52( "descr" ) );
-            add( new DTCellValue52( "md" ) );
-        }} );
+        model.getMetadataCols().add(new MetadataCol52());
+        model.getData().add(new ArrayList<DTCellValue52>() {{
+            add(new DTCellValue52(1));
+            add(new DTCellValue52("descr"));
+            add(new DTCellValue52("md"));
+        }});
 
-        uiModel.selectCell( 0,
-                            2 );
+        uiModel.selectCell(0,
+                           2);
 
-        menu.onDecisionTableSelectionsChangedEvent( new DecisionTableSelectionsChangedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectionsChangedEvent(new DecisionTableSelectionsChangedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( true ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(true));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(true));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(false));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(true));
     }
 
     @Test
     public void testOnDecisionTableSelectionsChangedEventWithSelectionsWithClipboardPopulated() {
-        model.getMetadataCols().add( new MetadataCol52() );
-        model.getData().add( new ArrayList<DTCellValue52>() {{
-            add( new DTCellValue52( 1 ) );
-            add( new DTCellValue52( "descr" ) );
-            add( new DTCellValue52( "md" ) );
-        }} );
+        model.getMetadataCols().add(new MetadataCol52());
+        model.getData().add(new ArrayList<DTCellValue52>() {{
+            add(new DTCellValue52(1));
+            add(new DTCellValue52("descr"));
+            add(new DTCellValue52("md"));
+        }});
 
-        uiModel.selectCell( 0,
-                            2 );
-        clipboard.setData( new HashSet<Clipboard.ClipboardData>() {{
-            add( new DefaultClipboard.ClipboardDataImpl( 0,
-                                                         2,
-                                                         model.getData().get( 0 ).get( 2 ) ) );
-        }} );
+        uiModel.selectCell(0,
+                           2);
+        clipboard.setData(new HashSet<Clipboard.ClipboardData>() {{
+            add(new DefaultClipboard.ClipboardDataImpl(0,
+                                                       2,
+                                                       model.getData().get(0).get(2)));
+        }});
 
-        menu.onDecisionTableSelectionsChangedEvent( new DecisionTableSelectionsChangedEvent( dtPresenter ) );
+        menu.onDecisionTableSelectionsChangedEvent(new DecisionTableSelectionsChangedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( true ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( true ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(true));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(true));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(true));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(true));
     }
 
     @Test
     public void testOnDecisionTableSelectedEventReadOnly() {
-        dtPresenter.getAccess().setReadOnly( true );
-        menu.onDecisionTableSelectedEvent( new DecisionTableSelectedEvent( dtPresenter ) );
+        dtPresenter.getAccess().setReadOnly(true);
+        menu.onDecisionTableSelectedEvent(new DecisionTableSelectedEvent(dtPresenter));
 
-        verify( view,
-                times( 1 ) ).enableCutMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableCopyMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enablePasteMenuItem( eq( false ) );
-        verify( view,
-                times( 1 ) ).enableDeleteCellMenuItem( eq( false ) );
+        verify(view,
+               times(1)).enableCutMenuItem(eq(false));
+        verify(view,
+               times(1)).enableCopyMenuItem(eq(false));
+        verify(view,
+               times(1)).enablePasteMenuItem(eq(false));
+        verify(view,
+               times(1)).enableDeleteCellMenuItem(eq(false));
     }
 
+    @Test
+    public void testOnRefreshMenusEvent() {
+        menu.onRefreshMenusEvent(new RefreshMenusEvent());
+
+        verify(menu).initialise();
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilderTest.java
@@ -33,6 +33,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
@@ -59,6 +60,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -126,10 +128,10 @@ public class EditMenuBuilderTest {
         uiModel.appendColumn(new BaseGridColumn<>(headerMetaData, gridColumnRenderer, 100));
         uiModel.appendRow(new BaseGridRow());
 
-        builder = new EditMenuBuilder(clipboard,
-                                      ts,
-                                      menuItemFactory,
-                                      popoverUtils);
+        builder = spy(new EditMenuBuilder(clipboard,
+                                          ts,
+                                          menuItemFactory,
+                                          popoverUtils));
         builder.setup();
     }
 
@@ -482,6 +484,13 @@ public class EditMenuBuilderTest {
         assertFalse(builder.miDeleteSelectedColumns.getMenuItem().isEnabled());
         assertFalse(builder.miDeleteSelectedRows.getMenuItem().isEnabled());
         assertFalse(builder.miOtherwiseCell.getMenuItem().isEnabled());
+    }
+
+    @Test
+    public void testOnRefreshMenusEvent() {
+        builder.onRefreshMenusEvent(new RefreshMenusEvent());
+
+        verify(builder).initialise();
     }
 
     private HashSet<Clipboard.ClipboardData> makeClipboardHashSetData() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilderTest.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
@@ -354,6 +355,13 @@ public class InsertMenuBuilderTest {
         builder.onAppendColumn();
 
         verify(builder, never()).openNewGuidedDecisionTableColumnWizard(any());
+    }
+
+    @Test
+    public void testOnRefreshMenusEvent() {
+        builder.onRefreshMenusEvent(new RefreshMenusEvent());
+
+        verify(builder).initialise();
     }
 
     private Pattern52 makePattern52() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenuTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenuTest.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiModel;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Before;
@@ -45,6 +46,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.Gr
 
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,8 +92,8 @@ public class RowContextMenuTest {
                                                         100));
         uiModel.appendRow(new BaseGridRow());
 
-        menu = new RowContextMenu(view,
-                                  clipboard);
+        menu = spy(new RowContextMenu(view,
+                                      clipboard));
         menu.setup();
     }
 
@@ -347,5 +349,12 @@ public class RowContextMenuTest {
                times(1)).enableInsertRowBelowMenuItem(eq(false));
         verify(view,
                times(1)).enableDeleteRowMenuItem(eq(false));
+    }
+
+    @Test
+    public void testOnRefreshMenusEvent() {
+        menu.onRefreshMenusEvent(new RefreshMenusEvent());
+
+        verify(menu).initialise();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilderTest.java
@@ -25,6 +25,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTablePinnedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -121,8 +123,8 @@ public class ViewMenuBuilderTest {
             return v;
         });
 
-        builder = new ViewMenuBuilder(ts,
-                                      menuItemFactory);
+        builder = spy(new ViewMenuBuilder(ts,
+                                          menuItemFactory));
         builder.setup();
         builder.setModeller(modeller);
     }
@@ -337,5 +339,12 @@ public class ViewMenuBuilderTest {
         //Verify clearing Decision Table selection disables view
         assertFalse(builder.miToggleMergeState.getMenuItem().isEnabled());
         assertFalse(builder.miViewAuditLog.getMenuItem().isEnabled());
+    }
+
+    @Test
+    public void testOnRefreshMenusEvent() {
+        builder.onRefreshMenusEvent(new RefreshMenusEvent());
+
+        verify(builder).initialise();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
@@ -40,6 +40,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanager.GuidedDecisionTableLockManager;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.cell.GridWidgetCellFactory;
@@ -204,6 +205,12 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
             //Do nothing. Default implementation throws an UnsupportedOperationException
         }
     });
+    protected Event<RefreshMenusEvent> refreshMenusEvent = spy(new EventSourceMock<RefreshMenusEvent>() {
+        @Override
+        public void fire(final RefreshMenusEvent event) {
+            //Do nothing. Default implementation throws an UnsupportedOperationException
+        }
+    });
     protected Event<NotificationEvent> notificationEvent = spy(new EventSourceMock<NotificationEvent>() {
         @Override
         public void fire(final NotificationEvent event) {
@@ -312,6 +319,7 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
                                                                                       refreshMetaDataPanelEvent,
                                                                                       refreshConditionsPanelEvent,
                                                                                       refreshActionsPanelEvent,
+                                                                                      refreshMenusEvent,
                                                                                       notificationEvent,
                                                                                       gridWidgetCellFactory,
                                                                                       gridWidgetColumnFactory,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -50,6 +50,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
@@ -152,6 +153,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         dtPresenter.onUpdatedLockStatusEvent(event);
 
         verify(dtPresenter).refreshColumnsPage();
+        verify(dtPresenter).refreshMenus();
         assertEquals(CURRENT_USER, dtPresenter.getAccess().getLock());
     }
 
@@ -165,6 +167,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         dtPresenter.onUpdatedLockStatusEvent(event);
 
         verify(dtPresenter).refreshColumnsPage();
+        verify(dtPresenter).refreshMenus();
         assertEquals(OTHER_USER, dtPresenter.getAccess().getLock());
     }
 
@@ -175,6 +178,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         dtPresenter.onUpdatedLockStatusEvent(event);
 
         verify(dtPresenter).refreshColumnsPage();
+        verify(dtPresenter).refreshMenus();
         assertEquals(NOBODY, dtPresenter.getAccess().getLock());
     }
 
@@ -1674,13 +1678,19 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
 
     @Test
     public void testRefreshColumnsPage() {
-
         dtPresenter.refreshColumnsPage();
 
         verify(refreshAttributesPanelEvent).fire(any(RefreshAttributesPanelEvent.class));
         verify(refreshMetaDataPanelEvent).fire(any(RefreshMetaDataPanelEvent.class));
         verify(refreshConditionsPanelEvent).fire(any(RefreshConditionsPanelEvent.class));
         verify(refreshActionsPanelEvent).fire(any(RefreshActionsPanelEvent.class));
+    }
+
+    @Test
+    public void testRefreshMenus() {
+        dtPresenter.refreshMenus();
+
+        verify(refreshMenusEvent).fire(any(RefreshMenusEvent.class));
     }
 
     /*

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
@@ -40,6 +40,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.analysis.Decisio
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMenusEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanager.GuidedDecisionTableLockManager;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
@@ -113,6 +114,9 @@ public class GuidedDecisionTablePresenter_AuditLogTest {
     private EventSourceMock<RefreshActionsPanelEvent> refreshActionsPanelEvent;
 
     @Mock
+    private EventSourceMock<RefreshMenusEvent> refreshMenusEvent;
+
+    @Mock
     private DecisionTableAnalyzerProvider decisionTableAnalyzerProvider;
 
     @Mock
@@ -164,6 +168,7 @@ public class GuidedDecisionTablePresenter_AuditLogTest {
                                                        refreshMetaDataPanelEvent,
                                                        refreshConditionsPanelEvent,
                                                        refreshActionsPanelEvent,
+                                                       refreshMenusEvent,
                                                        null,
                                                        null,
                                                        gridWidgetColumnFactory,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2149

The problem was that when the editor was opened the menus' state is set based on the "selected decision table". At the point of opening there has been no request for the "lock state" and hence the file appears unlocked and the menus enabled. However when the async call to retrieve the "lock state" completes the file becomes locked and the menus should be disabled.

This PR introduces a new ```RefreshMenusEvent``` that is fired when the "lock state" has been retrieved causing the menus to refresh themselves. Tried and tested locally (what is nice is that when a file is locked, as per the JIRA, and then becomes unlocked the menus in the other users browser update to become enabled).