### PR TITLE
[7.5.x] GUVNOR-3486: [Guided Decision Table Graph] Refresh after removal of table

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -266,6 +266,7 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
                        MenuItems.VALIDATE);
 
         if (!dtPresenter.isPresent()) {
+            activeDocument = null;
             return;
         }
 
@@ -292,15 +293,14 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
 
         addColumnsTab();
 
-        columnsTabToggle(dtPresenter);
+        enableColumnsTab(dtPresenter);
     }
 
-    void columnsTabToggle(final GuidedDecisionTableView.Presenter decisionTablePresenter) {
-        columnsTabToggle(isGuidedDecisionTableEditable(decisionTablePresenter));
+    void enableColumnsTab(final GuidedDecisionTableView.Presenter decisionTablePresenter) {
+        enableColumnsTab(isGuidedDecisionTableEditable(decisionTablePresenter));
     }
 
     boolean isGuidedDecisionTableEditable(final GuidedDecisionTableView.Presenter decisionTablePresenter) {
-
         final GuidedDecisionTablePresenter.Access access = decisionTablePresenter.getAccess();
         final boolean decisionTableIsEditable = !access.isReadOnly();
         final boolean decisionTableHasEditableColumns = access.hasEditableColumns();
@@ -308,27 +308,27 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
         return decisionTableIsEditable && decisionTableHasEditableColumns;
     }
 
-    void columnsTabToggle(final boolean disableColumnsPage) {
-        if (disableColumnsPage) {
-            disableColumnsPage();
-        } else {
+    void enableColumnsTab(final boolean enabled) {
+        if (enabled) {
             enableColumnsPage();
+        } else {
+            disableColumnsPage();
         }
     }
 
     void onUpdatedLockStatusEvent(final UpdatedLockStatusEvent event) {
-
         final Optional<GuidedDecisionTableView.Presenter> activeDecisionTable = Optional.ofNullable(modeller.getActiveDecisionTable());
 
         if (!activeDecisionTable.isPresent()) {
+            enableColumnsTab(false);
             return;
         }
 
         final boolean isEditable = isGuidedDecisionTableEditable(activeDecisionTable.get());
         final boolean isLocked = event.isLocked() && !event.isLockedByCurrentUser();
-        final boolean disableColumnsPage = isLocked || !isEditable;
+        final boolean enableColumnsPage = !isLocked && isEditable;
 
-        columnsTabToggle(disableColumnsPage);
+        enableColumnsTab(enableColumnsPage);
     }
 
     void addColumnsTab() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -50,6 +50,7 @@ import static org.drools.workbench.screens.guided.dtable.client.editor.BaseGuide
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -303,6 +304,35 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                never()).activateDocument(any(GuidedDecisionTableView.Presenter.class));
         assertFalse(getMenuState(presenter.getMenus(),
                                  MenuItems.VALIDATE));
+    }
+
+    @Test
+    public void checkOnDecisionTableSelectedEventReselection() {
+        final ObservablePath path = mock(ObservablePath.class);
+        final PlaceRequest placeRequest = mock(PlaceRequest.class);
+        final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
+        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable(path,
+                                                                                path,
+                                                                                placeRequest,
+                                                                                content);
+        final DecisionTableSelectedEvent eventSelect = new DecisionTableSelectedEvent(dtPresenter);
+        doReturn(true).when(modeller).isDecisionTableAvailable(dtPresenter);
+
+        presenter.onStartup(path,
+                            placeRequest);
+
+        presenter.onDecisionTableSelected(eventSelect);
+        assertEquals(dtPresenter,
+                     presenter.getActiveDocument());
+
+        final DecisionTableSelectedEvent eventDeselect = DecisionTableSelectedEvent.NONE;
+
+        presenter.onDecisionTableSelected(eventDeselect);
+        assertNull(presenter.getActiveDocument());
+
+        presenter.onDecisionTableSelected(eventSelect);
+        assertEquals(dtPresenter,
+                     presenter.getActiveDocument());
     }
 
     @Test
@@ -571,21 +601,20 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         verify(dtPresenter).activate();
         verify(presenter).enableMenus(true);
         verify(presenter).addColumnsTab();
-        verify(presenter).columnsTabToggle(dtPresenter);
+        verify(presenter).enableColumnsTab(dtPresenter);
         verify(presenter).activateDocument(dtPresenter, overview, oracle, imports, !isEditable);
     }
 
     @Test
-    public void testColumnsTabToggle() {
-
+    public void testEnableColumnsTab() {
         final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
         final boolean isGuidedDecisionTableEditable = true;
 
         doReturn(isGuidedDecisionTableEditable).when(presenter).isGuidedDecisionTableEditable(any());
 
-        presenter.columnsTabToggle(dtPresenter);
+        presenter.enableColumnsTab(dtPresenter);
 
-        verify(presenter).columnsTabToggle(isGuidedDecisionTableEditable);
+        verify(presenter).enableColumnsTab(eq(true));
     }
 
     @Test
@@ -686,74 +715,66 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
     @Test
     public void testOnUpdatedLockStatusEventWhenTableIsNotLockedAndIsEditable() {
-
         final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
-        final boolean disableColumnsTab = false;
 
         doReturn(false).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
         doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
-        doNothing().when(presenter).columnsTabToggle(anyBoolean());
+        doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
 
-        verify(presenter).columnsTabToggle(disableColumnsTab);
+        verify(presenter).enableColumnsTab(eq(true));
     }
 
     @Test
     public void testOnUpdatedLockStatusEventWhenTableIsNotLockedAndIsNotEditable() {
-
         final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
-        final boolean disableColumnsTab = true;
 
         doReturn(false).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(false).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
         doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
-        doNothing().when(presenter).columnsTabToggle(anyBoolean());
+        doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
 
-        verify(presenter).columnsTabToggle(disableColumnsTab);
+        verify(presenter).enableColumnsTab(eq(false));
     }
 
     @Test
     public void testOnUpdatedLockStatusEventWhenIsLockedByTheCurrentUser() {
-
         final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
-        final boolean disableColumnsTab = false;
 
         doReturn(true).when(event).isLocked();
         doReturn(true).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
         doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
-        doNothing().when(presenter).columnsTabToggle(anyBoolean());
+        doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
 
-        verify(presenter).columnsTabToggle(disableColumnsTab);
+        verify(presenter).enableColumnsTab(eq(true));
     }
 
     @Test
     public void testOnUpdatedLockStatusEventWhenIsLockedByAnotherUser() {
-
         final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
-        final boolean disableColumnsTab = true;
 
         doReturn(true).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
         doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
-        doNothing().when(presenter).columnsTabToggle(anyBoolean());
+        doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
 
-        verify(presenter).columnsTabToggle(disableColumnsTab);
+        verify(presenter).enableColumnsTab(eq(false));
     }
 
     @Test
@@ -765,6 +786,6 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
         presenter.onUpdatedLockStatusEvent(event);
 
-        verify(presenter, never()).columnsTabToggle(any());
+        verify(presenter, never()).enableColumnsTab(any());
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
@@ -732,7 +732,7 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
         verify(presenter, never()).initialiseEditorTabsWhenNoDocuments();
         verify(presenter).addColumnsTab();
-        verify(presenter).columnsTabToggle(dtPresenter);
+        verify(presenter).enableColumnsTab(dtPresenter);
     }
 
     private void checkOnDecisionTableSelected(final ParameterizedCommand<PlaceRequest> setup,


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3486

This is the corollary of https://github.com/kiegroup/drools-wb/pull/726 for 7.5.x

(cherry picked from commit dc4f41d1217b48ad0da971517d0b9e0f0f98557a)