### PR TITLE
[RHDM-349]: Added drools playground dependency

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -595,7 +595,7 @@
     <!-- KIE Workbench Playground Repository -->
     <dependency>
       <groupId>org.kie.workbench.playground</groupId>
-      <artifactId>playground-parent</artifactId>
+      <artifactId>kie-decision-playground</artifactId>
     </dependency>
 
     <!-- Drools Workbench REST -->


### PR DESCRIPTION
@porcelli could you review?

https://issues.jboss.org/browse/RHDM-349

Related to:
https://github.com/kiegroup/optaplanner-wb/pull/250
https://github.com/kiegroup/drools-wb/pull/799
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/692
https://github.com/kiegroup/kie-wb-distributions/pull/685
https://github.com/kiegroup/kie-wb-playground/pull/46
https://github.com/kiegroup/jbpm-wb/pull/980
https://github.com/kiegroup/kie-wb-common/pull/1411