### PR TITLE
[6.5.x] RHBPMS-5096: [GSS](6.4.z) Guided decision table in Business Central failed to load when using functions in BPM Suite 6.4

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/condition/FieldConditionInspectorKey.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/condition/FieldConditionInspectorKey.java
@@ -22,10 +22,10 @@ public class FieldConditionInspectorKey
         extends ConditionInspectorKey {
 
     private final Pattern52 pattern;
-    private final String    factField;
+    private final String factField;
 
-    public FieldConditionInspectorKey( final Pattern52 pattern,
-                                       final String factField ) {
+    public FieldConditionInspectorKey(final Pattern52 pattern,
+                                      final String factField) {
         this.pattern = pattern;
         this.factField = factField;
     }
@@ -39,21 +39,28 @@ public class FieldConditionInspectorKey
     }
 
     @Override
-    public boolean equals( Object o ) {
-        if ( this == o ) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
-        } else if ( o instanceof FieldConditionInspectorKey ) {
-            FieldConditionInspectorKey other = ( FieldConditionInspectorKey ) o;
-            return pattern.equals( other.pattern ) && factField.equals( other.factField );
-        } else {
+        }
+        if (!(o instanceof FieldConditionInspectorKey)) {
             return false;
         }
+
+        FieldConditionInspectorKey that = (FieldConditionInspectorKey) o;
+
+        if (!pattern.equals(that.pattern)) {
+            return false;
+        }
+        return factField != null ? factField.equals(that.factField) : that.factField == null;
     }
 
     @Override
     public int hashCode() {
-        final int result = 37 * pattern.hashCode() + factField.hashCode();
-        return ~~result;
+        int result = pattern.hashCode();
+        result = ~~result;
+        result = 31 * result + (factField != null ? factField.hashCode() : 0);
+        result = ~~result;
+        return result;
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/condition/ConditionInspectorTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/condition/ConditionInspectorTest.java
@@ -27,116 +27,149 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class ConditionInspectorTest {
 
-    private static final List<String> ALL_VALUE_LIST = Arrays.asList( "value", "val01", "val02" );
+    private static final List<String> ALL_VALUE_LIST = Arrays.asList("value", "val01", "val02");
+
+    private static final Pattern52 PATTERN = mock(Pattern52.class);
 
     private final FieldConditionInspector a;
     private final FieldConditionInspector b;
     private final boolean inspectorsEqual;
+    private final boolean inspectorsKeyEqual;
 
     @Test
     public void testEquals() {
-        assertEquals( getDescription(), inspectorsEqual, a.equals( b ) );
-        assertEquals( getDescription(), inspectorsEqual, b.equals( a ) );
+        assertEquals(getDescription(), inspectorsEqual, a.equals(b));
+        assertEquals(getDescription(), inspectorsEqual, b.equals(a));
     }
 
-    public ConditionInspectorTest( FieldConditionInspector a,
-                                   FieldConditionInspector b,
-                                   boolean inspectorsEqual ) {
+    @Test
+    public void testKeyEquals() {
+        assertEquals("FieldConditionInspectorKey.equals():" + getDescription(),
+                     inspectorsKeyEqual,
+                     a.getKey().equals(b.getKey()));
+        assertEquals("FieldConditionInspectorKey.equals(): " + getDescription(),
+                     inspectorsKeyEqual,
+                     b.getKey().equals(a.getKey()));
+    }
+
+    @Test
+    public void testKeyHashCode() {
+        if (inspectorsKeyEqual) {
+            assertEquals("FieldConditionInspectorKey.hashCode(): " + getDescription(),
+                         a.getKey().hashCode(),
+                         b.getKey().hashCode());
+        } else {
+            assertNotEquals("FieldConditionInspectorKey.hashCode(): " + getDescription(),
+                            a.getKey().hashCode(),
+                            b.getKey().hashCode());
+        }
+    }
+
+    public ConditionInspectorTest(FieldConditionInspector a,
+                                  FieldConditionInspector b,
+                                  boolean inspectorsEqual,
+                                  boolean inspectorsKeyEqual) {
         this.a = a;
         this.b = b;
         this.inspectorsEqual = inspectorsEqual;
+        this.inspectorsKeyEqual = inspectorsKeyEqual;
     }
 
     @Parameters
     public static Collection<Object[]> getData() {
-        return Arrays.asList( new Object[][]{
-                { getStringCondition( "strField", "value", "==" ), getStringCondition( "strField", "value", "==" ), true },
-                { getStringCondition( "strField", "value", "==" ), getStringCondition( "strField", "value", "!=" ), false },
-                { getStringCondition( "strField", "val01", "==" ), getStringCondition( "strField", "val02", "==" ), false },
-                { getStringCondition( "strFld01", "value", "==" ), getStringCondition( "strFld02", "value", "==" ), false },
+        return Arrays.asList(new Object[][]{
+                {getStringCondition("strField", "value", "=="), getStringCondition("strField", "value", "=="), true, true},
+                {getStringCondition("strField", "value", "=="), getStringCondition("strField", "value", "!="), false, true},
+                {getStringCondition("strField", "val01", "=="), getStringCondition("strField", "val02", "=="), false, true},
+                {getStringCondition("strFld01", "value", "=="), getStringCondition("strFld02", "value", "=="), false, false},
 
-                { getBooleanCondition( "boolField", true, "==" ), getBooleanCondition( "boolField", true, "==" ), true },
-                { getBooleanCondition( "boolField", true, "==" ), getBooleanCondition( "boolField", true, "!=" ), false },
-                { getBooleanCondition( "boolField", true, "==" ), getBooleanCondition( "boolField", false, "==" ), false },
-                { getBooleanCondition( "boolFld01", true, "==" ), getBooleanCondition( "boolFld02", true, "==" ), false },
+                {getBooleanCondition("boolField", true, "=="), getBooleanCondition("boolField", true, "=="), true, true},
+                {getBooleanCondition("boolField", true, "=="), getBooleanCondition("boolField", true, "!="), false, true},
+                {getBooleanCondition("boolField", true, "=="), getBooleanCondition("boolField", false, "=="), false, true},
+                {getBooleanCondition("boolFld01", true, "=="), getBooleanCondition("boolFld02", true, "=="), false, false},
 
-                { getComparableCondition( "comparable", 0, "==" ), getComparableCondition( "comparable", 0, "==" ), true },
-                { getComparableCondition( "comparable", 0, "==" ), getComparableCondition( "comparable", 0, "!=" ), false },
-                { getComparableCondition( "comparable", 0, "==" ), getComparableCondition( "comparable", 1, "==" ), false },
-                { getComparableCondition( "comparab01", 0, "==" ), getComparableCondition( "comparab02", 0, "==" ), false },
+                {getComparableCondition("comparable", 0, "=="), getComparableCondition("comparable", 0, "=="), true, true},
+                {getComparableCondition("comparable", 0, "=="), getComparableCondition("comparable", 0, "!="), false, true},
+                {getComparableCondition("comparable", 0, "=="), getComparableCondition("comparable", 1, "=="), false, true},
+                {getComparableCondition("comparab01", 0, "=="), getComparableCondition("comparab02", 0, "=="), false, false},
 
-                { getEnumCondition( "enumField", "value", "==" ), getEnumCondition( "enumField", "value", "==" ), true },
-                { getEnumCondition( "enumField", "value", "==" ), getEnumCondition( "enumField", "value", "!=" ), false },
-                { getEnumCondition( "enumField", "val01", "==" ), getEnumCondition( "enumField", "val02", "==" ), false },
-                { getEnumCondition( "enumFld01", "value", "==" ), getEnumCondition( "enumFld02", "value", "==" ), false },
+                {getEnumCondition("enumField", "value", "=="), getEnumCondition("enumField", "value", "=="), true, true},
+                {getEnumCondition("enumField", "value", "=="), getEnumCondition("enumField", "value", "!="), false, true},
+                {getEnumCondition("enumField", "val01", "=="), getEnumCondition("enumField", "val02", "=="), false, true},
+                {getEnumCondition("enumFld01", "value", "=="), getEnumCondition("enumFld02", "value", "=="), false, false},
 
-                { getNumericIntegerCondition( "comparable", 0, "==" ), getNumericIntegerCondition( "comparable", 0, "==" ), true },
-                { getNumericIntegerCondition( "comparable", 0, "==" ), getNumericIntegerCondition( "comparable", 0, "!=" ), false },
-                { getNumericIntegerCondition( "comparable", 0, "==" ), getNumericIntegerCondition( "comparable", 1, "==" ), false },
-                { getNumericIntegerCondition( "comparab01", 0, "==" ), getNumericIntegerCondition( "comparab02", 0, "==" ), false },
+                {getNumericIntegerCondition("comparable", 0, "=="), getNumericIntegerCondition("comparable", 0, "=="), true, true},
+                {getNumericIntegerCondition("comparable", 0, "=="), getNumericIntegerCondition("comparable", 0, "!="), false, true},
+                {getNumericIntegerCondition("comparable", 0, "=="), getNumericIntegerCondition("comparable", 1, "=="), false, true},
+                {getNumericIntegerCondition("comparab01", 0, "=="), getNumericIntegerCondition("comparab02", 0, "=="), false, false},
 
-                { getStringCondition( "strField", "value", "==" ), getBooleanCondition( "boolField", true, "==" ), false },
-                { getStringCondition( "strField", "value", "==" ), getComparableCondition( "comparable", 0, "==" ), false },
-                { getStringCondition( "strField", "value", "==" ), getEnumCondition( "enumField", "value", "==" ), false },
-                { getStringCondition( "strField", "value", "==" ), getNumericIntegerCondition( "comparable", 0, "==" ), false },
-                { getStringCondition( "strField", "value", "==" ), getUnrecognizedCondition( "randomField", "==" ), false },
-                { getBooleanCondition( "boolField", true, "==" ), getComparableCondition( "comparable", 0, "==" ), false },
-                { getBooleanCondition( "boolField", true, "==" ), getEnumCondition( "enumField", "value", "==" ), false },
-                { getBooleanCondition( "boolField", true, "==" ), getNumericIntegerCondition( "comparable", 0, "==" ), false },
-                { getBooleanCondition( "boolField", true, "==" ), getUnrecognizedCondition( "randomField", "==" ), false },
-                { getComparableCondition( "comparable", 0, "==" ), getEnumCondition( "enumField", "value", "==" ), false },
-                { getComparableCondition( "comparable", 0, "==" ), getNumericIntegerCondition( "comparable", 0, "==" ), false },
-                { getComparableCondition( "comparable", 0, "==" ), getUnrecognizedCondition( "randomField", "==" ), false },
-                { getEnumCondition( "enumField", "value", "==" ), getNumericIntegerCondition( "comparable", 0, "==" ), false },
-                { getEnumCondition( "enumField", "value", "==" ), getUnrecognizedCondition( "randomField", "==" ), false },
-        } );
+                {getStringCondition("strField", "value", "=="), getBooleanCondition("boolField", true, "=="), false, false},
+                {getStringCondition("strField", "value", "=="), getComparableCondition("comparable", 0, "=="), false, false},
+                {getStringCondition("strField", "value", "=="), getEnumCondition("enumField", "value", "=="), false, false},
+                {getStringCondition("strField", "value", "=="), getNumericIntegerCondition("comparable", 0, "=="), false, false},
+                {getStringCondition("strField", "value", "=="), getUnrecognizedCondition("randomField", "=="), false, false},
+                {getBooleanCondition("boolField", true, "=="), getComparableCondition("comparable", 0, "=="), false, false},
+                {getBooleanCondition("boolField", true, "=="), getEnumCondition("enumField", "value", "=="), false, false},
+                {getBooleanCondition("boolField", true, "=="), getNumericIntegerCondition("comparable", 0, "=="), false, false},
+                {getBooleanCondition("boolField", true, "=="), getUnrecognizedCondition("randomField", "=="), false, false},
+                {getComparableCondition("comparable", 0, "=="), getEnumCondition("enumField", "value", "=="), false, false},
+                {getComparableCondition("comparable", 0, "=="), getNumericIntegerCondition("comparable", 0, "=="), false, true},
+                {getComparableCondition("comparable", 0, "=="), getUnrecognizedCondition("randomField", "=="), false, false},
+                {getEnumCondition("enumField", "value", "=="), getNumericIntegerCondition("comparable", 0, "=="), false, false},
+                {getEnumCondition("enumField", "value", "=="), getUnrecognizedCondition("randomField", "=="), false, false},
+
+                {getStringCondition(null, "eval(true)", ""), getStringCondition(null, "eval(true)", ""), true, true},
+                {getStringCondition(null, "eval(true)", ""), getStringCondition("strField", "value", "=="), false, false}
+        });
     }
 
     public String getDescription() {
-        return format( "Expected '%s' %sto be equal to '%s'.",
-                       a.toHumanReadableString(),
-                       inspectorsEqual ? "" : "not ",
-                       b.toHumanReadableString() );
+        return format("Expected '%s' %sto be equal to '%s'.",
+                      a.toHumanReadableString(),
+                      inspectorsEqual ? "" : "not ",
+                      b.toHumanReadableString());
     }
 
-    private static StringConditionInspector getStringCondition( String field,
-                                                                String value,
-                                                                String operator ) {
-        return new StringConditionInspector( mock( Pattern52.class ), field, value, operator );
+    private static StringConditionInspector getStringCondition(String field,
+                                                               String value,
+                                                               String operator) {
+        return new StringConditionInspector(PATTERN, field, value, operator);
     }
 
-    private static BooleanConditionInspector getBooleanCondition( String field,
-                                                                  Boolean value,
-                                                                  String operator ) {
-        return new BooleanConditionInspector( mock( Pattern52.class ), field, value, operator );
+    private static BooleanConditionInspector getBooleanCondition(String field,
+                                                                 Boolean value,
+                                                                 String operator) {
+        return new BooleanConditionInspector(PATTERN, field, value, operator);
     }
 
-    private static ComparableConditionInspector getComparableCondition( String field,
-                                                                        Comparable value,
-                                                                        String operator ) {
-        return new ComparableConditionInspector( mock( Pattern52.class ), field, value, operator );
+    @SuppressWarnings("unchecked")
+    private static ComparableConditionInspector getComparableCondition(String field,
+                                                                       Comparable value,
+                                                                       String operator) {
+        return new ComparableConditionInspector(PATTERN, field, value, operator);
     }
 
-    private static EnumConditionInspector getEnumCondition( String field,
-                                                            String value,
-                                                            String operator ) {
-        return new EnumConditionInspector( mock( Pattern52.class ), field, ALL_VALUE_LIST, value, operator );
+    private static EnumConditionInspector getEnumCondition(String field,
+                                                           String value,
+                                                           String operator) {
+        return new EnumConditionInspector(PATTERN, field, ALL_VALUE_LIST, value, operator);
     }
 
-    private static NumericIntegerConditionInspector getNumericIntegerCondition( String field,
-                                                                                Integer value,
-                                                                                String operator ) {
-        return new NumericIntegerConditionInspector( mock( Pattern52.class ), field, value, operator );
+    private static NumericIntegerConditionInspector getNumericIntegerCondition(String field,
+                                                                               Integer value,
+                                                                               String operator) {
+        return new NumericIntegerConditionInspector(PATTERN, field, value, operator);
     }
 
-    private static UnrecognizedConditionInspector getUnrecognizedCondition( String field,
-                                                                            String operator ) {
-        return new UnrecognizedConditionInspector( mock( Pattern52.class ), field, operator );
+    private static UnrecognizedConditionInspector getUnrecognizedCondition(String field,
+                                                                           String operator) {
+        return new UnrecognizedConditionInspector(PATTERN, field, operator);
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-5096

@Rikkola fix and tests.. just want your opinion on whether this is "safe" (as Hash Code is quite important to V&V). All tests in ```drools-wb-guided-dtable-editor-client``` pass. ```master``` branch seems unaffected.
  