### PR TITLE
[7.5.x] DROOLS-2250: Align Engine hints in Decision Table column wizard with BAPL-708

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
@@ -175,12 +175,12 @@ NewPatternPresenter.PleaseEnterANameThatIsNotAlreadyUsedByAnotherPattern=That bi
 AdditionalInfoPage.AdditionalInfo=Additional info
 AdditionalInfoPage.HideColumnDescription=Select this to hide the column, or clear this to display the column.
 AdditionalInfoPage.HeaderColumnDescription=Describe shortly what this column serves for.
-AdditionalInfoPage.LogicalInsertDescription=Select this to insert the fact pattern logically into the inference engine, or clear this to insert it regularly. \
-                                            The rules engine is responsible for logical decisions on insertions and retractions of facts. After regular or stated \
+AdditionalInfoPage.LogicalInsertDescription=Select this to insert the fact pattern logically into the decision engine, or clear this to insert it regularly. \
+                                            The decision engine is responsible for logical decisions on insertions and retractions of facts. After regular or stated \
                                             insertions, facts have to be retracted explicitly. After logical insertions, facts are automatically retracted when the \
                                             conditions that asserted the facts in the first place are no longer true. For more details, see <b>Truth Maintenance</b>.Red Hat JBoss BPM Suite Development Guide.
 AdditionalInfoPage.UpdateEngineDescription=This option appears when the selected Fact Pattern is already used in another column in the guided decision table. \
-                                           Select this to update the rules engine with the modified field values, or clear this to not update the rules engine.
+                                           Select this to update the decision engine with the modified field values, or clear this to not update the decision engine.
 AttributeColumnPage.AddNewAttribute=Add a new Attribute column
 CalculationTypePage.CalculationType=Calculation type
 FieldPage.Field=Field


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2250

This is the corollary of https://github.com/kiegroup/drools-wb/pull/759 for 7.5.x

(cherry picked from commit c87b0971372415102820f6f4493169c3d8b8971b)