### PR TITLE
[7.5.x] DROOLS-2181: Icons (Edit, Collapse, Delete etc) do not respond to mouse clicks

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/widget/shapes/BaseGuidedDecisionTreeShape.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/widget/shapes/BaseGuidedDecisionTreeShape.java
@@ -18,15 +18,12 @@ package org.drools.workbench.screens.guided.dtree.client.widget.shapes;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.ait.lienzo.client.core.event.NodeMouseClickEvent;
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.client.core.shape.Circle;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Picture;
-import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.shared.core.types.Color;
+import com.ait.lienzo.shared.core.types.ImageSelectionMode;
 import com.ait.lienzo.shared.core.types.TextAlign;
 import com.ait.lienzo.shared.core.types.TextBaseLine;
 import com.google.gwt.resources.client.ImageResource;
@@ -75,13 +72,6 @@ public abstract class BaseGuidedDecisionTreeShape<T extends Node> extends WiresB
 
         add( circle );
         add( nodeLabel );
-
-        nodeLabel.addNodeMouseClickHandler( new NodeMouseClickHandler() {
-            @Override
-            public void onNodeMouseClick( final NodeMouseClickEvent nodeMouseClickEvent ) {
-                selectionManager.selectShape( BaseGuidedDecisionTreeShape.this );
-            }
-        } );
 
         if ( !isReadOnly ) {
             setupControls();
@@ -168,37 +158,19 @@ public abstract class BaseGuidedDecisionTreeShape<T extends Node> extends WiresB
         controls.add( ctrlGroupEditIcon );
     }
 
-    protected Group setupControl( final ImageResource resource,
-                                  final Command command ) {
+    protected Group setupControl(final ImageResource resource,
+                                 final Command command) {
         final Group controlGroup = new Group();
-        new Picture( resource, picture1 -> {
-            //This is a hack for Lienzo 1.2 (and possibly 2.x?). There is a bug in Picture when
-            //we want to add it to Lienzo's SelectionLayer. We work around it here by adding
-            //the Picture to a Group containing a "near invisible" Rectangle that we use to
-            //capture the NodeMouseClickEvents.
-            final double offsetX = -picture1.getImageData().getWidth() / 2;
-            final double offsetY = -picture1.getImageData().getHeight() / 2;
-            final Rectangle selector = new Rectangle( picture1.getImageData().getWidth(),
-                    picture1.getImageData().getHeight() );
-            selector.setFillColor( Color.rgbToBrowserHexColor( 255,
-                    255,
-                    255 ) );
-            selector.setAlpha( 0.01 );
-            selector.setLocation( new Point2D( offsetX,
-                    offsetY ) );
-            picture1.setLocation( new Point2D( offsetX,
-                    offsetY ) );
-            controlGroup.add( picture1 );
-            controlGroup.add( selector );
-        },
-        false );
+        final Picture p = new Picture(resource,
+                                      picture1 -> {
+                                          final double offsetX = -picture1.getImageData().getWidth() / 2;
+                                          final double offsetY = -picture1.getImageData().getHeight() / 2;
+                                          picture1.setLocation(new Point2D(offsetX, offsetY));
+                                          picture1.addNodeMouseClickHandler(e -> command.execute());
+                                      },
+                                      ImageSelectionMode.SELECT_BOUNDS);
+        controlGroup.add(p);
 
-        controlGroup.addNodeMouseClickHandler( new NodeMouseClickHandler() {
-            @Override
-            public void onNodeMouseClick( final NodeMouseClickEvent nodeMouseClickEvent ) {
-                command.execute();
-            }
-        } );
         return controlGroup;
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/widget/shapes/NodeLabel.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/widget/shapes/NodeLabel.java
@@ -15,7 +15,6 @@
  */
 package org.drools.workbench.screens.guided.dtree.client.widget.shapes;
 
-import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Rectangle;
@@ -26,7 +25,6 @@ import com.ait.lienzo.client.widget.LienzoPanel;
 import com.ait.lienzo.shared.core.types.Color;
 import com.ait.lienzo.shared.core.types.TextAlign;
 import com.ait.lienzo.shared.core.types.TextBaseLine;
-import com.google.gwt.event.shared.HandlerRegistration;
 import org.uberfire.ext.wires.core.client.util.ShapeFactoryUtil;
 
 public class NodeLabel extends Group {
@@ -50,6 +48,7 @@ public class NodeLabel extends Group {
                                                               180,
                                                               180 ) );
         container.setAlpha( 0.50 );
+        text.setFillBoundsForSelection(true);
         text.setTextAlign( TextAlign.CENTER );
         text.setTextBaseLine( TextBaseLine.MIDDLE );
         text.setFillColor( Color.rgbToBrowserHexColor( 0,
@@ -76,21 +75,6 @@ public class NodeLabel extends Group {
         container.setHeight( ch );
         container.setLocation( new Point2D( -cw / 2,
                                             -ch / 2 ) );
-    }
-
-    @Override
-    public HandlerRegistration addNodeMouseClickHandler( final NodeMouseClickHandler handler ) {
-        final HandlerRegistration ch = container.addNodeMouseClickHandler( handler );
-        final HandlerRegistration th = text.addNodeMouseClickHandler( handler );
-        final HandlerRegistration nh = super.addNodeMouseClickHandler( handler );
-        return new HandlerRegistration() {
-            @Override
-            public void removeHandler() {
-                ch.removeHandler();
-                th.removeHandler();
-                nh.removeHandler();
-            }
-        };
     }
 
     public double getWidth() {


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2181

This is the corollary of https://github.com/kiegroup/drools-wb/pull/740 for 7.5.x

(cherry picked from commit b6b2bc812106b1d35ba83e38c93f65af4bc1e135)