### PR TITLE
[7.5.x] DROOLS-2263: Unexpected results in GDST when using enumerations with commas - info

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/i18n/GuidedDecisionTableErraiConstants.properties
@@ -154,7 +154,7 @@ ValueOptionsPageView.Default=Default value:
 ValueOptionsPageView.ConstraintValue=Constraint value:
 ValueOptionsPageView.ValueOptionsPageDescription=(optional) Enter a list of value options, delimited by a comma and space, to limit table input data for the condition ("WHEN") portion of the rule. \
                                                  When this value list is defined, the values will be provided in the table cells for that column as a drop-down list, from which users can select only one option. \
-                                                 (Example list: <b>Monday</b>, <b>Wednesday</b>, <b>Friday </b>to specify only these three options)
+                                                 (Example 1 list: <b>Monday</b>, <b>Wednesday</b>, <b>Friday </b>to specify only these three options. Example 2 list: <b>"Berlin, Germany"</b>, <b>"Paris, France"</b>)
 WorkItemPageView.Select=Select a Work Item
 WorkItemPageView.WorkItem=Work Item:
 WorkItemPageView.NoWorkItemsAvailable=<None available>


### PR DESCRIPTION

(cherry picked from commit f68c96ca7432a3787f9dadb9387f109bdc8227ea)

https://issues.jboss.org/browse/DROOLS-2263

And the same for 7.5.x