### PR TITLE
Increase the TableWizard coverage

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImpl.java
@@ -185,7 +185,8 @@ public class ActionSetFieldsPageViewImpl extends Composite
         availablePatternsWidget.setKeyboardSelectionPolicy( KeyboardSelectionPolicy.ENABLED );
         availablePatternsWidget.setMinimumWidth( 170 );
 
-        final Label lstEmpty = new Label( GuidedDecisionTableConstants.INSTANCE.DecisionTableWizardNoAvailablePatterns() );
+        final Label lstEmpty = GWT.create(Label.class);
+        lstEmpty.setText( GuidedDecisionTableConstants.INSTANCE.DecisionTableWizardNoAvailablePatterns() );
         lstEmpty.setStyleName( WizardCellListResources.INSTANCE.cellListStyle().cellListEmptyItem() );
         availablePatternsWidget.setEmptyListWidget( lstEmpty );
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.wizard.table.pages;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ActionSetFieldsPageTest {
+
+    private GuidedDecisionTable52 model;
+
+    @Captor
+    private ArgumentCaptor<List<Pattern52>> patternsCaptor;
+
+    @Mock
+    private ActionSetFieldsPageView actionSetFieldsPageView;
+
+    @InjectMocks
+    private ActionSetFieldsPage actionSetFieldsPage;
+
+    @Before
+    public void setUp() throws Exception {
+        model = new GuidedDecisionTable52();
+        actionSetFieldsPage.model = model;
+    }
+
+    @Test
+    public void testPrepareViewNoPatterns() throws Exception {
+        actionSetFieldsPage.prepareView();
+        verify(actionSetFieldsPageView).setAvailablePatterns(Collections.emptyList());
+    }
+
+    @Test
+    public void testPrepareViewPatternsAvailableButNoConditionSpecified() throws Exception {
+        model.setConditionPatterns(Collections.singletonList(new Pattern52()));
+
+        actionSetFieldsPage.prepareView();
+        verify(actionSetFieldsPageView).setAvailablePatterns(Collections.emptyList());
+    }
+
+    @Test
+    public void testPrepareView() throws Exception {
+        final Pattern52 pattern = new Pattern52() {{
+            setFactType("Person");
+            setBoundName("p");
+            setChildColumns(Collections.singletonList(new ConditionCol52()));
+        }};
+        model.setConditionPatterns(Collections.singletonList(pattern));
+
+        actionSetFieldsPage.prepareView();
+        verify(actionSetFieldsPageView).setAvailablePatterns(patternsCaptor.capture());
+
+        assertEquals(1, patternsCaptor.getValue().size());
+        assertEquals(pattern, patternsCaptor.getValue().get(0));
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/ActionSetFieldsPageViewImplTest.java
@@ -17,13 +17,16 @@
 package org.drools.workbench.screens.guided.dtable.client.wizard.table.pages;
 
 import com.google.gwt.view.client.MultiSelectionModel;
+import com.google.gwtmockito.GwtMockito;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
 import org.drools.workbench.screens.guided.dtable.client.widget.Validator;
 import org.drools.workbench.screens.guided.dtable.client.wizard.table.pages.cells.ActionSetFieldCell;
 import org.drools.workbench.screens.guided.dtable.client.wizard.table.pages.cells.ActionSetFieldPatternCell;
+import org.gwtbootstrap3.client.ui.Label;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,9 +41,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@WithClassesToStub(Text.class)
+@WithClassesToStub({Text.class})
 @RunWith(GwtMockitoTestRunner.class)
 public class ActionSetFieldsPageViewImplTest {
+
+    @Mock
+    Label noAvailablePatternsLabel;
 
     @Mock
     ActionSetFieldPatternCell actionSetFieldPatternCell;
@@ -60,6 +66,8 @@ public class ActionSetFieldsPageViewImplTest {
 
     @Before
     public void setUp() throws Exception {
+        GwtMockito.useProviderForType(Label.class, aClass -> noAvailablePatternsLabel);
+
         view.setup();
         view.setValidator(mock(Validator.class));
         ActionSetFieldsPageView.Presenter presenter = mock(ActionSetFieldsPageView.Presenter.class);
@@ -83,5 +91,8 @@ public class ActionSetFieldsPageViewImplTest {
         assertTrue(selectionModel.isSelected(setFieldCol52));
     }
 
-
+    @Test
+    public void testNoAvailablePattern() throws Exception {
+        verify(noAvailablePatternsLabel).setText(GuidedDecisionTableConstants.INSTANCE.DecisionTableWizardNoAvailablePatterns());
+    }
 }


### PR DESCRIPTION
This PR focus on a case when the TableWizard informs the user about no available pattenrs which could be used in the table actions. In other words, user can not change a field of a pattern because there is no pattern defined yet.

This PR is part of migration form internal selenium test suite into community. See BAQE-314.

@manstis please have a look.