### PR TITLE
[7.5.x] DROOLS-2160: Convert delete buttons to gwt-bootstrap3 (#723)

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ActivateRuleFlowWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ActivateRuleFlowWidget.java
@@ -16,20 +16,18 @@
 
 package org.drools.workbench.screens.testscenario.client;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
-import com.google.gwt.user.client.ui.Image;
 import org.drools.workbench.models.testscenarios.shared.ActivateRuleFlowGroup;
 import org.drools.workbench.models.testscenarios.shared.Fixture;
 import org.drools.workbench.models.testscenarios.shared.FixtureList;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
 
 public class ActivateRuleFlowWidget
@@ -75,23 +73,23 @@ public class ActivateRuleFlowWidget
             outer.setWidget( row,
                              0,
                              new SmallLabel( acticateRuleFlowGroup.getName() ) );
-            Image image = CommonAltedImages.INSTANCE.DeleteItemSmall();
-            image.setAltText( TestScenarioConstants.INSTANCE.RemoveThisRuleFlowActivation() );
-            ImageButton del = new ImageButton( image,
-                                               TestScenarioConstants.INSTANCE.RemoveThisRuleFlowActivation(),
-                                               new ClickHandler() {
-                                                   public void onClick( ClickEvent w ) {
-                                                       retList.remove( acticateRuleFlowGroup );
-                                                       sc.getFixtures().remove( acticateRuleFlowGroup );
-                                                       render( retList,
-                                                               outer,
-                                                               sc );
-                                                       parent.renderEditor();
-                                                   }
-                                               } );
+
+            Button deleteButton = new Button();
+            deleteButton.setIcon(IconType.TRASH);
+            deleteButton.setType(ButtonType.DANGER);
+            deleteButton.setTitle(TestScenarioConstants.INSTANCE.RemoveThisRuleFlowActivation());
+            deleteButton.addClickHandler(clickEvent -> {
+                retList.remove(acticateRuleFlowGroup);
+                sc.getFixtures().remove(acticateRuleFlowGroup);
+                render(retList,
+                       outer,
+                       sc);
+                parent.renderEditor();
+            });
+
             outer.setWidget( row,
                              1,
-                             del );
+                             deleteButton );
 
             row++;
         }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/CallMethodWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/CallMethodWidget.java
@@ -37,14 +37,15 @@ import org.drools.workbench.models.testscenarios.shared.FactData;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.drools.workbench.screens.testscenario.client.resources.images.TestScenarioAltedImages;
+import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.soup.project.datamodel.oracle.DropDownData;
 import org.kie.soup.project.datamodel.oracle.MethodInfo;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
 import org.kie.workbench.common.widgets.client.resources.HumanReadable;
 import org.uberfire.client.callbacks.Callback;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
 import org.uberfire.ext.widgets.common.client.common.popups.FormStylePopup;
 
@@ -260,11 +261,12 @@ public class CallMethodWidget extends Composite {
         }
     }
 
-    class DeleteButton extends ImageButton {
+    class DeleteButton extends Button {
 
         public DeleteButton() {
-            super(CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                  TestScenarioConstants.INSTANCE.RemoveCallMethod());
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.RemoveCallMethod());
 
             addClickHandler(new ClickHandler() {
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ExpectPanel.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ExpectPanel.java
@@ -23,10 +23,11 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import org.drools.workbench.models.testscenarios.shared.ExecutionTrace;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
 
 public class ExpectPanel extends HorizontalPanel {
 
@@ -51,12 +52,12 @@ public class ExpectPanel extends HorizontalPanel {
         add( new DeleteButton() );
     }
 
-    class DeleteButton
-            extends ImageButton {
+    class DeleteButton extends Button {
 
         public DeleteButton() {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   CommonConstants.INSTANCE.DeleteItem() );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(CommonConstants.INSTANCE.DeleteItem());
             addClickHandler( new ClickHandler() {
 
                 public void onClick( ClickEvent event ) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FactDataWidgetFactory.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FactDataWidgetFactory.java
@@ -38,10 +38,11 @@ import org.drools.workbench.models.testscenarios.shared.FieldPlaceHolder;
 import org.drools.workbench.models.testscenarios.shared.FixtureList;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
 import org.uberfire.ext.widgets.common.client.common.ClickableLabel;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
 
 public class FactDataWidgetFactory {
@@ -226,11 +227,12 @@ public class FactDataWidgetFactory {
         return rowIndexByFieldName.amountOrRows();
     }
 
-    class DeleteFactColumnButton extends ImageButton {
+    class DeleteFactColumnButton extends Button {
 
         public DeleteFactColumnButton( final FactData fact ) {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   TestScenarioConstants.INSTANCE.RemoveTheColumnForScenario( fact.getName() ) );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.RemoveTheColumnForScenario(fact.getName()));
 
             addClickHandler( new ClickHandler() {
                 public void onClick( ClickEvent event ) {
@@ -247,12 +249,13 @@ public class FactDataWidgetFactory {
         }
     }
 
-    class DeleteFieldRowButton extends ImageButton {
+    class DeleteFieldRowButton extends Button {
 
         public DeleteFieldRowButton( final Fact fact,
                                      final String fieldName ) {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   TestScenarioConstants.INSTANCE.RemoveThisRow() );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.RemoveThisRow());
 
             addClickHandler( new ClickHandler() {
                 public void onClick( ClickEvent event ) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FactWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FactWidget.java
@@ -25,9 +25,10 @@ import org.drools.workbench.models.testscenarios.shared.Fixture;
 import org.drools.workbench.models.testscenarios.shared.FixtureList;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
 
 public abstract class FactWidget extends HorizontalPanel {
 
@@ -65,12 +66,12 @@ public abstract class FactWidget extends HorizontalPanel {
         }
     }
 
-    class DeleteButton
-            extends ImageButton {
+    class DeleteButton extends Button {
 
         public DeleteButton( final FixtureList definitionList ) {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   TestScenarioConstants.INSTANCE.RemoveThisBlockOfData() );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.RemoveThisBlockOfData());
 
             addClickHandler( new ClickHandler() {
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ListEditorRow.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ListEditorRow.java
@@ -28,6 +28,9 @@ import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.testscenarios.shared.CollectionFieldData;
 import org.drools.workbench.models.testscenarios.shared.FieldData;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 
 public class ListEditorRow extends Composite {
 
@@ -43,7 +46,7 @@ public class ListEditorRow extends Composite {
     FieldDataConstraintEditor fieldDataConstraintEditor;
 
     @UiField
-    Image deleteItem;
+    Button deleteItem;
 
     @UiField
     Image newItemBelow;
@@ -78,6 +81,8 @@ public class ListEditorRow extends Composite {
         } );
 
         initWidget( uiBinder.createAndBindUi( this ) );
+        deleteItem.setIcon(IconType.TRASH);
+        deleteItem.setType(ButtonType.DANGER);
     }
 
     @UiHandler("deleteItem")

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ListEditorRow.ui.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ListEditorRow.ui.xml
@@ -17,6 +17,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:gwt='urn:import:com.google.gwt.user.client.ui'
+             xmlns:gwtbootstrap="urn:import:org.gwtbootstrap3.client.ui"
              xmlns:guvnor='urn:import:org.drools.workbench.screens.testscenario.client'>
 
   <ui:with field="i18n" type="org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants"/>
@@ -25,17 +26,14 @@
 
   <gwt:HorizontalPanel>
     <guvnor:FieldDataConstraintEditor ui:field="fieldDataConstraintEditor"/>
-    <gwt:Image ui:field="deleteItem"
-               resource="{images.DeleteItemSmall}"
-               altText="{i18n.AElementToDelInCollectionList}"
-        />
+    <gwtbootstrap:Button ui:field="deleteItem"
+                         title="{i18n.AElementToDelInCollectionList}"/>
     <gwt:Image ui:field="newItemBelow"
                resource="{images.newItemBelow}"
                altText="{i18n.AddElementBelow}"/>
     <gwt:Image ui:field="suffleDown"
                resource="{images.shuffleDown}"
-               altText="{i18n.MoveDownListMove}"
-        />
+               altText="{i18n.MoveDownListMove}"/>
     <gwt:Image ui:field="suffleUp"
                resource="{images.shuffleUp}"
                altText="{i18n.MoveUpList}"/>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/RetractWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/RetractWidget.java
@@ -26,8 +26,9 @@ import org.drools.workbench.models.testscenarios.shared.FixtureList;
 import org.drools.workbench.models.testscenarios.shared.RetractFact;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
 
 public class RetractWidget extends FlexTable {
@@ -83,11 +84,12 @@ public class RetractWidget extends FlexTable {
         }
     }
 
-    class DeleteButton extends ImageButton {
+    class DeleteButton extends Button {
 
         public DeleteButton( final RetractFact retractFact ) {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   TestScenarioConstants.INSTANCE.RemoveThisDeleteStatement() );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.RemoveThisDeleteStatement());
 
             addClickHandler( new ClickHandler() {
                 public void onClick( ClickEvent event ) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFactWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFactWidget.java
@@ -40,11 +40,13 @@ import org.drools.workbench.models.testscenarios.shared.VerifyField;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.drools.workbench.screens.testscenario.client.resources.images.TestScenarioAltedImages;
 import org.drools.workbench.screens.testscenario.client.resources.images.TestScenarioImages;
+import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.soup.project.datamodel.oracle.MethodInfo;
 import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
 import org.kie.workbench.common.widgets.client.resources.CommonImages;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.widgets.common.client.common.ClickableLabel;
@@ -209,24 +211,23 @@ public class VerifyFactWidget extends Composite {
                            3,
                            cellEditor);
 
-            Image del = CommonAltedImages.INSTANCE.DeleteItemSmall();
-            del.setAltText(TestScenarioConstants.INSTANCE.RemoveThisFieldExpectation());
-            del.setTitle(TestScenarioConstants.INSTANCE.RemoveThisFieldExpectation());
-            del.addClickHandler(new ClickHandler() {
-                public void onClick(ClickEvent w) {
-                    if (Window.confirm(TestScenarioConstants.INSTANCE.AreYouSureYouWantToRemoveThisFieldExpectation(
-                            fld.getFieldName()))) {
-                        vf.getFieldValues().remove(fld);
-                        FlexTable data = render(vf);
-                        outer.setWidget(1,
-                                        0,
-                                        data);
-                    }
+            Button deleteButton = new Button();
+            deleteButton.setIcon(IconType.TRASH);
+            deleteButton.setType(ButtonType.DANGER);
+            deleteButton.setTitle(TestScenarioConstants.INSTANCE.RemoveThisFieldExpectation());
+            deleteButton.addClickHandler(clickEvent -> {
+                if (Window.confirm(TestScenarioConstants.INSTANCE.AreYouSureYouWantToRemoveThisFieldExpectation(
+                        fld.getFieldName()))) {
+                    vf.getFieldValues().remove(fld);
+                    FlexTable renderedTableAfterDelete = render(vf);
+                    outer.setWidget(1,
+                                    0,
+                                    renderedTableAfterDelete);
                 }
             });
             data.setWidget(i,
                            4,
-                           del);
+                           deleteButton);
 
             if (showResults && fld.getSuccessResult() != null) {
                 if (!fld.getSuccessResult().booleanValue()) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFactsPanel.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFactsPanel.java
@@ -27,9 +27,10 @@ import org.drools.workbench.models.testscenarios.shared.FixtureList;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.models.testscenarios.shared.VerifyFact;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
-import org.uberfire.ext.widgets.common.client.common.ImageButton;
 
 public class VerifyFactsPanel extends VerticalPanel {
 
@@ -65,11 +66,12 @@ public class VerifyFactsPanel extends VerticalPanel {
         }
     }
 
-    class DeleteButton extends ImageButton {
+    class DeleteButton extends Button {
 
         public DeleteButton( final VerifyFact verifyFact ) {
-            super( CommonAltedImages.INSTANCE.DeleteItemSmall(),
-                   TestScenarioConstants.INSTANCE.DeleteTheExpectationForThisFact() );
+            setIcon(IconType.TRASH);
+            setType(ButtonType.DANGER);
+            setTitle(TestScenarioConstants.INSTANCE.DeleteTheExpectationForThisFact());
 
             addClickHandler( new ClickHandler() {
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyRulesFiredWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyRulesFiredWidget.java
@@ -19,8 +19,6 @@ package org.drools.workbench.screens.testscenario.client;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyPressHandler;
 import com.google.gwt.user.client.Window;
@@ -37,9 +35,11 @@ import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.models.testscenarios.shared.VerifyRuleFired;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.drools.workbench.screens.testscenario.client.resources.images.TestScenarioImages;
+import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
+import org.gwtbootstrap3.client.ui.constants.ButtonType;
+import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.kie.workbench.common.widgets.client.resources.CommonImages;
 import org.uberfire.ext.widgets.common.client.common.SmallLabel;
 
@@ -164,21 +164,20 @@ public class VerifyRulesFiredWidget extends Composite {
                             2,
                             h );
 
-            Image del = CommonAltedImages.INSTANCE.DeleteItemSmall();
-            del.setAltText( TestScenarioConstants.INSTANCE.RemoveThisRuleExpectation() );
+            Button del = new Button();
+            del.setIcon(IconType.TRASH);
+            del.setType(ButtonType.DANGER);
             del.setTitle( TestScenarioConstants.INSTANCE.RemoveThisRuleExpectation() );
-            del.addClickHandler( new ClickHandler() {
-                public void onClick( ClickEvent w ) {
-                    if ( Window.confirm( TestScenarioConstants.INSTANCE.AreYouSureYouWantToRemoveThisRuleExpectation() ) ) {
-                        rfl.remove( v );
-                        sc.removeFixture( v );
-                        outer.setWidget( 1,
-                                         0,
-                                         render( rfl,
-                                                 sc ) );
-                    }
+            del.addClickHandler(clickEvent -> {
+                if (Window.confirm(TestScenarioConstants.INSTANCE.AreYouSureYouWantToRemoveThisRuleExpectation())) {
+                    rfl.remove(v);
+                    sc.removeFixture(v);
+                    outer.setWidget(1,
+                                    0,
+                                    render(rfl,
+                                           sc));
                 }
-            } );
+            });
 
             data.setWidget( i,
                             3,


### PR DESCRIPTION
This is corollary of #723,
@ibek asked me to cherry-pick as this is part of Getting Started Experience requirement targeted for RHDM-7.0.GA.