### PR TITLE
[7.5.x] BAQE-336: Increase coverage of drl file validation

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/java/org/kiegroup/storage/Storage.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/java/org/kiegroup/storage/Storage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kiegroup.storage;
+
+import java.util.List;
+import java.util.ArrayList;
+import org.kiegroup.DrivingLicenseApplication;
+
+public class Storage {
+    private List<DrivingLicenseApplication> data = new ArrayList<DrivingLicenseApplication>();
+
+    public void addApplication(DrivingLicenseApplication application) {
+        data.add(application);
+    }
+
+    public int getCountOfApplications() {
+        return data.size();
+    }
+}

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/addAdditionalStorage.drl
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/addAdditionalStorage.drl
@@ -1,0 +1,12 @@
+package org.kiegroup;
+
+import org.kiegroup.storage.Storage;
+
+rule "Add additional Storage"
+dialect "mvel"
+when
+    eval(storage.getCountOfApplications() > 1000)
+then
+    Storage additionalStorage = new Storage();
+    insert(additionalStorage);
+end

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/addAdditionalStorageBroken.drl
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/addAdditionalStorageBroken.drl
@@ -1,0 +1,13 @@
+package org.kiegroup;
+
+import org.kiegroup.storage.Storage;
+import org.kiegroup.storage.NonExistingCache;
+
+rule "Add additional Storage"
+dialect "mvel"
+when
+    eval(storage.getCountOfApplications() > 1000)
+then
+    Storage additionalStorage = new Storage();
+    insert(additionalStorage);
+end

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/applyForCarDrivingLicenseAndStore.drl
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/applyForCarDrivingLicenseAndStore.drl
@@ -1,0 +1,11 @@
+package org.kiegroup;
+
+rule "Apply for car driving license"
+dialect "mvel"
+when
+    $p : Person(age > 18, dummy == false)
+then
+    DrivingLicenseApplication application = new DrivingLicenseApplication("car", $p);
+    insert(application);
+    storage.addApplication(application);
+end

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/applyForCarDrivingLicenseAndStoreBroken.drl
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/applyForCarDrivingLicenseAndStoreBroken.drl
@@ -1,0 +1,11 @@
+package org.kiegroup;
+
+rule "Apply for car driving license"
+dialect "mvel"
+when
+    $p : Person(age > 18, dummy == false)
+then
+    DrivingLicenseApplication application = new DrivingLicenseApplication("car", $p);
+    insert(application);
+    unknownStorageVariable.addApplication(application);
+end

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/globalStorage.gdrl
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/org/drools/workbench/screens/drltext/backend/server/drl/src/main/resources/org/kiegroup/globalStorage.gdrl
@@ -1,0 +1,3 @@
+package org.kiegroup;
+
+global org.kiegroup.storage.Storage storage;


### PR DESCRIPTION
This PR increases validation coverage of:
- DRL file with global varaible
- DRL file with explicit import

This is **cherry-pick** of #779 