### PR TITLE
DROOLS-2229 : Error shown every time GDT editor opened in Firefox and IE11

### DIFF
--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/resources/org/drools/workbench/services/verifier/webworker/linker/ScriptTemplate.js
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/src/main/resources/org/drools/workbench/services/verifier/webworker/linker/ScriptTemplate.js
@@ -26,6 +26,7 @@ $self = self;
 $wnd = self;
 $doc = self;
 $sessionId = null;
+window = self;
 
 /*
  * Here we have the template for the main function.


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2229

(cherry picked from commit ecb5767c5df936a239b14104a17cc751875488a6)