### PR TITLE
AF-819: Renaming assets discards changes

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-api/src/main/java/org/drools/workbench/screens/drltext/service/DRLTextEditorService.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-api/src/main/java/org/drools/workbench/screens/drltext/service/DRLTextEditorService.java
@@ -19,7 +19,7 @@ package org.drools.workbench.screens.drltext.service;
 import java.util.List;
 
 import org.drools.workbench.screens.drltext.model.DrlModelContent;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface DRLTextEditorService
@@ -35,17 +35,15 @@ public interface DRLTextEditorService
         ValidationService<String>,
         SupportsCreate<String>,
         SupportsRead<String>,
-        SupportsUpdate<String>,
+        SupportsSaveAndRename<String, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    DrlModelContent loadContent( final Path path );
+    DrlModelContent loadContent(final Path path);
 
-    List<String> loadClassFields( final Path path,
-                                  final String fullyQualifiedClassName );
+    List<String> loadClassFields(final Path path,
+                                 final String fullyQualifiedClassName);
 
-    String assertPackageName( final String drl,
-                              final Path resource );
-
+    String assertPackageName(final String drl,
+                             final Path resource);
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/pom.xml
@@ -186,6 +186,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/main/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/main/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImpl.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.drltext.backend.server;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -49,6 +50,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.DataModelOracl
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -92,6 +94,9 @@ public class DRLTextEditorServiceImpl
     private DSLRResourceTypeDefinition dslrResourceType;
 
     @Inject
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
+    @Inject
     private CommentedOptionFactory commentedOptionFactory;
     private SafeSessionInfo safeSessionInfo;
 
@@ -101,6 +106,11 @@ public class DRLTextEditorServiceImpl
     @Inject
     public DRLTextEditorServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -294,5 +304,14 @@ public class DRLTextEditorServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/DRLTextEditorServiceImplTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.options.CommentedOption;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
@@ -61,6 +62,9 @@ public class DRLTextEditorServiceImplTest {
 
     @Mock
     private KieModuleService moduleService;
+
+    @Mock
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
 
     @InjectMocks
     private DRLTextEditorServiceImpl drlService = new DRLTextEditorServiceImpl();
@@ -106,5 +110,27 @@ public class DRLTextEditorServiceImplTest {
                                 eq(ruleContent),
                                 eq(Collections.EMPTY_MAP),
                                 eq(commentedOption));
+    }
+
+    @Test
+    public void testInit() {
+
+        drlService.init();
+
+        verify(saveAndRenameService).init(drlService);
+    }
+
+    @Test
+    public void testSaveAndRename() {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final String content = "content";
+        final String comment = "comment";
+
+        drlService.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/pom.xml
@@ -106,6 +106,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.drltext.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
@@ -29,6 +30,7 @@ import org.drools.workbench.screens.drltext.client.type.DRLResourceType;
 import org.drools.workbench.screens.drltext.client.type.DSLRResourceType;
 import org.drools.workbench.screens.drltext.model.DrlModelContent;
 import org.drools.workbench.screens.drltext.service.DRLTextEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -44,6 +46,7 @@ import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.client.workbench.type.ClientResourceType;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -57,9 +60,9 @@ import org.uberfire.workbench.model.menu.Menus;
  * This is the default rule editor widget (just text editor based).
  */
 @Dependent
-@WorkbenchEditor(identifier = "DRLEditor", supportedTypes = { DRLResourceType.class, DSLRResourceType.class })
+@WorkbenchEditor(identifier = "DRLEditor", supportedTypes = {DRLResourceType.class, DSLRResourceType.class})
 public class DRLEditorPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     @Inject
     private Caller<DRLTextEditorService> drlTextEditorService;
@@ -81,87 +84,95 @@ public class DRLEditorPresenter
     private boolean isDSLR;
 
     @Inject
-    public DRLEditorPresenter( final DRLEditorView view ) {
-        super( view );
+    public DRLEditorPresenter(final DRLEditorView view) {
+        super(view);
         this.view = view;
     }
 
     @PostConstruct
     public void init() {
-        view.init( this );
+        view.init(this);
     }
 
     @OnStartup
-    public void onStartup( final ObservablePath path,
-                           final PlaceRequest place ) {
-        super.init( path,
-                    place,
-                    getResourceType( path ) );
-        this.isDSLR = resourceTypeDSLR.accept( path );
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest place) {
+        super.init(path,
+                   place,
+                   getResourceType(path));
+        this.isDSLR = resourceTypeDSLR.accept(path);
     }
 
     protected void loadContent() {
         view.showLoading();
-        drlTextEditorService.call( getLoadContentSuccessCallback(),
-                                   getNoSuchFileExceptionErrorCallback() ).loadContent( versionRecordManager.getCurrentPath() );
+        drlTextEditorService.call(getLoadContentSuccessCallback(),
+                                  getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<String> getContentSupplier() {
+        return () -> view.getContent();
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<String, Metadata>> getSaveAndRenameServiceCaller() {
+        return drlTextEditorService;
     }
 
     private RemoteCallback<DrlModelContent> getLoadContentSuccessCallback() {
         return new RemoteCallback<DrlModelContent>() {
 
             @Override
-            public void callback( final DrlModelContent content ) {
+            public void callback(final DrlModelContent content) {
                 //Path is set to null when the Editor is closed (which can happen before async calls complete).
-                if ( versionRecordManager.getCurrentPath() == null ) {
+                if (versionRecordManager.getCurrentPath() == null) {
                     return;
                 }
 
-                resetEditorPages( content.getOverview() );
+                resetEditorPages(content.getOverview());
 
-                final String drl = assertContent( content.getDrl() );
+                final String drl = assertContent(content.getDrl());
                 final List<String> fullyQualifiedClassNames = content.getFullyQualifiedClassNames();
                 final List<DSLSentence> dslConditions = content.getDslConditions();
                 final List<DSLSentence> dslActions = content.getDslActions();
 
                 //Populate view
-                if ( isDSLR ) {
-                    view.setContent( drl,
-                                     fullyQualifiedClassNames,
-                                     dslConditions,
-                                     dslActions );
+                if (isDSLR) {
+                    view.setContent(drl,
+                                    fullyQualifiedClassNames,
+                                    dslConditions,
+                                    dslActions);
                 } else {
-                    view.setContent( drl,
-                                     fullyQualifiedClassNames );
+                    view.setContent(drl,
+                                    fullyQualifiedClassNames);
                 }
-                view.setReadOnly( isReadOnly );
+                view.setReadOnly(isReadOnly);
                 view.hideBusyIndicator();
-                createOriginalHash( view.getContent() );
+                createOriginalHash(view.getContent());
             }
 
-            private String assertContent( final String drl ) {
-                if ( drl == null || drl.isEmpty() ) {
+            private String assertContent(final String drl) {
+                if (drl == null || drl.isEmpty()) {
                     return "";
                 }
                 return drl;
             }
-
         };
     }
 
-    public void loadClassFields( final String fullyQualifiedClassName,
-                                 final Callback<List<String>> callback ) {
-        drlTextEditorService.call( getLoadClassFieldsSuccessCallback( callback ),
-                                   new HasBusyIndicatorDefaultErrorCallback( view ) ).loadClassFields( versionRecordManager.getCurrentPath(),
-                                                                                                       fullyQualifiedClassName );
-
+    public void loadClassFields(final String fullyQualifiedClassName,
+                                final Callback<List<String>> callback) {
+        drlTextEditorService.call(getLoadClassFieldsSuccessCallback(callback),
+                                  new HasBusyIndicatorDefaultErrorCallback(view)).loadClassFields(versionRecordManager.getCurrentPath(),
+                                                                                                  fullyQualifiedClassName);
     }
 
-    private RemoteCallback<List<String>> getLoadClassFieldsSuccessCallback( final Callback<List<String>> callback ) {
+    private RemoteCallback<List<String>> getLoadClassFieldsSuccessCallback(final Callback<List<String>> callback) {
         return new RemoteCallback<List<String>>() {
 
             @Override
-            public void callback( final List<String> fields ) {
-                callback.callback( fields );
+            public void callback(final List<String> fields) {
+                callback.callback(fields);
             }
         };
     }
@@ -170,29 +181,29 @@ public class DRLEditorPresenter
         return new Command() {
             @Override
             public void execute() {
-                drlTextEditorService.call( new RemoteCallback<List<ValidationMessage>>() {
+                drlTextEditorService.call(new RemoteCallback<List<ValidationMessage>>() {
                     @Override
-                    public void callback( final List<ValidationMessage> results ) {
-                        if ( results == null || results.isEmpty() ) {
-                            notification.fire( new NotificationEvent( CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
-                                                                      NotificationEvent.NotificationType.SUCCESS ) );
+                    public void callback(final List<ValidationMessage> results) {
+                        if (results == null || results.isEmpty()) {
+                            notification.fire(new NotificationEvent(CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
+                                                                    NotificationEvent.NotificationType.SUCCESS));
                         } else {
-                            validationPopup.showMessages( results );
+                            validationPopup.showMessages(results);
                         }
                     }
-                } ).validate( versionRecordManager.getCurrentPath(),
-                              view.getContent() );
+                }).validate(versionRecordManager.getCurrentPath(),
+                            view.getContent());
             }
         };
     }
 
     @Override
-    protected void save( String commitMessage ) {
-        drlTextEditorService.call( getSaveSuccessCallback( view.getContent().hashCode() ),
-                                   new HasBusyIndicatorDefaultErrorCallback( view ) ).save( versionRecordManager.getCurrentPath(),
-                                                                                            view.getContent(),
-                                                                                            metadata,
-                                                                                            commitMessage );
+    protected void save(String commitMessage) {
+        drlTextEditorService.call(getSaveSuccessCallback(view.getContent().hashCode()),
+                                  new HasBusyIndicatorDefaultErrorCallback(view)).save(versionRecordManager.getCurrentPath(),
+                                                                                       view.getContent(),
+                                                                                       metadata,
+                                                                                       commitMessage);
     }
 
     @OnClose
@@ -202,7 +213,7 @@ public class DRLEditorPresenter
 
     @OnMayClose
     public boolean mayClose() {
-        return super.mayClose( view.getContent() );
+        return super.mayClose(view.getContent());
     }
 
     @WorkbenchPartTitleDecoration
@@ -215,8 +226,8 @@ public class DRLEditorPresenter
         return super.getTitleText();
     }
 
-    private ClientResourceType getResourceType( Path path ) {
-        if ( resourceTypeDRL.accept( path ) ) {
+    private ClientResourceType getResourceType(Path path) {
+        if (resourceTypeDRL.accept(path)) {
             return resourceTypeDRL;
         } else {
             return resourceTypeDSLR;
@@ -232,5 +243,4 @@ public class DRLEditorPresenter
     public Menus getMenus() {
         return menus;
     }
-
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/test/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/test/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorPresenterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.drltext.client.editor;
+
+import java.util.function.Supplier;
+
+import org.drools.workbench.screens.drltext.service.DRLTextEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DRLEditorPresenterTest {
+
+    @Mock
+    private DRLEditorView view;
+
+    @Mock
+    private Caller<DRLTextEditorService> drlTextEditorService;
+
+    @InjectMocks
+    private DRLEditorPresenter drlEditor = new DRLEditorPresenter(view);
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final String content = "";
+
+        doReturn(content).when(view).getContent();
+
+        final Supplier<String> contentSupplier = drlEditor.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<String, Metadata>> serviceCaller = drlEditor.getSaveAndRenameServiceCaller();
+
+        assertEquals(drlTextEditorService, serviceCaller);
+    }
+}

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-api/src/main/java/org/drools/workbench/screens/dsltext/service/DSLTextEditorService.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-api/src/main/java/org/drools/workbench/screens/dsltext/service/DSLTextEditorService.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.dsltext.service;
 
 import org.drools.workbench.screens.dsltext.model.DSLTextEditorContent;
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
@@ -26,7 +26,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface DSLTextEditorService
@@ -35,11 +35,9 @@ public interface DSLTextEditorService
         ValidationService<String>,
         SupportsCreate<String>,
         SupportsRead<String>,
-        SupportsUpdate<String>,
+        SupportsSaveAndRename<String, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    DSLTextEditorContent loadContent( final Path path );
-
+    DSLTextEditorContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/DSLTextEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/DSLTextEditorServiceImpl.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -43,6 +44,7 @@ import org.jboss.errai.bus.server.annotations.Service;
 import org.kie.workbench.common.services.backend.service.KieService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -82,9 +84,17 @@ public class DSLTextEditorServiceImpl
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
 
+    @Inject
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public DSLTextEditorServiceImpl() {
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Inject
@@ -296,5 +306,14 @@ public class DSLTextEditorServiceImpl
         msg.setLevel( Level.ERROR );
         msg.setText( "Uncategorized error " + o );
         return msg;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/DSLTextEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/DSLTextEditorServiceImplTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.dsltext.backend.server;
+
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DSLTextEditorServiceImplTest {
+
+    @Mock
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
+    @InjectMocks
+    private DSLTextEditorServiceImpl service = new DSLTextEditorServiceImpl();
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final String content = "content";
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+    }
+}

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/pom.xml
@@ -95,6 +95,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/main/java/org/drools/workbench/screens/dsltext/client/editor/DSLEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/main/java/org/drools/workbench/screens/dsltext/client/editor/DSLEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.dsltext.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -26,6 +27,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.dsltext.client.type.DSLResourceType;
 import org.drools.workbench.screens.dsltext.model.DSLTextEditorContent;
 import org.drools.workbench.screens.dsltext.service.DSLTextEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -38,6 +40,7 @@ import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -53,7 +56,7 @@ import org.uberfire.workbench.model.menu.Menus;
 @Dependent
 @WorkbenchEditor(identifier = "DSLEditor", supportedTypes = { DSLResourceType.class })
 public class DSLEditorPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     @Inject
     private Caller<DSLTextEditorService> dslTextEditorService;
@@ -87,6 +90,16 @@ public class DSLEditorPresenter
         view.showLoading();
         dslTextEditorService.call( getModelSuccessCallback(),
                                    getNoSuchFileExceptionErrorCallback() ).loadContent( versionRecordManager.getCurrentPath() );
+    }
+
+    @Override
+    protected Supplier<String> getContentSupplier() {
+        return () -> view.getContent();
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<String, Metadata>> getSaveAndRenameServiceCaller() {
+        return dslTextEditorService;
     }
 
     private RemoteCallback<DSLTextEditorContent> getModelSuccessCallback() {

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/test/java/org/drools/workbench/screens/dsltext/client/editor/DSLEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/test/java/org/drools/workbench/screens/dsltext/client/editor/DSLEditorPresenterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.dsltext.client.editor;
+
+import java.util.function.Supplier;
+
+import org.drools.workbench.screens.dsltext.service.DSLTextEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DSLEditorPresenterTest {
+
+    @Mock
+    private DSLEditorView view;
+
+    @Mock
+    private Caller<DSLTextEditorService> dslTextEditorService;
+
+    @InjectMocks
+    private DSLEditorPresenter dslEditor = new DSLEditorPresenter(view);
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final String content = "";
+
+        doReturn(content).when(view).getContent();
+
+        final Supplier<String> contentSupplier = dslEditor.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<String, Metadata>> serviceCaller = dslEditor.getSaveAndRenameServiceCaller();
+
+        assertEquals(dslTextEditorService, serviceCaller);
+    }
+}

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/main/java/org/drools/workbench/screens/dtablexls/client/editor/DecisionTableXLSEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/main/java/org/drools/workbench/screens/dtablexls/client/editor/DecisionTableXLSEditorPresenter.java
@@ -65,7 +65,7 @@ import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopu
 @Dependent
 @WorkbenchEditor(identifier = "DecisionTableXLSEditor", supportedTypes = {DecisionTableXLSResourceType.class, DecisionTableXLSXResourceType.class})
 public class DecisionTableXLSEditorPresenter
-        extends KieEditor
+        extends KieEditor<DecisionTableXLSContent>
         implements DecisionTableXLSEditorView.Presenter {
 
     private Caller<DecisionTableXLSService> decisionTableXLSService;

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/test/java/org/drools/workbench/screens/dtablexls/client/editor/DecisionTableXLSEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/test/java/org/drools/workbench/screens/dtablexls/client/editor/DecisionTableXLSEditorPresenterTest.java
@@ -33,6 +33,7 @@ import org.drools.workbench.screens.dtablexls.service.DecisionTableXLSService;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
@@ -302,7 +303,9 @@ public class DecisionTableXLSEditorPresenterTest {
             @Override
             public DecisionTableXLSContent loadContent(Path path) {
                 DecisionTableXLSContent content = new DecisionTableXLSContent();
-                content.setOverview(new Overview());
+                content.setOverview(new Overview() {{
+                    setMetadata(mock(Metadata.class));
+                }});
                 remoteCallback.callback(content);
                 return null;
             }

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-api/src/main/java/org/drools/workbench/screens/enums/service/EnumService.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-api/src/main/java/org/drools/workbench/screens/enums/service/EnumService.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.enums.service;
 import org.drools.workbench.screens.enums.model.EnumModelContent;
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
@@ -26,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface EnumService
@@ -35,11 +36,9 @@ public interface EnumService
         ValidationService<String>,
         SupportsCreate<String>,
         SupportsRead<String>,
-        SupportsUpdate<String>,
+        SupportsSaveAndRename<String, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    EnumModelContent loadContent( final Path path );
-
+    EnumModelContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/main/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImpl.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/main/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -46,6 +47,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.builder.util.D
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -94,6 +96,9 @@ public class EnumServiceImpl
     @Inject
     private MVELEvaluator evaluator;
 
+    @Inject
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public EnumServiceImpl() {
@@ -102,6 +107,11 @@ public class EnumServiceImpl
     @Inject
     public EnumServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -287,5 +297,14 @@ public class EnumServiceImpl
         msg.setLevel(Level.ERROR);
         msg.setText(message);
         return msg;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 
 import javax.enterprise.event.Event;
 
-import org.drools.workbench.screens.enums.service.EnumService;
 import org.guvnor.common.services.backend.metadata.MetadataServerSideService;
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.project.builder.events.InvalidateDMOPackageCacheEvent;
@@ -33,6 +32,7 @@ import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.options.CommentedOption;
 
@@ -60,9 +60,12 @@ public class EnumServiceImplTest {
     @Mock
     private Event<InvalidateDMOPackageCacheEvent> invalidateDMOPackageCache;
 
+    @Mock
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
     @Spy
     @InjectMocks
-    private EnumService enumService = new EnumServiceImpl();
+    private EnumServiceImpl enumService = new EnumServiceImpl();
 
     @Test
     public void testCreate() throws Exception {
@@ -98,5 +101,26 @@ public class EnumServiceImplTest {
                                 eq(fileContent),
                                 eq(Collections.EMPTY_MAP),
                                 eq(commentedOption));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        enumService.init();
+
+        verify(saveAndRenameService).init(enumService);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final String content = "content";
+        final String comment = "comment";
+
+        enumService.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/pom.xml
@@ -99,6 +99,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/src/main/java/org/drools/workbench/screens/enums/client/editor/EnumEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/src/main/java/org/drools/workbench/screens/enums/client/editor/EnumEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.enums.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -25,6 +26,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.enums.client.type.EnumResourceType;
 import org.drools.workbench.screens.enums.model.EnumModelContent;
 import org.drools.workbench.screens.enums.service.EnumService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -37,6 +39,7 @@ import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -50,9 +53,9 @@ import org.uberfire.workbench.model.menu.Menus;
  * Enum Editor Presenter
  */
 @Dependent
-@WorkbenchEditor(identifier = "EnumEditor", supportedTypes = { EnumResourceType.class })
+@WorkbenchEditor(identifier = "EnumEditor", supportedTypes = {EnumResourceType.class})
 public class EnumEditorPresenter
-        extends KieEditor {
+        extends KieEditor<String> {
 
     private EnumEditorView view;
 
@@ -67,11 +70,11 @@ public class EnumEditorPresenter
     }
 
     @Inject
-    public EnumEditorPresenter( final EnumEditorView baseView,
-                                final Caller<EnumService> enumService,
-                                final EnumResourceType type,
-                                final ValidationPopup validationPopup ) {
-        super( baseView );
+    public EnumEditorPresenter(final EnumEditorView baseView,
+                               final Caller<EnumService> enumService,
+                               final EnumResourceType type,
+                               final ValidationPopup validationPopup) {
+        super(baseView);
         this.view = baseView;
         this.enumService = enumService;
         this.type = type;
@@ -79,37 +82,47 @@ public class EnumEditorPresenter
     }
 
     @OnStartup
-    public void onStartup( final ObservablePath path,
-                           final PlaceRequest place ) {
-        super.init( path,
-                    place,
-                    type );
+    public void onStartup(final ObservablePath path,
+                          final PlaceRequest place) {
+        super.init(path,
+                   place,
+                   type);
     }
 
     protected void loadContent() {
         view.showLoading();
-        enumService.call( getModelSuccessCallback(),
-                          getNoSuchFileExceptionErrorCallback() ).loadContent( versionRecordManager.getCurrentPath() );
+        enumService.call(getModelSuccessCallback(),
+                         getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<String> getContentSupplier() {
+        return () -> EnumParser.toString(view.getContent());
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<String, Metadata>> getSaveAndRenameServiceCaller() {
+        return enumService;
     }
 
     private RemoteCallback<EnumModelContent> getModelSuccessCallback() {
         return new RemoteCallback<EnumModelContent>() {
 
             @Override
-            public void callback( final EnumModelContent content ) {
+            public void callback(final EnumModelContent content) {
                 //Path is set to null when the Editor is closed (which can happen before async calls complete).
-                if ( versionRecordManager.getCurrentPath() == null ) {
+                if (versionRecordManager.getCurrentPath() == null) {
                     return;
                 }
 
-                resetEditorPages( content.getOverview() );
+                resetEditorPages(content.getOverview());
                 addSourcePage();
 
-                final List<EnumRow> enumDefinitions = EnumParser.fromString( content.getModel().getEnumDefinitions() );
-                view.setContent( enumDefinitions );
+                final List<EnumRow> enumDefinitions = EnumParser.fromString(content.getModel().getEnumDefinitions());
+                view.setContent(enumDefinitions);
                 view.hideBusyIndicator();
 
-                createOriginalHash( enumDefinitions );
+                createOriginalHash(EnumParser.toString(enumDefinitions));
             }
         };
     }
@@ -118,35 +131,35 @@ public class EnumEditorPresenter
         return new Command() {
             @Override
             public void execute() {
-                enumService.call( new RemoteCallback<List<ValidationMessage>>() {
+                enumService.call(new RemoteCallback<List<ValidationMessage>>() {
                     @Override
-                    public void callback( final List<ValidationMessage> results ) {
-                        if ( results == null || results.isEmpty() ) {
-                            notification.fire( new NotificationEvent( CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
-                                                                      NotificationEvent.NotificationType.SUCCESS ) );
+                    public void callback(final List<ValidationMessage> results) {
+                        if (results == null || results.isEmpty()) {
+                            notification.fire(new NotificationEvent(CommonConstants.INSTANCE.ItemValidatedSuccessfully(),
+                                                                    NotificationEvent.NotificationType.SUCCESS));
                         } else {
-                            validationPopup.showMessages( results );
+                            validationPopup.showMessages(results);
                         }
                     }
-                } ).validate( versionRecordManager.getCurrentPath(),
-                              EnumParser.toString( view.getContent() ) );
+                }).validate(versionRecordManager.getCurrentPath(),
+                            EnumParser.toString(view.getContent()));
             }
         };
     }
 
     @Override
-    protected void save( final String commitMessage ) {
+    protected void save(final String commitMessage) {
         final List<EnumRow> content = view.getContent();
-        enumService.call( getSaveSuccessCallback( content.hashCode() ),
-                          new HasBusyIndicatorDefaultErrorCallback( view ) ).save( versionRecordManager.getCurrentPath(),
-                                                                                   EnumParser.toString( content ),
-                                                                                   metadata,
-                                                                                   commitMessage );
+        enumService.call(getSaveSuccessCallback(content.hashCode()),
+                         new HasBusyIndicatorDefaultErrorCallback(view)).save(versionRecordManager.getCurrentPath(),
+                                                                              EnumParser.toString(content),
+                                                                              metadata,
+                                                                              commitMessage);
     }
 
     @Override
     public void onSourceTabSelected() {
-        updateSource( EnumParser.toString( view.getContent() ) );
+        updateSource(EnumParser.toString(view.getContent()));
     }
 
     @OnClose
@@ -156,7 +169,7 @@ public class EnumEditorPresenter
 
     @OnMayClose
     public boolean mayClose() {
-        return super.mayClose( view.getContent() );
+        return super.mayClose(view.getContent());
     }
 
     @WorkbenchPartTitle
@@ -178,5 +191,4 @@ public class EnumEditorPresenter
     public Menus getMenus() {
         return menus;
     }
-
 }

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-api/src/main/java/org/drools/workbench/screens/globals/service/GlobalsEditorService.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-api/src/main/java/org/drools/workbench/screens/globals/service/GlobalsEditorService.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.globals.service;
 
 import org.drools.workbench.screens.globals.model.GlobalsEditorContent;
 import org.drools.workbench.screens.globals.model.GlobalsModel;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.shared.source.ViewSourceService;
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 /**
  * Service definition for Globals editor
@@ -39,16 +39,14 @@ public interface GlobalsEditorService
         ValidationService<GlobalsModel>,
         SupportsCreate<GlobalsModel>,
         SupportsRead<GlobalsModel>,
-        SupportsUpdate<GlobalsModel>,
+        SupportsSaveAndRename<GlobalsModel, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    GlobalsEditorContent loadContent( final Path path );
+    GlobalsEditorContent loadContent(final Path path);
 
-    Path generate( final Path context,
-                   final String fileName,
-                   final GlobalsModel content,
-                   final String comment );
-
+    Path generate(final Path context,
+                  final String fileName,
+                  final GlobalsModel content,
+                  final String comment);
 }

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/main/java/org/drools/workbench/screens/globals/backend/server/GlobalsEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/main/java/org/drools/workbench/screens/globals/backend/server/GlobalsEditorServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -44,6 +45,7 @@ import org.kie.workbench.common.services.backend.service.KieService;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -81,6 +83,9 @@ public class GlobalsEditorServiceImpl
     @Inject
     private GenericValidator genericValidator;
 
+    @Inject
+    private SaveAndRenameServiceImpl<GlobalsModel, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public GlobalsEditorServiceImpl() {
@@ -89,6 +94,11 @@ public class GlobalsEditorServiceImpl
     @Inject
     public GlobalsEditorServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -280,5 +290,14 @@ public class GlobalsEditorServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final GlobalsModel content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/GlobalsEditorServiceTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/GlobalsEditorServiceTest.java
@@ -25,15 +25,16 @@ import org.guvnor.common.services.backend.metadata.MetadataServerSideService;
 import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.options.CommentedOption;
 
@@ -63,19 +64,18 @@ public class GlobalsEditorServiceTest {
     @Mock
     private MetadataServerSideService metadataService;
 
-    private GlobalsEditorService globalsEditorService;
+    @Mock
+    private SaveAndRenameServiceImpl<GlobalsModel, Metadata> saveAndRenameService;
 
-    @Before
-    public void setUp() {
-        globalsEditorService = new GlobalsEditorServiceImpl() {
-            {
-                moduleService = GlobalsEditorServiceTest.this.kieModuleService;
-                ioService = GlobalsEditorServiceTest.this.ioService;
-                commentedOptionFactory = GlobalsEditorServiceTest.this.commentedOptionFactory;
-                metadataService = GlobalsEditorServiceTest.this.metadataService;
-            }
-        };
-    }
+    @InjectMocks
+    private GlobalsEditorService globalsEditorService = new GlobalsEditorServiceImpl() {
+        {
+            moduleService = GlobalsEditorServiceTest.this.kieModuleService;
+            ioService = GlobalsEditorServiceTest.this.ioService;
+            commentedOptionFactory = GlobalsEditorServiceTest.this.commentedOptionFactory;
+            metadataService = GlobalsEditorServiceTest.this.metadataService;
+        }
+    };
 
     @Test
     public void save() {
@@ -134,5 +134,30 @@ public class GlobalsEditorServiceTest {
         Object generatedAttribute = capturedMap.get(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME);
         assertNotNull(generatedAttribute);
         assertTrue(Boolean.parseBoolean(generatedAttribute.toString()));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+
+        final GlobalsEditorServiceImpl service = (GlobalsEditorServiceImpl) globalsEditorService;
+
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final GlobalsEditorServiceImpl service = (GlobalsEditorServiceImpl) globalsEditorService;
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final GlobalsModel content = mock(GlobalsModel.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/pom.xml
@@ -125,6 +125,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/main/java/org/drools/workbench/screens/globals/client/editor/GlobalsEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/main/java/org/drools/workbench/screens/globals/client/editor/GlobalsEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.globals.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -26,6 +27,7 @@ import org.drools.workbench.screens.globals.client.type.GlobalResourceType;
 import org.drools.workbench.screens.globals.model.GlobalsEditorContent;
 import org.drools.workbench.screens.globals.model.GlobalsModel;
 import org.drools.workbench.screens.globals.service.GlobalsEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -40,6 +42,7 @@ import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -52,7 +55,7 @@ import org.uberfire.workbench.model.menu.Menus;
 
 @WorkbenchEditor(identifier = "org.kie.guvnor.globals", supportedTypes = {GlobalResourceType.class}, priority = 101)
 public class GlobalsEditorPresenter
-        extends KieEditor {
+        extends KieEditor<GlobalsModel> {
 
     @Inject
     protected Caller<GlobalsEditorService> globalsEditorService;
@@ -97,8 +100,7 @@ public class GlobalsEditorPresenter
                     .addSave(versionRecordManager.newSaveMenuItem(this::saveAction))
                     .addCopy(versionRecordManager.getCurrentPath(),
                              assetUpdateValidator)
-                    .addRename(versionRecordManager.getPathToLatest(),
-                               assetUpdateValidator)
+                    .addRename(getSaveAndRename())
                     .addDelete(this::onDelete);
         }
 
@@ -111,6 +113,16 @@ public class GlobalsEditorPresenter
         view.showLoading();
         globalsEditorService.call(getModelSuccessCallback(),
                                   getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<GlobalsModel> getContentSupplier() {
+        return () -> model;
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<GlobalsModel, Metadata>> getSaveAndRenameServiceCaller() {
+        return globalsEditorService;
     }
 
     protected RemoteCallback<GlobalsEditorContent> getModelSuccessCallback() {

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/test/java/org/drools/workbench/screens/globals/client/editor/GlobalsEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/test/java/org/drools/workbench/screens/globals/client/editor/GlobalsEditorPresenterTest.java
@@ -131,6 +131,11 @@ public class GlobalsEditorPresenterTest {
                 versionRecordManager = GlobalsEditorPresenterTest.this.versionRecordManager;
                 assetUpdateValidator = GlobalsEditorPresenterTest.this.assetUpdateValidator;
             }
+
+            @Override
+            protected Command getSaveAndRename() {
+                return mock(Command.class);
+            }
         };
     }
 
@@ -231,8 +236,7 @@ public class GlobalsEditorPresenterTest {
         verify(fileMenuBuilder).addSave(any(MenuItem.class));
         verify(fileMenuBuilder).addCopy(any(Path.class),
                                         any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder).addRename(any(Path.class),
-                                          any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder).addRename(any(Command.class));
         verify(fileMenuBuilder).addDelete(any(Command.class));
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/model/GuidedDecisionTableEditorContent.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/model/GuidedDecisionTableEditorContent.java
@@ -24,6 +24,7 @@ import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.uberfire.backend.vfs.ObservablePath;
 
 @Portable
 public class GuidedDecisionTableEditorContent {
@@ -32,8 +33,20 @@ public class GuidedDecisionTableEditorContent {
     private Set<PortableWorkDefinition> workItemDefinitions;
     private PackageDataModelOracleBaselinePayload dataModel;
     private Overview overview;
+    private ObservablePath currentPath;
+    private ObservablePath latestPath;
 
     public GuidedDecisionTableEditorContent() {
+    }
+
+    public GuidedDecisionTableEditorContent(final GuidedDecisionTable52 model,
+                                            final Overview overview,
+                                            final ObservablePath currentPath,
+                                            final ObservablePath latestPath) {
+        this.model = PortablePreconditions.checkNotNull("model", model);
+        this.overview = PortablePreconditions.checkNotNull("overview", overview);
+        this.currentPath = PortablePreconditions.checkNotNull("currentPath", currentPath);
+        this.latestPath = PortablePreconditions.checkNotNull("latestPath", latestPath);
     }
 
     public GuidedDecisionTableEditorContent(final GuidedDecisionTable52 model,
@@ -68,5 +81,13 @@ public class GuidedDecisionTableEditorContent {
 
     public void setOverview(Overview overview) {
         this.overview = overview;
+    }
+
+    public ObservablePath getCurrentPath() {
+        return currentPath;
+    }
+
+    public ObservablePath getLatestPath() {
+        return latestPath;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableEditorService.java
@@ -30,6 +30,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface GuidedDecisionTableEditorService
@@ -38,20 +39,18 @@ public interface GuidedDecisionTableEditorService
         ValidationService<GuidedDecisionTable52>,
         SupportsCreate<GuidedDecisionTable52>,
         SupportsRead<GuidedDecisionTable52>,
-        SupportsUpdate<GuidedDecisionTable52>,
+        SupportsSaveAndRename<GuidedDecisionTable52, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
     String DTABLE_VERIFICATION_DISABLED = "org.kie.verification.disable-dtable-realtime-verification";
 
-    GuidedDecisionTableEditorContent loadContent( final Path path );
+    GuidedDecisionTableEditorContent loadContent(final Path path);
 
-    PackageDataModelOracleBaselinePayload loadDataModel( final Path path );
+    PackageDataModelOracleBaselinePayload loadDataModel(final Path path);
 
-    Path saveAndUpdateGraphEntries( final Path resource,
-                                    final GuidedDecisionTable52 model,
-                                    final Metadata metadata,
-                                    final String comment );
-
+    Path saveAndUpdateGraphEntries(final Path resource,
+                                   final GuidedDecisionTable52 model,
+                                   final Metadata metadata,
+                                   final String comment);
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableGraphEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableGraphEditorService.java
@@ -39,8 +39,7 @@ public interface GuidedDecisionTableGraphEditorService
         SupportsCopy,
         SupportsRename {
 
-    GuidedDecisionTableEditorGraphContent loadContent( final Path path );
+    GuidedDecisionTableEditorGraphContent loadContent(final Path path);
 
-    List<Path> listDecisionTablesInPackage( final Path path );
-
+    List<Path> listDecisionTablesInPackage(final Path path);
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableGraphSaveAndRenameService.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableGraphSaveAndRenameService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.service;
+
+import java.util.List;
+
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+@Remote
+public interface GuidedDecisionTableGraphSaveAndRenameService
+        extends
+        SupportsSaveAndRename<List<GuidedDecisionTableEditorContent>, Metadata> {
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -54,6 +55,7 @@ import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.backend.version.VersionRecordService;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
@@ -85,6 +87,7 @@ public class GuidedDecisionTableEditorServiceImpl
     private GenericValidator genericValidator;
     private CommentedOptionFactory commentedOptionFactory;
     private SafeSessionInfo safeSessionInfo;
+    private SaveAndRenameServiceImpl<GuidedDecisionTable52, Metadata> saveAndRenameService;
 
     public GuidedDecisionTableEditorServiceImpl() {
         //Zero parameter constructor for CDI
@@ -104,6 +107,7 @@ public class GuidedDecisionTableEditorServiceImpl
                                                 final Event<ResourceOpenedEvent> resourceOpenedEvent,
                                                 final GenericValidator genericValidator,
                                                 final CommentedOptionFactory commentedOptionFactory,
+                                                final SaveAndRenameServiceImpl<GuidedDecisionTable52, Metadata> saveAndRenameService,
                                                 final SessionInfo sessionInfo) {
         this.ioService = ioService;
         this.copyService = copyService;
@@ -118,7 +122,13 @@ public class GuidedDecisionTableEditorServiceImpl
         this.resourceOpenedEvent = resourceOpenedEvent;
         this.genericValidator = genericValidator;
         this.commentedOptionFactory = commentedOptionFactory;
+        this.saveAndRenameService = saveAndRenameService;
         this.safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -371,5 +381,14 @@ public class GuidedDecisionTableEditorServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final GuidedDecisionTable52 content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableGraphSaveAndRenameServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableGraphSaveAndRenameServiceImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.backend.server;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
+import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableGraphSaveAndRenameService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+
+public class GuidedDecisionTableGraphSaveAndRenameServiceImpl implements GuidedDecisionTableGraphSaveAndRenameService {
+
+    private GuidedDecisionTableEditorService editorService;
+
+    private SaveAndRenameServiceImpl<List<GuidedDecisionTableEditorContent>, Metadata> saveAndRenameService;
+
+    @Inject
+    public GuidedDecisionTableGraphSaveAndRenameServiceImpl(final GuidedDecisionTableEditorService editorService,
+                                                            final SaveAndRenameServiceImpl<List<GuidedDecisionTableEditorContent>, Metadata> saveAndRenameService) {
+        this.editorService = editorService;
+        this.saveAndRenameService = saveAndRenameService;
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final List<GuidedDecisionTableEditorContent> content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newName,
+                       final String comment) {
+        return editorService.rename(path, newName, comment);
+    }
+
+    @Override
+    public Path save(final Path path,
+                     final List<GuidedDecisionTableEditorContent> content,
+                     final Metadata metadata,
+                     final String comment) {
+
+        content.forEach(c -> {
+            editorService.save(c.getCurrentPath(), c.getModel(), c.getOverview().getMetadata(), comment);
+        });
+
+        return path;
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplTest.java
@@ -53,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.backend.version.VersionRecordService;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
@@ -127,6 +128,9 @@ public class GuidedDecisionTableEditorServiceImplTest {
     private SessionInfo sessionInfo;
 
     @Mock
+    private SaveAndRenameServiceImpl<GuidedDecisionTable52, Metadata> saveAndRenameService;
+
+    @Mock
     private org.guvnor.common.services.project.model.Package pkg;
 
     @Mock
@@ -139,7 +143,9 @@ public class GuidedDecisionTableEditorServiceImplTest {
     private BasicFileAttributes basicFileAttributes;
 
     private GuidedDTableResourceTypeDefinition dtType = new GuidedDTableResourceTypeDefinition();
+
     private GuidedDTableGraphResourceTypeDefinition dtGraphType = new GuidedDTableGraphResourceTypeDefinition();
+
     private GuidedDecisionTableEditorServiceImpl service;
 
     @Before
@@ -158,6 +164,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
                                                            resourceOpenedEvent,
                                                            genericValidator,
                                                            commentedOptionFactory,
+                                                           saveAndRenameService,
                                                            sessionInfo) {
             {
                 this.sourceServices = mockSourceServices;
@@ -425,6 +432,27 @@ public class GuidedDecisionTableEditorServiceImplTest {
         verify(mockSourceService,
                times(1)).getSource(any(org.uberfire.java.nio.file.Path.class),
                                    eq(model));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final GuidedDecisionTable52 content = mock(GuidedDecisionTable52.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -36,12 +36,15 @@ import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Imports;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.UpdatedLockStatusEvent;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
 import org.uberfire.client.workbench.widgets.multipage.Page;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.Menus;
@@ -69,6 +72,9 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
     private GuidedDTableResourceType resourceType = new GuidedDTableResourceType();
 
+    @Mock
+    private SaveAndRenameCommandBuilder<GuidedDecisionTable52, Metadata> saveAndRenameCommandBuilder;
+
     @Override
     protected GuidedDecisionTableEditorPresenter getPresenter() {
         return new GuidedDecisionTableEditorPresenter(view,
@@ -84,7 +90,13 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                                                       modeller,
                                                       beanManager,
                                                       placeManager,
-                                                      columnsPage);
+                                                      columnsPage,
+                                                      saveAndRenameCommandBuilder) {
+            @Override
+            protected Command getSaveAndRenameCommand() {
+                return mock(Command.class);
+            }
+        };
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
@@ -34,6 +34,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.project.client.security.ProjectController;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
@@ -18,10 +18,12 @@ package org.drools.workbench.screens.guided.dtable.client.editor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipboard;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.EditMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
@@ -34,8 +36,10 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.pages.common.DecisionTablePopoverUtils;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -65,6 +69,7 @@ import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilderImpl;
 import org.uberfire.ext.editor.commons.client.menu.RestoreVersionCommandProvider;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.client.validation.DefaultFileNameValidator;
 import org.uberfire.ext.editor.commons.version.VersionService;
 import org.uberfire.ext.editor.commons.version.events.RestoreEvent;
@@ -234,6 +239,9 @@ public class GuidedDecisionTableEditorMenusTest {
     protected ColumnsPage columnsPage;
 
     @Mock
+    protected SaveAndRenameCommandBuilder<GuidedDecisionTable52, Metadata> saveAndRenameCommandBuilder;
+
+    @Mock
     protected MenuItemWithIconView menuItemWithIconView;
 
     @Mock
@@ -326,7 +334,13 @@ public class GuidedDecisionTableEditorMenusTest {
                                                                                                   modeller,
                                                                                                   beanManager,
                                                                                                   placeManager,
-                                                                                                  columnsPage);
+                                                                                                  columnsPage,
+                                                                                                  saveAndRenameCommandBuilder) {
+            @Override
+            protected Command getSaveAndRenameCommand() {
+                return mock(Command.class);
+            }
+        };
 
         wrapped.setKieEditorWrapperView(kieEditorWrapperView);
         wrapped.setOverviewWidget(overviewWidget);

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-api/src/main/java/org/drools/workbench/screens/guided/dtree/service/GuidedDecisionTreeEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-api/src/main/java/org/drools/workbench/screens/guided/dtree/service/GuidedDecisionTreeEditorService.java
@@ -17,7 +17,7 @@ package org.drools.workbench.screens.guided.dtree.service;
 
 import org.drools.workbench.models.guided.dtree.shared.model.GuidedDecisionTree;
 import org.drools.workbench.screens.guided.dtree.model.GuidedDecisionTreeEditorContent;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface GuidedDecisionTreeEditorService
@@ -36,13 +36,11 @@ public interface GuidedDecisionTreeEditorService
         ValidationService<GuidedDecisionTree>,
         SupportsCreate<GuidedDecisionTree>,
         SupportsRead<GuidedDecisionTree>,
-        SupportsUpdate<GuidedDecisionTree>,
+        SupportsSaveAndRename<GuidedDecisionTree, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    GuidedDecisionTreeEditorContent loadContent( final Path path );
+    GuidedDecisionTreeEditorContent loadContent(final Path path);
 
-    PackageDataModelOracleBaselinePayload loadDataModel( final Path path );
-
+    PackageDataModelOracleBaselinePayload loadDataModel(final Path path);
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -46,6 +47,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.service.DataMo
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -89,6 +91,9 @@ public class GuidedDecisionTreeEditorServiceImpl
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
 
+    @Inject
+    private SaveAndRenameServiceImpl<GuidedDecisionTree, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public GuidedDecisionTreeEditorServiceImpl() {
@@ -98,6 +103,11 @@ public class GuidedDecisionTreeEditorServiceImpl
     @Inject
     public GuidedDecisionTreeEditorServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -284,5 +294,14 @@ public class GuidedDecisionTreeEditorServiceImpl
         } catch (Exception e) {
             throw ExceptionUtilities.handleException(e);
         }
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final GuidedDecisionTree content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtree.backend.server;
+
+import org.drools.workbench.models.guided.dtree.shared.model.GuidedDecisionTree;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedDecisionTreeEditorServiceImplTest {
+
+    @Mock
+    private SaveAndRenameServiceImpl<GuidedDecisionTree, Metadata> saveAndRenameService;
+
+    @InjectMocks
+    private GuidedDecisionTreeEditorServiceImpl service = new GuidedDecisionTreeEditorServiceImpl();
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final GuidedDecisionTree content = mock(GuidedDecisionTree.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/pom.xml
@@ -168,6 +168,11 @@
       <artifactId>lienzo-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorPresenter.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.guided.dtree.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
@@ -39,6 +40,7 @@ import org.drools.workbench.screens.guided.dtree.client.widget.popups.EditTypePo
 import org.drools.workbench.screens.guided.dtree.client.widget.popups.ParserMessagesPopup;
 import org.drools.workbench.screens.guided.dtree.model.GuidedDecisionTreeEditorContent;
 import org.drools.workbench.screens.guided.dtree.service.GuidedDecisionTreeEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -57,6 +59,7 @@ import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -71,7 +74,7 @@ import org.uberfire.workbench.model.menu.Menus;
  */
 @WorkbenchEditor(identifier = "GuidedDecisionTreeEditorPresenter", supportedTypes = { GuidedDTreeResourceType.class }, priority = 101)
 public class GuidedDecisionTreeEditorPresenter
-        extends KieEditor {
+        extends KieEditor<GuidedDecisionTree> {
 
     @Inject
     private ImportsWidgetPresenter importsWidget;
@@ -93,6 +96,7 @@ public class GuidedDecisionTreeEditorPresenter
 
     private GuidedDecisionTree model;
     private AsyncPackageDataModelOracle oracle;
+
     private GuidedDecisionTreeEditorContent content;
 
     private GuidedDecisionTreeEditorView view;
@@ -125,6 +129,16 @@ public class GuidedDecisionTreeEditorPresenter
         view.showLoading();
         service.call( getModelSuccessCallback(),
                       getNoSuchFileExceptionErrorCallback() ).loadContent( versionRecordManager.getCurrentPath() );
+    }
+
+    @Override
+    protected Supplier<GuidedDecisionTree> getContentSupplier() {
+        return () -> view.getModel();
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<GuidedDecisionTree, Metadata>> getSaveAndRenameServiceCaller() {
+        return service;
     }
 
     private RemoteCallback<GuidedDecisionTreeEditorContent> getModelSuccessCallback() {

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorView.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorView.java
@@ -32,4 +32,5 @@ public interface GuidedDecisionTreeEditorView extends KieEditorView,
     void setDataModel( final AsyncPackageDataModelOracle oracle,
                        final boolean isReadOnly );
 
+    GuidedDecisionTree getModel();
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java/org/drools/workbench/screens/guided/dtree/client/editor/GuidedDecisionTreeEditorViewImpl.java
@@ -92,4 +92,8 @@ public class GuidedDecisionTreeEditorViewImpl
                                     isReadOnly );
     }
 
+    @Override
+    public GuidedDecisionTree getModel() {
+        return model;
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-api/src/main/java/org/drools/workbench/screens/guided/rule/service/GuidedRuleEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-api/src/main/java/org/drools/workbench/screens/guided/rule/service/GuidedRuleEditorService.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.guided.rule.service;
 
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.model.GuidedEditorContent;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.shared.source.ViewSourceService;
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface GuidedRuleEditorService
@@ -36,11 +36,9 @@ public interface GuidedRuleEditorService
         ValidationService<RuleModel>,
         SupportsCreate<RuleModel>,
         SupportsRead<RuleModel>,
-        SupportsUpdate<RuleModel>,
+        SupportsSaveAndRename<RuleModel, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    GuidedEditorContent loadContent( final Path path );
-
+    GuidedEditorContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
@@ -52,6 +53,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.service.DataMo
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -100,6 +102,9 @@ public class GuidedRuleEditorServiceImpl
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
 
+    @Inject
+    private SaveAndRenameServiceImpl<RuleModel, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     private Collection<RuleModelIActionPersistenceExtension> persistenceExtensions = new ArrayList<>();
@@ -113,6 +118,11 @@ public class GuidedRuleEditorServiceImpl
         this.safeSessionInfo = new SafeSessionInfo(sessionInfo);
 
         persistenceExtensionInstance.forEach(persistenceExtensions::add);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -334,5 +344,14 @@ public class GuidedRuleEditorServiceImpl
                                                             dslrResourceType.accept(path));
         final String source = RuleModelDRLPersistenceImpl.getInstance().marshal(model);
         return source;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final RuleModel content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplTest.java
@@ -27,8 +27,10 @@ import javax.enterprise.inject.Instance;
 import org.drools.workbench.models.datamodel.oracle.DSLActionSentence;
 import org.drools.workbench.models.datamodel.oracle.DSLConditionSentence;
 import org.drools.workbench.models.datamodel.rule.DSLSentence;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.model.GuidedEditorContent;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDSLRResourceTypeDefinition;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +44,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.io.IOService;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.ResourceOpenedEvent;
@@ -50,6 +53,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,6 +64,10 @@ public class GuidedRuleEditorServiceImplTest {
 
     @Mock
     private SessionInfo sessionInfo;
+
+    @InjectMocks
+    GuidedRuleEditorServiceImpl service = new GuidedRuleEditorServiceImpl(sessionInfo,
+                                                                          mock(Instance.class));
 
     @Mock
     private GuidedRuleDSLRResourceTypeDefinition dslrResourceTypeDefinition;
@@ -76,9 +84,8 @@ public class GuidedRuleEditorServiceImplTest {
     @Mock
     private DSLSentence dslSentence;
 
-    @InjectMocks
-    GuidedRuleEditorServiceImpl service = new GuidedRuleEditorServiceImpl(sessionInfo,
-                                                                          mock(Instance.class));
+    @Mock
+    private SaveAndRenameServiceImpl<RuleModel, Metadata> saveAndRenameService;
 
     @Test
     public void checkConstructContentPopulateProjectCollectionTypesAndDSLSentences() throws Exception {
@@ -107,5 +114,26 @@ public class GuidedRuleEditorServiceImplTest {
         assertTrue(content.getDataModel().getCollectionTypes().containsKey("java.util.Set"));
         assertTrue(content.getDataModel().getPackageElements(DSLActionSentence.INSTANCE).contains(dslSentence));
         assertTrue(content.getDataModel().getPackageElements(DSLConditionSentence.INSTANCE).contains(dslSentence));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final RuleModel content = mock(RuleModel.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/pom.xml
@@ -130,6 +130,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenter.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.rule.client.editor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
@@ -32,6 +33,7 @@ import org.drools.workbench.screens.guided.rule.client.type.GuidedRuleDRLResourc
 import org.drools.workbench.screens.guided.rule.client.type.GuidedRuleDSLRResourceType;
 import org.drools.workbench.screens.guided.rule.model.GuidedEditorContent;
 import org.drools.workbench.screens.guided.rule.service.GuidedRuleEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -55,6 +57,7 @@ import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.workbench.type.ClientResourceType;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
 import org.uberfire.lifecycle.OnClose;
@@ -69,7 +72,7 @@ import org.uberfire.workbench.model.menu.Menus;
 @Dependent
 @WorkbenchEditor(identifier = "GuidedRuleEditor", supportedTypes = {GuidedRuleDRLResourceType.class, GuidedRuleDSLRResourceType.class}, priority = 102)
 public class GuidedRuleEditorPresenter
-        extends KieEditor {
+        extends KieEditor<RuleModel> {
 
     @Inject
     private ImportsWidgetPresenter importsWidget;
@@ -125,6 +128,16 @@ public class GuidedRuleEditorPresenter
         view.showLoading();
         getService().call(getModelSuccessCallback(),
                           getNoSuchFileExceptionErrorCallback()).loadContent(getVersionRecordManager().getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<RuleModel> getContentSupplier() {
+        return () -> view.getContent();
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<RuleModel, Metadata>> getSaveAndRenameServiceCaller() {
+        return getService();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleEditorPresenterTest.java
@@ -16,14 +16,18 @@
 
 package org.drools.workbench.screens.guided.rule.client.editor;
 
+import java.util.function.Supplier;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.client.editor.plugin.RuleModellerActionPlugin;
 import org.drools.workbench.screens.guided.rule.model.GuidedEditorContent;
 import org.drools.workbench.screens.guided.rule.service.GuidedRuleEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.gwtbootstrap3.client.ui.html.Text;
+import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,12 +44,15 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.mocks.CallerMock;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -153,5 +160,25 @@ public class GuidedRuleEditorPresenterTest {
         verify(overviewWidgetPresenter, never()).setContent(overview, resourcePath);
         verify(importsWidgetPresenter, never()).setContent(oracle, imports, false);
         verify(view).hideBusyIndicator();
+    }
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final RuleModel content = mock(RuleModel.class);
+
+        doReturn(content).when(view).getContent();
+
+        final Supplier<RuleModel> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<RuleModel, Metadata>> serviceCaller = presenter.getSaveAndRenameServiceCaller();
+
+        assertEquals(this.serviceCaller, serviceCaller);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-api/src/main/java/org/drools/workbench/screens/guided/scorecard/service/GuidedScoreCardEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-api/src/main/java/org/drools/workbench/screens/guided/scorecard/service/GuidedScoreCardEditorService.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.guided.scorecard.service;
 
 import org.drools.workbench.models.guided.scorecard.shared.ScoreCardModel;
 import org.drools.workbench.screens.guided.scorecard.model.ScoreCardModelContent;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.shared.source.ViewSourceService;
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface GuidedScoreCardEditorService
@@ -36,11 +36,9 @@ public interface GuidedScoreCardEditorService
         ValidationService<ScoreCardModel>,
         SupportsCreate<ScoreCardModel>,
         SupportsRead<ScoreCardModel>,
-        SupportsUpdate<ScoreCardModel>,
+        SupportsSaveAndRename<ScoreCardModel, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    ScoreCardModelContent loadContent( final Path path );
-
+    ScoreCardModelContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/pom.xml
@@ -138,6 +138,11 @@
       <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/main/java/org/drools/workbench/screens/guided/scorecard/backend/server/GuidedScoreCardEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/main/java/org/drools/workbench/screens/guided/scorecard/backend/server/GuidedScoreCardEditorServiceImpl.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.scorecard.backend.server;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -47,6 +48,7 @@ import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleB
 import org.kie.workbench.common.services.shared.source.SourceGenerationFailedException;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -82,6 +84,10 @@ public class GuidedScoreCardEditorServiceImpl
 
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
+
+    @Inject
+    private SaveAndRenameServiceImpl<ScoreCardModel, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public GuidedScoreCardEditorServiceImpl() {
@@ -90,6 +96,11 @@ public class GuidedScoreCardEditorServiceImpl
     @Inject
     public GuidedScoreCardEditorServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -337,5 +348,14 @@ public class GuidedScoreCardEditorServiceImpl
         msg.setText(message);
         msg.setLevel(Level.ERROR);
         return msg;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final ScoreCardModel content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/GuidedScoreCardEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/GuidedScoreCardEditorServiceImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.scorecard.backend.server;
+
+import org.drools.workbench.models.guided.scorecard.shared.ScoreCardModel;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedScoreCardEditorServiceImplTest {
+
+    @Mock
+    private SaveAndRenameServiceImpl<ScoreCardModel, Metadata> saveAndRenameService;
+
+    @InjectMocks
+    private GuidedScoreCardEditorServiceImpl service = new GuidedScoreCardEditorServiceImpl();
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final ScoreCardModel content = mock(ScoreCardModel.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/pom.xml
@@ -124,6 +124,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/src/test/java/org/drools/workbench/screens/guided/scorecard/client/editor/GuidedScoreCardEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/src/test/java/org/drools/workbench/screens/guided/scorecard/client/editor/GuidedScoreCardEditorPresenterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.scorecard.client.editor;
+
+import java.util.function.Supplier;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.scorecard.shared.ScoreCardModel;
+import org.drools.workbench.screens.guided.scorecard.service.GuidedScoreCardEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedScoreCardEditorPresenterTest {
+
+    @Mock
+    private Caller<GuidedScoreCardEditorService> scoreCardEditorService;
+
+    @Mock
+    private GuidedScoreCardEditorView view;
+
+    @InjectMocks
+    private GuidedScoreCardEditorPresenter editor = new GuidedScoreCardEditorPresenter(view);
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final ScoreCardModel content = mock(ScoreCardModel.class);
+
+        doReturn(content).when(view).getModel();
+
+        final Supplier<ScoreCardModel> contentSupplier = editor.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<ScoreCardModel, Metadata>> serviceCaller = editor.getSaveAndRenameServiceCaller();
+
+        assertEquals(scoreCardEditorService, serviceCaller);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-api/src/main/java/org/drools/workbench/screens/guided/template/service/GuidedRuleTemplateEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-api/src/main/java/org/drools/workbench/screens/guided/template/service/GuidedRuleTemplateEditorService.java
@@ -20,6 +20,7 @@ import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.drools.workbench.screens.guided.template.model.GuidedTemplateEditorContent;
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.shared.source.ViewSourceService;
@@ -29,6 +30,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface GuidedRuleTemplateEditorService
@@ -38,11 +40,9 @@ public interface GuidedRuleTemplateEditorService
         ValidationService<TemplateModel>,
         SupportsCreate<TemplateModel>,
         SupportsRead<TemplateModel>,
-        SupportsUpdate<TemplateModel>,
+        SupportsSaveAndRename<TemplateModel, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
-    GuidedTemplateEditorContent loadContent( final Path path );
-
+    GuidedTemplateEditorContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -49,6 +50,7 @@ import org.kie.workbench.common.services.datamodel.backend.server.service.DataMo
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -90,9 +92,18 @@ public class GuidedRuleTemplateEditorServiceImpl
 
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
+
+    @Inject
+    private SaveAndRenameServiceImpl<TemplateModel, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public GuidedRuleTemplateEditorServiceImpl() {
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Inject
@@ -311,5 +322,14 @@ public class GuidedRuleTemplateEditorServiceImpl
         msg.setLevel(Level.WARNING);
         msg.setText(message);
         return msg;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final TemplateModel content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImplTest.java
@@ -20,10 +20,12 @@ import java.util.HashMap;
 
 import javax.enterprise.event.Event;
 
+import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.drools.workbench.screens.guided.template.model.GuidedTemplateEditorContent;
 import org.drools.workbench.screens.guided.template.type.GuidedRuleTemplateResourceTypeDefinition;
 import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.backend.validation.GenericValidator;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -45,6 +48,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -79,9 +83,10 @@ public class GuidedRuleTemplateEditorServiceImplTest {
 
     @Mock
     private SessionInfo sessionInfo;
-
     @InjectMocks
     GuidedRuleTemplateEditorServiceImpl service = spy(new GuidedRuleTemplateEditorServiceImpl(sessionInfo));
+    @Mock
+    private SaveAndRenameServiceImpl<TemplateModel, Metadata> saveAndRenameService;
 
     @Test
     public void checkConstructContentPopulateProjectCollectionTypes() {
@@ -114,5 +119,26 @@ public class GuidedRuleTemplateEditorServiceImplTest {
         assertTrue(content.getDataModel().getCollectionTypes().containsKey("java.util.Collection"));
         assertTrue(content.getDataModel().getCollectionTypes().containsKey("java.util.List"));
         assertTrue(content.getDataModel().getCollectionTypes().containsKey("java.util.Set"));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        service.init();
+
+        verify(saveAndRenameService).init(service);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final TemplateModel content = mock(TemplateModel.class);
+        final String comment = "comment";
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/pom.xml
@@ -138,6 +138,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.guided.template.client.editor;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -31,6 +32,7 @@ import org.drools.workbench.screens.guided.template.client.resources.i18n.Guided
 import org.drools.workbench.screens.guided.template.client.type.GuidedRuleTemplateResourceType;
 import org.drools.workbench.screens.guided.template.model.GuidedTemplateEditorContent;
 import org.drools.workbench.screens.guided.template.service.GuidedRuleTemplateEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -51,6 +53,7 @@ import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.views.pfly.multipage.PageImpl;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -63,7 +66,7 @@ import org.uberfire.workbench.model.menu.Menus;
 @Dependent
 @WorkbenchEditor(identifier = "GuidedRuleTemplateEditor", supportedTypes = {GuidedRuleTemplateResourceType.class})
 public class GuidedRuleTemplateEditorPresenter
-        extends KieEditor {
+        extends KieEditor<TemplateModel> {
 
     private GuidedRuleTemplateEditorView view;
 
@@ -114,6 +117,16 @@ public class GuidedRuleTemplateEditorPresenter
         view.showLoading();
         getService().call(getModelSuccessCallback(),
                           getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<TemplateModel> getContentSupplier() {
+        return this::getModel;
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<TemplateModel, Metadata>> getSaveAndRenameServiceCaller() {
+        return getService();
     }
 
     private RemoteCallback<GuidedTemplateEditorContent> getModelSuccessCallback() {
@@ -258,5 +271,9 @@ public class GuidedRuleTemplateEditorPresenter
      */
     Caller<GuidedRuleTemplateEditorService> getService() {
         return service;
+    }
+
+    TemplateModel getModel() {
+        return model;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/GuidedRuleTemplateEditorPresenterTest.java
@@ -16,12 +16,15 @@
 
 package org.drools.workbench.screens.guided.template.client.editor;
 
+import java.util.function.Supplier;
+
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.drools.workbench.screens.guided.template.model.GuidedTemplateEditorContent;
 import org.drools.workbench.screens.guided.template.service.GuidedRuleTemplateEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.common.client.api.Caller;
 import org.junit.Before;
@@ -39,14 +42,17 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.mocks.CallerMock;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -136,5 +142,25 @@ public class GuidedRuleTemplateEditorPresenterTest {
                                          any(Caller.class),
                                          any(EventBus.class),
                                          anyBoolean());
+    }
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final TemplateModel content = mock(TemplateModel.class);
+
+        doReturn(content).when(presenter).getModel();
+
+        final Supplier<TemplateModel> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<TemplateModel, Metadata>> serviceCaller = presenter.getSaveAndRenameServiceCaller();
+
+        assertEquals(this.serviceCaller, serviceCaller);
     }
 }

--- a/drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-client/src/main/java/org/drools/workbench/screens/scorecardxls/client/editor/ScoreCardXLSEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-client/src/main/java/org/drools/workbench/screens/scorecardxls/client/editor/ScoreCardXLSEditorPresenter.java
@@ -49,7 +49,7 @@ import org.uberfire.workbench.model.menu.Menus;
 @Dependent
 @WorkbenchEditor(identifier = "ScoreCardXLSEditor", supportedTypes = { ScoreCardXLSResourceType.class })
 public class ScoreCardXLSEditorPresenter
-        extends KieEditor
+        extends KieEditor<ScoreCardXLSContent>
         implements ScoreCardXLSEditorView.Presenter {
 
     @Inject

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/service/ScenarioTestEditorService.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/service/ScenarioTestEditorService.java
@@ -20,6 +20,7 @@ import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.model.TestScenarioModelContent;
 import org.drools.workbench.screens.testscenario.model.TestScenarioResult;
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
@@ -27,6 +28,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 /**
  * Service definition for Globals editor
@@ -36,18 +38,16 @@ public interface ScenarioTestEditorService
         extends
         SupportsCreate<Scenario>,
         SupportsRead<Scenario>,
-        SupportsUpdate<Scenario>,
+        SupportsSaveAndRename<Scenario, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
     public static final String TEST_SCENARIO_EDITOR_SETTINGS = "test-scenario-editor-settings";
     public static final String TEST_SCENARIO_EDITOR_MAX_RULE_FIRINGS = "max-rule-firings";
 
-    TestScenarioModelContent loadContent( final Path path );
+    TestScenarioModelContent loadContent(final Path path);
 
     TestScenarioResult runScenario(final String userName,
                                    final Path path,
                                    final Scenario scenario);
-
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/pom.xml
@@ -187,6 +187,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-decisiontables</artifactId>
       <scope>test</scope>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioTestEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioTestEditorServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -52,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -92,6 +94,10 @@ public class ScenarioTestEditorServiceImpl
 
     @Inject
     private CommentedOptionFactory commentedOptionFactory;
+
+    @Inject
+    private SaveAndRenameServiceImpl<Scenario, Metadata> saveAndRenameService;
+
     private SafeSessionInfo safeSessionInfo;
 
     public ScenarioTestEditorServiceImpl() {
@@ -100,6 +106,11 @@ public class ScenarioTestEditorServiceImpl
     @Inject
     public ScenarioTestEditorServiceImpl(final SessionInfo sessionInfo) {
         safeSessionInfo = new SafeSessionInfo(sessionInfo);
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -331,5 +342,14 @@ public class ScenarioTestEditorServiceImpl
 
     private Collection<String> getFullyQualifiedClassNamesUsedByGlobals(final PackageDataModelOracle dataModelOracle) {
         return dataModelOracle.getPackageGlobals().values();
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final Scenario content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioTestEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioTestEditorServiceImplTest.java
@@ -49,6 +49,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -75,9 +76,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ScenarioTestEditorServiceImplTest {
 
-    private static final String COMMENT = "comment";
     public static final String EMPTY_SCENARIO_FILENAME = "empty.scenario";
     public static final String NEW_FILE_NAME = "new" + EMPTY_SCENARIO_FILENAME;
+    private static final String COMMENT = "comment";
 
     @Mock
     Scenario scenario;
@@ -114,6 +115,9 @@ public class ScenarioTestEditorServiceImplTest {
 
     @Mock
     CopyService copyService;
+
+    @Mock
+    SaveAndRenameServiceImpl<Scenario, Metadata> saveAndRenameService;
 
     @Spy
     IOService ioService = new IOServiceDotFileImpl("testIoService");
@@ -527,6 +531,27 @@ public class ScenarioTestEditorServiceImplTest {
         verify(scenarioRunner).run("userName",
                                    scenario,
                                    module);
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        testEditorService.init();
+
+        verify(saveAndRenameService).init(testEditorService);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final Metadata metadata = mock(Metadata.class);
+        final Scenario content = mock(Scenario.class);
+        final String comment = "comment";
+
+        testEditorService.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 
     private FactData factData(final String type) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
@@ -156,6 +156,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.testscenario.client;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
@@ -31,6 +32,7 @@ import org.drools.workbench.screens.testscenario.client.utils.ScenarioUtils;
 import org.drools.workbench.screens.testscenario.model.TestScenarioModelContent;
 import org.drools.workbench.screens.testscenario.model.TestScenarioResult;
 import org.drools.workbench.screens.testscenario.service.ScenarioTestEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.test.TestService;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -45,6 +47,7 @@ import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
 import org.uberfire.lifecycle.OnClose;
 import org.uberfire.lifecycle.OnMayClose;
@@ -55,7 +58,7 @@ import org.uberfire.workbench.model.menu.Menus;
 
 @WorkbenchEditor(identifier = "ScenarioEditorPresenter", supportedTypes = {TestScenarioResourceType.class})
 public class ScenarioEditorPresenter
-        extends KieEditor
+        extends KieEditor<Scenario>
         implements ScenarioEditorView.Presenter {
 
     private final TestScenarioResourceType type;
@@ -115,16 +118,28 @@ public class ScenarioEditorPresenter
                      getNoSuchFileExceptionErrorCallback()).loadContent(versionRecordManager.getCurrentPath());
     }
 
+    @Override
+    protected Supplier<Scenario> getContentSupplier() {
+        return this::getScenario;
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<Scenario, Metadata>> getSaveAndRenameServiceCaller() {
+        return service;
+    }
+
     private RemoteCallback<TestScenarioModelContent> getModelSuccessCallback() {
         return new RemoteCallback<TestScenarioModelContent>() {
             @Override
             public void callback(final TestScenarioModelContent content) {
+
                 //Path is set to null when the Editor is closed (which can happen before async calls complete).
                 if (versionRecordManager.getCurrentPath() == null) {
                     return;
                 }
 
                 scenario = content.getScenario();
+                setOriginalHash(scenario.hashCode());
 
                 ifFixturesSizeZeroThenAddExecutionTrace();
 
@@ -243,8 +258,7 @@ public class ScenarioEditorPresenter
                     .addSave(this::saveAction)
                     .addCopy(versionRecordManager.getCurrentPath(),
                              assetUpdateValidator)
-                    .addRename(versionRecordManager.getPathToLatest(),
-                               assetUpdateValidator)
+                    .addRename(getSaveAndRename())
                     .addDelete(versionRecordManager.getPathToLatest(),
                                assetUpdateValidator);
         }
@@ -264,6 +278,10 @@ public class ScenarioEditorPresenter
     @OnMayClose
     public boolean mayClose() {
         return super.mayClose(scenario);
+    }
+
+    Scenario getScenario() {
+        return scenario;
     }
 
     @OnClose

--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-api/src/main/java/org/drools/workbench/screens/workitems/service/WorkItemsEditorService.java
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-api/src/main/java/org/drools/workbench/screens/workitems/service/WorkItemsEditorService.java
@@ -22,7 +22,7 @@ import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
 import org.drools.workbench.screens.workitems.model.WorkItemDefinitionElements;
 import org.drools.workbench.screens.workitems.model.WorkItemsModelContent;
 import org.guvnor.common.services.project.builder.service.BuildValidationHelper;
-import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
@@ -30,7 +30,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 
 @Remote
 public interface WorkItemsEditorService
@@ -39,10 +39,9 @@ public interface WorkItemsEditorService
         ValidationService<String>,
         SupportsCreate<String>,
         SupportsRead<String>,
-        SupportsUpdate<String>,
+        SupportsSaveAndRename<String, Metadata>,
         SupportsDelete,
-        SupportsCopy,
-        SupportsRename {
+        SupportsCopy {
 
     public static final String WORK_ITEM_DEFINITION = "work-item-definition";
 
@@ -60,10 +59,9 @@ public interface WorkItemsEditorService
 
     public static final String WORK_ITEMS_EDITOR_SETTINGS_PARAMETER_VALUES = "ParameterValues";
 
-    WorkItemsModelContent loadContent( final Path path );
+    WorkItemsModelContent loadContent(final Path path);
 
     WorkItemDefinitionElements loadDefinitionElements();
 
-    Set<PortableWorkDefinition> loadWorkItemDefinitions( final Path path );
-
+    Set<PortableWorkDefinition> loadWorkItemDefinitions(final Path path);
 }

--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-backend/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+
     <!-- Weld Modules. For tests only -->
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-backend/src/main/java/org/drools/workbench/screens/workitems/backend/server/WorkItemsEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-backend/src/main/java/org/drools/workbench/screens/workitems/backend/server/WorkItemsEditorServiceImpl.java
@@ -69,6 +69,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -117,6 +118,9 @@ public class WorkItemsEditorServiceImpl
     private WorkItemsTypeDefinition resourceTypeDefinition;
 
     @Inject
+    private SaveAndRenameServiceImpl<String, Metadata> saveAndRenameService;
+
+    @Inject
     private CommentedOptionFactory commentedOptionFactory;
 
     private WorkItemDefinitionElements workItemDefinitionElements;
@@ -134,9 +138,10 @@ public class WorkItemsEditorServiceImpl
     @PostConstruct
     public void setupWorkItemDefinitionElements() {
         workItemDefinitionElements = new WorkItemDefinitionElements(loadWorkItemDefinitionElements());
+        saveAndRenameService.init(this);
     }
 
-    private Map<String, String> loadWorkItemDefinitionElements() {
+    Map<String, String> loadWorkItemDefinitionElements() {
         final Map<String, String> workItemDefinitionElements = new HashMap<String, String>();
         final List<ConfigGroup> editorConfigGroups = configurationService.getConfiguration(ConfigType.EDITOR);
         for (ConfigGroup editorConfigGroup : editorConfigGroups) {
@@ -401,5 +406,14 @@ public class WorkItemsEditorServiceImpl
             }
         }
         return pps;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/pom.xml
@@ -97,6 +97,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/test/java/org/drools/workbench/screens/workitems/client/editor/WorkItemsEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/test/java/org/drools/workbench/screens/workitems/client/editor/WorkItemsEditorPresenterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.workitems.client.editor;
+
+import java.util.function.Supplier;
+
+import org.drools.workbench.screens.workitems.service.WorkItemsEditorService;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkItemsEditorPresenterTest {
+
+    @Mock
+    private Caller<WorkItemsEditorService> workItemsService;
+
+    @Mock
+    private WorkItemsEditorView view;
+
+    @InjectMocks
+    private WorkItemsEditorPresenter editor = new WorkItemsEditorPresenter(view);
+
+    @Test
+    public void testGetContentSupplier() throws Exception {
+
+        final String content = "content";
+
+        doReturn(content).when(view).getContent();
+
+        final Supplier<String> contentSupplier = editor.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() throws Exception {
+
+        final Caller<? extends SupportsSaveAndRename<String, Metadata>> serviceCaller = editor.getSaveAndRenameServiceCaller();
+
+        assertEquals(workItemsService, serviceCaller);
+    }
+}


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBA-148
- https://issues.jboss.org/browse/AF-819

---
Demo:
![demo](https://user-images.githubusercontent.com/1079279/35909185-e79488d6-0bd9-11e8-8223-97e9718f444f.gif)

---

Important topics:

I) I'm keeping the editors, that have their own implementation of the save-and-rename operation, intact;

II) I couldn't apply the generic approach on `jbpm-designer`, due to the save operation that is coupled to native JS code. Thus, I needed to implement a custom solution there;

III) The "save commit" and the "rename commit" are not being squashed. I don't think that it's a problem since we're showing explicitly to the user that two operations are being executed (but, maybe I'm missing something, wdyt @manstis?).

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/170
- https://github.com/kiegroup/kie-wb-common/pull/1414
- https://github.com/kiegroup/drools-wb/pull/804
- https://github.com/kiegroup/optaplanner-wb/pull/251
- https://github.com/kiegroup/jbpm-designer/pull/743