### PR TITLE
DROOLS-2218: Catch NPE in CDI tests cleanup

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImplCDITest.java
@@ -127,7 +127,7 @@ public class DRLTextEditorServiceImplCDITest extends CDITestSetup {
         Assertions.assertThat(validationMessages).hasSize(2);
         Assertions.assertThat(validationMessages)
                 .allMatch(message -> message.getText()
-                .contains("Error importing : 'org.kiegroup.storage.NonExistingCache'"));
+                        .contains("Error importing : 'org.kiegroup.storage.NonExistingCache'"));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
@@ -28,7 +28,9 @@ import org.drools.workbench.screens.dtablexls.service.DecisionTableXLSService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.guvnor.test.CDITestSetup;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
@@ -39,26 +41,33 @@ public class DecisionTableXLSServiceImplCDITest extends CDITestSetup {
 
     private DecisionTableXLSService xlsService;
 
-    private String droolsDateFormat;
+    private static String droolsDateFormat;
+
+    @BeforeClass
+    public static void setUpDateTimeFormat() {
+        droolsDateFormat = System.getProperty(ApplicationPreferences.DATE_FORMAT);
+        System.setProperty(ApplicationPreferences.DATE_FORMAT, "dd-MM-yyyy");
+    }
+
+    @AfterClass
+    public static void clearDateTimeFormat() {
+        if (droolsDateFormat != null) {
+            System.setProperty(ApplicationPreferences.DATE_FORMAT, droolsDateFormat);
+        } else {
+            System.clearProperty(ApplicationPreferences.DATE_FORMAT);
+        }
+    }
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
 
         xlsService = getReference(DecisionTableXLSService.class);
-
-        droolsDateFormat = System.getProperty(ApplicationPreferences.DATE_FORMAT);
-        System.setProperty(ApplicationPreferences.DATE_FORMAT, "dd-MM-yyyy");
     }
 
     @After
     public void tearDown() throws Exception {
         super.cleanup();
-        if (droolsDateFormat != null) {
-            System.setProperty(ApplicationPreferences.DATE_FORMAT, droolsDateFormat);
-        } else {
-            System.clearProperty(ApplicationPreferences.DATE_FORMAT);
-        }
     }
 
     /**

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplCDITest.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.enums.service.EnumService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.guvnor.test.CDITestSetup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.backend.server.util.Paths;
@@ -38,6 +39,11 @@ public class EnumServiceImplCDITest extends CDITestSetup {
         super.setUp();
 
         enumService = getReference(EnumService.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.cleanup();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplCDITest.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.guvnor.test.CDITestSetup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -40,6 +41,11 @@ public class GuidedDecisionTableEditorServiceImplCDITest extends CDITestSetup {
         super.setUp();
 
         testedService = getReference(GuidedDecisionTableEditorService.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.cleanup();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplCDITest.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.guided.rule.service.GuidedRuleEditorService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.guvnor.test.CDITestSetup;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.backend.server.util.Paths;
@@ -40,6 +41,11 @@ public class GuidedRuleEditorServiceImplCDITest extends CDITestSetup {
         super.setUp();
 
         guidedRuleService = getReference(GuidedRuleEditorService.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.cleanup();
     }
 
     @Test


### PR DESCRIPTION
@manstis please could you have a look?

This could "fix" [the problem](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/drools-wb-pullrequests-7.5.x/46/testReport/org.drools.workbench.screens.dtablexls.backend.server/DecisionTableXLSServiceImplCDITest/testValidateColumnsNotInStandardOrder/), however I admit "fix" is not the right word. It is like hiding symptoms. I am sorry but I am not able to reproduce locally so this is the most I was able to do. Any hints?