### PR TITLE
DROOLS-2371: Unable to complete your request. The following exception occurred: (TypeError) in Guided Decision Table Graph

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -223,10 +223,10 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
     }
 
     protected void onFocus() {
-        if (modeller.getActiveDecisionTable() != null) {
-            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(modeller.getActiveDecisionTable()));
-            modeller.getActiveDecisionTable().initialiseAnalysis();
-        }
+        modeller.getActiveDecisionTable().ifPresent(dt -> {
+            decisionTableSelectedEvent.fire(new DecisionTableSelectedEvent(dt));
+            dt.initialiseAnalysis();
+        });
     }
 
     protected String getTitleText() {
@@ -317,7 +317,7 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
     }
 
     void onUpdatedLockStatusEvent(final UpdatedLockStatusEvent event) {
-        final Optional<GuidedDecisionTableView.Presenter> activeDecisionTable = Optional.ofNullable(modeller.getActiveDecisionTable());
+        final Optional<GuidedDecisionTableView.Presenter> activeDecisionTable = modeller.getActiveDecisionTable();
 
         if (!activeDecisionTable.isPresent()) {
             enableColumnsTab(false);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
@@ -179,12 +179,13 @@ public class InsertMenuBuilder extends BaseMenu implements MenuFactory.CustomMen
     }
 
     void openNewGuidedDecisionTableColumnWizard(final GuidedDecisionTableModellerView.Presenter modeller) {
-
         final NewGuidedDecisionTableColumnWizard wizard = wizardManagedInstance.get();
-        final GuidedDecisionTableView.Presenter activeDecisionTable = modeller.getActiveDecisionTable();
+        final Optional<GuidedDecisionTableView.Presenter> activeDecisionTable = modeller.getActiveDecisionTable();
 
-        wizard.init(activeDecisionTable);
-        wizard.start();
+        activeDecisionTable.ifPresent(dt -> {
+            wizard.init(dt);
+            wizard.start();
+        });
     }
 
     private void enableMenuItemsForAppendingRows(final boolean enabled) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -255,8 +255,8 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     }
 
     @Override
-    public GuidedDecisionTableView.Presenter getActiveDecisionTable() {
-        return activeDecisionTable;
+    public Optional<GuidedDecisionTableView.Presenter> getActiveDecisionTable() {
+        return Optional.ofNullable(activeDecisionTable);
     }
 
     @Override
@@ -271,11 +271,11 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
 
     @Override
     public boolean isActiveDecisionTableEditable() {
-        final GuidedDecisionTableView.Presenter dtPresenter = getActiveDecisionTable();
-        if (dtPresenter == null) {
-            return false;
+        final Optional<GuidedDecisionTableView.Presenter> dtPresenter = getActiveDecisionTable();
+        if (dtPresenter.isPresent()) {
+            return dtPresenter.get().getAccess().isEditable();
         }
-        return dtPresenter.getAccess().isEditable();
+        return false;
     }
 
     @Override
@@ -342,12 +342,15 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
         }
         final GuidedDecisionTableView.Presenter presenter = dtPresenter.get();
         if (!isDecisionTableAvailable(presenter)) {
-            activeDecisionTable = null;
             return;
         }
-        if (presenter.equals(getActiveDecisionTable())) {
-            return;
+        final Optional<GuidedDecisionTableView.Presenter> activeDecisionTable = getActiveDecisionTable();
+        if (activeDecisionTable.isPresent()) {
+            if (presenter.equals(activeDecisionTable.get())) {
+                return;
+            }
         }
+
         doDecisionTableSelected(presenter);
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -15,8 +15,7 @@
  */
 package org.drools.workbench.screens.guided.dtable.client.widget.table;
 
-import java.util.Collection;
-import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.enterprise.event.Observes;
@@ -28,19 +27,10 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.ProvidesResize;
 import com.google.gwt.user.client.ui.RequiresResize;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
-import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
-import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableColumnSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.UberView;
@@ -107,7 +97,7 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
 
         void removeDecisionTable(final GuidedDecisionTableView.Presenter dtPresenter);
 
-        GuidedDecisionTableView.Presenter getActiveDecisionTable();
+        Optional<GuidedDecisionTableView.Presenter> getActiveDecisionTable();
 
         Set<GuidedDecisionTableView.Presenter> getAvailableDecisionTables();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRow.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control;
 
+import java.util.Optional;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -23,6 +25,7 @@ import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.gwtbootstrap3.client.ui.CheckBox;
@@ -56,8 +59,11 @@ public class AttributeColumnConfigRow {
                                                                     editedColumn.setUseRowNumber(useRowNumberCheckBox.getValue());
                                                                     reverseOrderCheckBox.setEnabled(useRowNumberCheckBox.getValue());
                                                                     try {
-                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                        editedColumn);
+                                                                        final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                                                        if (dtPresenter.isPresent()) {
+                                                                            dtPresenter.get().updateColumn(originalColumn,
+                                                                                                           editedColumn);
+                                                                        }
                                                                     } catch (VetoException veto) {
                                                                         presenter.getView().showGenericVetoMessage();
                                                                     }
@@ -71,8 +77,11 @@ public class AttributeColumnConfigRow {
                                                                     final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                                                     editedColumn.setReverseOrder(reverseOrderCheckBox.getValue());
                                                                     try {
-                                                                        presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                        editedColumn);
+                                                                        final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                                                        if (dtPresenter.isPresent()) {
+                                                                            dtPresenter.get().updateColumn(originalColumn,
+                                                                                                           editedColumn);
+                                                                        }
                                                                     } catch (VetoException veto) {
                                                                         presenter.getView().showGenericVetoMessage();
                                                                     }
@@ -86,8 +95,11 @@ public class AttributeColumnConfigRow {
                                  final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                  editedColumn.setDefaultValue(event.getEditedDefaultValue());
                                  try {
-                                     presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                     editedColumn);
+                                     final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                     if (dtPresenter.isPresent()) {
+                                         dtPresenter.get().updateColumn(originalColumn,
+                                                                        editedColumn);
+                                     }
                                  } catch (VetoException veto) {
                                      presenter.getView().showGenericVetoMessage();
                                  }
@@ -98,8 +110,11 @@ public class AttributeColumnConfigRow {
                                                             final AttributeCol52 editedColumn = originalColumn.cloneColumn();
                                                             editedColumn.setHideColumn(hideColumnCheckBox.getValue());
                                                             try {
-                                                                presenter.getActiveDecisionTable().updateColumn(originalColumn,
-                                                                                                                editedColumn);
+                                                                final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                                                if (dtPresenter.isPresent()) {
+                                                                    dtPresenter.get().updateColumn(originalColumn,
+                                                                                                   editedColumn);
+                                                                }
                                                             } catch (VetoException veto) {
                                                                 presenter.getView().showGenericVetoMessage();
                                                             }
@@ -115,7 +130,10 @@ public class AttributeColumnConfigRow {
 
         view.addRemoveAttributeButton(() -> {
                                           try {
-                                              presenter.getActiveDecisionTable().deleteColumn(attributeColumn);
+                                              final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                              if (dtPresenter.isPresent()) {
+                                                  dtPresenter.get().deleteColumn(attributeColumn);
+                                              }
                                           } catch (VetoException veto) {
                                               presenter.getView().showGenericVetoMessage();
                                           }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/ColumnManagementView.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.c
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -36,6 +37,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoDeletePatternInUseException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.VetoException;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
@@ -91,13 +93,18 @@ public class ColumnManagementView extends VerticalPanel {
         action.add(actionLabel);
 
         final FlowPanel buttons = new FlowPanel() {{
-            add(editAnchor((clickEvent) -> presenter.getActiveDecisionTable().editAction(actionColumn)));
+            add(editAnchor((clickEvent) -> {
+                presenter.getActiveDecisionTable().ifPresent(dt -> dt.editAction(actionColumn));
+            }));
 
             if (presenter.isActiveDecisionTableEditable()) {
                 add(deleteAnchor(actionColumn.getHeader(),
                                  () -> {
                                      try {
-                                         presenter.getActiveDecisionTable().deleteColumn(actionColumn);
+                                         final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                         if (dtPresenter.isPresent()) {
+                                             dtPresenter.get().deleteColumn(actionColumn);
+                                         }
                                      } catch (VetoDeletePatternInUseException veto) {
                                          presenter.getView().showUnableToDeleteColumnMessage(actionColumn);
                                      } catch (VetoException veto) {
@@ -122,9 +129,10 @@ public class ColumnManagementView extends VerticalPanel {
             condition.add(conditionLabel);
 
             final FlowPanel buttons = new FlowPanel() {{
-                add(editAnchor((clickEvent) -> presenter.getActiveDecisionTable().editCondition(pattern,
-                                                                                                conditionColumn))
-                );
+                add(editAnchor((clickEvent) -> {
+                    presenter.getActiveDecisionTable().ifPresent(dt -> dt.editCondition(pattern,
+                                                                                        conditionColumn));
+                }));
 
                 if (presenter.isActiveDecisionTableEditable()) {
                     add(removeCondition(conditionColumn));
@@ -145,7 +153,9 @@ public class ColumnManagementView extends VerticalPanel {
         condition.add(columnLabel);
 
         final FlowPanel buttons = new FlowPanel() {{
-            add(editAnchor((clickEvent) -> presenter.getActiveDecisionTable().editCondition(conditionColumn)));
+            add(editAnchor((clickEvent) -> {
+                presenter.getActiveDecisionTable().ifPresent(dt -> dt.editCondition(conditionColumn));
+            }));
 
             if (presenter.isActiveDecisionTableEditable()) {
                 add(removeCondition(conditionColumn));
@@ -185,7 +195,10 @@ public class ColumnManagementView extends VerticalPanel {
         return deleteAnchor(column.getHeader(),
                             () -> {
                                 try {
-                                    presenter.getActiveDecisionTable().deleteColumn(column);
+                                    final Optional<GuidedDecisionTableView.Presenter> dtPresenter = presenter.getActiveDecisionTable();
+                                    if (dtPresenter.isPresent()) {
+                                        dtPresenter.get().deleteColumn(column);
+                                    }
                                 } catch (VetoDeletePatternInUseException veto) {
                                     presenter.getView().showUnableToDeleteColumnMessage(column);
                                 } catch (VetoException veto) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImpl.java
@@ -20,7 +20,6 @@ import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.guided.dtable.client.GuidedDecisionTable;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.LockManagerImpl;
@@ -33,29 +32,26 @@ public class GuidedDecisionTableLockManagerImpl extends LockManagerImpl implemen
     private GuidedDecisionTableModellerView.Presenter presenter;
 
     @Override
-    public void init( final LockTarget lockTarget,
-                      final GuidedDecisionTableModellerView.Presenter presenter ) {
+    public void init(final LockTarget lockTarget,
+                     final GuidedDecisionTableModellerView.Presenter presenter) {
         this.presenter = presenter;
-        init( lockTarget );
+        init(lockTarget);
     }
 
     @Override
     public void fireChangeTitleEvent() {
         final Path path = getLockInfo().getFile();
-        if ( path == null ) {
+        if (path == null) {
             return;
         }
-        final GuidedDecisionTableView.Presenter dtPresenter = presenter.getActiveDecisionTable();
-        if ( dtPresenter == null ) {
-            return;
-        }
-        final ObservablePath dtPath = dtPresenter.getCurrentPath();
-        if ( dtPath == null ) {
-            return;
-        }
-        if ( dtPath.equals( path ) ) {
-            super.fireChangeTitleEvent();
-        }
+        presenter.getActiveDecisionTable().ifPresent(dtPresenter -> {
+            final ObservablePath dtPath = dtPresenter.getCurrentPath();
+            if (dtPath == null) {
+                return;
+            }
+            if (dtPath.equals(path)) {
+                super.fireChangeTitleEvent();
+            }
+        });
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -161,7 +162,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
     @Test
     public void checkDecisionTableSelectedEventFiredWhenEditorReceivesFocusWithActiveDecisionTable() {
         final GuidedDecisionTableView.Presenter activeDtable = mock(GuidedDecisionTableView.Presenter.class);
-        when(modeller.getActiveDecisionTable()).thenReturn(activeDtable);
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.of(activeDtable));
 
         presenter.onFocus();
 
@@ -180,6 +181,8 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
     @Test
     public void checkDecisionTableSelectedEventNotFiredWhenEditorReceivesFocusWithoutActiveDecisionTable() {
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
         presenter.onFocus();
 
         verify(decisionTableSelectedEvent,
@@ -734,7 +737,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         doReturn(false).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
@@ -750,7 +753,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         doReturn(false).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(false).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
@@ -766,7 +769,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         doReturn(true).when(event).isLocked();
         doReturn(true).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
@@ -782,7 +785,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         doReturn(true).when(event).isLocked();
         doReturn(false).when(event).isLockedByCurrentUser();
         doReturn(true).when(presenter).isGuidedDecisionTableEditable(activeDecisionTable);
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doNothing().when(presenter).enableColumnsTab(anyBoolean());
 
         presenter.onUpdatedLockStatusEvent(event);
@@ -795,7 +798,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
 
         final UpdatedLockStatusEvent event = mock(UpdatedLockStatusEvent.class);
 
-        doReturn(null).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.empty()).when(modeller).getActiveDecisionTable();
 
         presenter.onUpdatedLockStatusEvent(event);
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
@@ -740,7 +740,7 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
         doNothing().when(presenter).initialiseKieEditorTabs(dtPresenter, overview, oracle, model.getImports(), false);
         doNothing().when(presenter).initialiseEditorTabsWhenNoDocuments();
         doReturn(true).when(modeller).isDecisionTableAvailable(dtPresenter);
-        doReturn(dtPresenter).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(dtPresenter)).when(modeller).getActiveDecisionTable();
         doReturn(overview).when(dtPresenter).getOverview();
         doReturn(oracle).when(dtPresenter).getDataModelOracle();
         doReturn(model).when(dtPresenter).getModel();
@@ -1366,6 +1366,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
     @Test
     public void checkOnUpdatedLockStatusEventWithNullPath() {
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
         checkOnUpdatedLockStatusEvent(null,
                                       false,
                                       false,
@@ -1375,6 +1377,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
     @Test
     public void checkOnUpdatedLockStatusEventNotLocked() {
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
         checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
                                       false,
                                       false,
@@ -1384,6 +1388,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
     @Test
     public void checkOnUpdatedLockStatusEventLockedByOtherUser() {
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
         checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
                                       true,
                                       false,
@@ -1393,6 +1399,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
 
     @Test
     public void checkOnUpdatedLockStatusEventLockedByCurrentUser() {
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
         checkOnUpdatedLockStatusEvent(mock(ObservablePath.class),
                                       true,
                                       true,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilderTest.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
@@ -323,7 +324,7 @@ public class InsertMenuBuilderTest {
         final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
 
         doReturn(wizard).when(wizardManagedInstance).get();
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
 
         builder.openNewGuidedDecisionTableColumnWizard(modeller);
 
@@ -333,10 +334,10 @@ public class InsertMenuBuilderTest {
 
     @Test
     public void testOnAppendColumnWhenModellerIsPresent() {
-
         final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
 
         doReturn(wizard).when(wizardManagedInstance).get();
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.of(dtPresenter));
 
         builder.setModeller(modeller);
         builder.onAppendColumn();
@@ -346,7 +347,6 @@ public class InsertMenuBuilderTest {
 
     @Test
     public void testOnAppendColumnWhenModellerIsNotPresent() {
-
         final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
 
         doReturn(wizard).when(wizardManagedInstance).get();
@@ -355,6 +355,20 @@ public class InsertMenuBuilderTest {
         builder.onAppendColumn();
 
         verify(builder, never()).openNewGuidedDecisionTableColumnWizard(any());
+    }
+
+    @Test
+    public void testOnAppendColumnWhenActiveDecisionTableIsNotPresent() {
+        final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
+
+        when(wizardManagedInstance.get()).thenReturn(wizard);
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+
+        builder.setModeller(modeller);
+        builder.onAppendColumn();
+
+        verify(wizard, never()).init(any(GuidedDecisionTableView.Presenter.class));
+        verify(wizard, never()).start();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/page/ColumnsPagePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/page/ColumnsPagePresenterTest.java
@@ -17,6 +17,8 @@
 package org.drools.workbench.screens.guided.dtable.client.editor.page;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,6 +27,8 @@ import java.util.function.Consumer;
 import com.google.gwt.dev.util.collect.HashMap;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
@@ -61,9 +65,12 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.ruleselector.RuleSelector;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.UpdatedLockStatusEvent;
+import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.drools.workbench.screens.guided.dtable.client.editor.page.accordion.GuidedDecisionTableAccordionItem.Type.ACTION;
 import static org.drools.workbench.screens.guided.dtable.client.editor.page.accordion.GuidedDecisionTableAccordionItem.Type.ATTRIBUTE;
@@ -73,6 +80,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -82,6 +90,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ColumnsPagePresenterTest {
@@ -391,7 +400,7 @@ public class ColumnsPagePresenterTest {
 
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
 
         presenter.deleteMetadataCommand(modeller, metadataColumn).execute();
 
@@ -404,7 +413,7 @@ public class ColumnsPagePresenterTest {
 
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doThrow(ModelSynchronizer.VetoException.class).when(activeDecisionTable).deleteColumn(metadataColumn);
         doNothing().when(presenter).showGenericVetoMessage();
 
@@ -440,7 +449,7 @@ public class ColumnsPagePresenterTest {
         final ClickEvent clickEvent = mock(ClickEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(clone).when(metadataColumn).cloneColumn();
 
         final ClickHandler clickHandler = presenter.hideMetadataClickHandler(modeller, checkBox, metadataColumn);
@@ -459,7 +468,7 @@ public class ColumnsPagePresenterTest {
         final ClickEvent clickEvent = mock(ClickEvent.class);
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(clone).when(metadataColumn).cloneColumn();
         doThrow(ModelSynchronizer.VetoException.class).when(activeDecisionTable).updateColumn(metadataColumn, clone);
         doNothing().when(presenter).showGenericVetoMessage();
@@ -612,7 +621,7 @@ public class ColumnsPagePresenterTest {
         final ObservablePath path = mock(ObservablePath.class);
 
         doReturn(true).when(presenter).hasActiveDecisionTable();
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(path).when(activeDecisionTable).getCurrentPath();
         doReturn(path).when(event).getFile();
         doNothing().when(presenter).refresh();
@@ -630,7 +639,7 @@ public class ColumnsPagePresenterTest {
         final ObservablePath path = mock(ObservablePath.class);
 
         doReturn(true).when(presenter).hasActiveDecisionTable();
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(path).when(activeDecisionTable).getCurrentPath();
         doReturn(null).when(event).getFile();
 
@@ -674,7 +683,7 @@ public class ColumnsPagePresenterTest {
     @Test
     public void testHasActiveDecisionTableWhenActiveDecisionTableIsNotNull() {
 
-        doReturn(mock(GuidedDecisionTableView.Presenter.class)).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(mock(GuidedDecisionTableView.Presenter.class))).when(modeller).getActiveDecisionTable();
 
         final boolean hasActiveDecisionTable = presenter.hasActiveDecisionTable();
 
@@ -758,7 +767,7 @@ public class ColumnsPagePresenterTest {
 
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(true).when(activeDecisionTable).hasColumnDefinitions();
 
         presenter.setupColumnsNoteInfo(modeller);
@@ -771,7 +780,7 @@ public class ColumnsPagePresenterTest {
 
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(false).when(activeDecisionTable).hasColumnDefinitions();
 
         presenter.setupColumnsNoteInfo(modeller);
@@ -810,6 +819,46 @@ public class ColumnsPagePresenterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void testRuleSelectorWidget() {
+        final RuleSelector ruleSelector = mock(RuleSelector.class);
+        final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
+        final GuidedDecisionTable52 model = new GuidedDecisionTable52();
+        final Collection<String> ruleNames = Collections.singletonList("rule");
+        model.setParentName("parent");
+
+        doReturn(ruleSelector).when(presenter).makeRuleSelector();
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.of(dtPresenter));
+        when(dtPresenter.getModel()).thenReturn(model);
+
+        final ArgumentCaptor<ValueChangeHandler> valueChangeHandlerCaptor = ArgumentCaptor.forClass(ValueChangeHandler.class);
+        final ArgumentCaptor<ParameterizedCommand> commandCaptor = ArgumentCaptor.forClass(ParameterizedCommand.class);
+
+        presenter.ruleSelector();
+
+        verify(ruleSelector).addValueChangeHandler(valueChangeHandlerCaptor.capture());
+        valueChangeHandlerCaptor.getValue().onValueChange(mock(ValueChangeEvent.class));
+        verify(dtPresenter).setParentRuleName(anyString());
+        verify(presenter).setupRuleSelector(eq(dtPresenter));
+
+        verify(dtPresenter).getPackageParentRuleNames(commandCaptor.capture());
+        commandCaptor.getValue().execute(ruleNames);
+        verify(ruleSelector).setRuleName(eq("parent"));
+        verify(ruleSelector).setRuleNames(eq(ruleNames));
+    }
+
+    @Test
+    public void testRuleSelectorWidgetWitNoActiveDecisionTable() {
+        final RuleSelector ruleSelector = mock(RuleSelector.class);
+        when(modeller.getActiveDecisionTable()).thenReturn(Optional.empty());
+        doReturn(ruleSelector).when(presenter).makeRuleSelector();
+
+        presenter.ruleSelector();
+
+        verify(presenter, never()).setupRuleSelector(any(GuidedDecisionTableView.Presenter.class));
+    }
+
+    @Test
     public void testOpenNewGuidedDecisionTableColumnWizardWhenColumnCreatingIsNotEnabled() {
 
         final NewGuidedDecisionTableColumnWizard wizard = mock(NewGuidedDecisionTableColumnWizard.class);
@@ -830,7 +879,7 @@ public class ColumnsPagePresenterTest {
         final GuidedDecisionTableView.Presenter activeDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
 
         doReturn(true).when(presenter).isColumnCreationEnabledToActiveDecisionTable();
-        doReturn(activeDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(activeDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(wizard).when(wizardManagedInstance).get();
 
         presenter.openNewGuidedDecisionTableColumnWizard();
@@ -867,7 +916,7 @@ public class ColumnsPagePresenterTest {
 
         doReturn(true).when(dtPresenter).isReadOnly();
 
-        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(dtPresenter);
+        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(Optional.of(dtPresenter));
 
         assertFalse(isColumnCreationEnabled);
     }
@@ -880,7 +929,7 @@ public class ColumnsPagePresenterTest {
         doReturn(false).when(dtPresenter).isReadOnly();
         doReturn(false).when(dtPresenter).hasEditableColumns();
 
-        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(dtPresenter);
+        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(Optional.of(dtPresenter));
 
         assertFalse(isColumnCreationEnabled);
     }
@@ -893,7 +942,7 @@ public class ColumnsPagePresenterTest {
         doReturn(false).when(dtPresenter).isReadOnly();
         doReturn(true).when(dtPresenter).hasEditableColumns();
 
-        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(dtPresenter);
+        final boolean isColumnCreationEnabled = presenter.isColumnCreationEnabled(Optional.of(dtPresenter));
 
         assertTrue(isColumnCreationEnabled);
     }
@@ -928,11 +977,10 @@ public class ColumnsPagePresenterTest {
 
         final DecisionTableSelectedEvent event = mock(DecisionTableSelectedEvent.class);
         final GuidedDecisionTableView.Presenter presenterDecisionTable = mock(GuidedDecisionTableView.Presenter.class);
-        final Optional<GuidedDecisionTableView.Presenter> presenterOptional = Optional.ofNullable(presenterDecisionTable);
 
         doReturn(true).when(presenter).hasActiveDecisionTable();
-        doReturn(presenterDecisionTable).when(modeller).getActiveDecisionTable();
-        doReturn(presenterOptional).when(event).getPresenter();
+        doReturn(Optional.of(presenterDecisionTable)).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(presenterDecisionTable)).when(event).getPresenter();
 
         presenter.onDecisionTableSelected(event);
 
@@ -948,7 +996,7 @@ public class ColumnsPagePresenterTest {
         final Optional<GuidedDecisionTableView.Presenter> presenterOptional = Optional.ofNullable(eventDecisionTable);
 
         doReturn(true).when(presenter).hasActiveDecisionTable();
-        doReturn(presenterDecisionTable).when(modeller).getActiveDecisionTable();
+        doReturn(Optional.of(presenterDecisionTable)).when(modeller).getActiveDecisionTable();
         doReturn(presenterOptional).when(event).getPresenter();
         doNothing().when(presenter).setupRuleSelector(any());
 
@@ -962,7 +1010,7 @@ public class ColumnsPagePresenterTest {
 
         final GuidedDecisionTable52 guidedDecisionTable52 = mock(GuidedDecisionTable52.class);
 
-        doReturn(guidedDecisionTable52).when(presenter).getGuidedDecisionTable52();
+        doReturn(Optional.of(guidedDecisionTable52)).when(presenter).getGuidedDecisionTable52();
 
         doNothing().when(presenter).refreshAttributeWidget(any());
         doNothing().when(presenter).refreshMetaDataWidget(any());

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRowTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/control/AttributeColumnConfigRowTest.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.control;
 
+import java.util.Optional;
+
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -36,6 +38,7 @@ import org.mockito.Mock;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +91,7 @@ public class AttributeColumnConfigRowTest {
         when(attributeColumn.getAttribute()).thenReturn(RuleAttributeWidget.SALIENCE_ATTR);
         when(attributeColumn.cloneColumn()).thenReturn(editedAttributeColumn);
         when(presenter.isActiveDecisionTableEditable()).thenReturn(true);
-        when(presenter.getActiveDecisionTable()).thenReturn(decisionTable);
+        when(presenter.getActiveDecisionTable()).thenReturn(Optional.of(decisionTable));
 
         when(view.addUseRowNumberCheckBox(any(), anyBoolean(), any())).thenReturn(useRowNumberCheckBox);
         when(view.addReverseOrderCheckBox(any(), anyBoolean(), any())).thenReturn(reverseOrderCheckBox);
@@ -116,6 +119,24 @@ public class AttributeColumnConfigRowTest {
     }
 
     @Test
+    public void testInitUseRowNumberCheckBoxWithoutActiveDecisionTable() throws Exception {
+        when(useRowNumberCheckBox.getValue()).thenReturn(true);
+        when(presenter.getActiveDecisionTable()).thenReturn(Optional.empty());
+
+        columnConfigRow.init(attributeColumn,
+                             presenter);
+        verify(view).addUseRowNumberCheckBox(eq(attributeColumn),
+                                             eq(true),
+                                             clickCaptor.capture());
+        //Simulates that checkbox was clicked
+        clickCaptor.getValue().onClick(null);
+
+        verify(decisionTable,
+               never()).updateColumn(any(AttributeCol52.class),
+                                     any(AttributeCol52.class));
+    }
+
+    @Test
     public void testInitReverseOrder() throws Exception {
         when(reverseOrderCheckBox.getValue()).thenReturn(true);
         columnConfigRow.init(attributeColumn, presenter);
@@ -124,6 +145,24 @@ public class AttributeColumnConfigRowTest {
         clickCaptor.getValue().onClick(null);
         verify(editedAttributeColumn).setReverseOrder(true);
         verify(decisionTable).updateColumn(attributeColumn, editedAttributeColumn);
+    }
+
+    @Test
+    public void testInitReverseOrderWithoutActiveDecisionTable() throws Exception {
+        when(reverseOrderCheckBox.getValue()).thenReturn(true);
+        when(presenter.getActiveDecisionTable()).thenReturn(Optional.empty());
+
+        columnConfigRow.init(attributeColumn,
+                             presenter);
+        verify(view).addReverseOrderCheckBox(eq(attributeColumn),
+                                             eq(true),
+                                             clickCaptor.capture());
+        //Simulates that checkbox was clicked
+        clickCaptor.getValue().onClick(null);
+
+        verify(decisionTable,
+               never()).updateColumn(any(AttributeCol52.class),
+                                     any(AttributeCol52.class));
     }
 
     @Test
@@ -138,6 +177,24 @@ public class AttributeColumnConfigRowTest {
     }
 
     @Test
+    public void testInitDefaultValueWithoutActiveDecisionTable() throws Exception {
+        when(event.getEditedDefaultValue()).thenReturn(defaultValue);
+        when(presenter.getActiveDecisionTable()).thenReturn(Optional.empty());
+
+        columnConfigRow.init(attributeColumn,
+                             presenter);
+        verify(view).addDefaultValue(eq(attributeColumn),
+                                     eq(true),
+                                     defaultValueCaptor.capture());
+        //Simulates that checkbox was clicked
+        defaultValueCaptor.getValue().onDefaultValueChanged(event);
+
+        verify(decisionTable,
+               never()).updateColumn(any(AttributeCol52.class),
+                                     any(AttributeCol52.class));
+    }
+
+    @Test
     public void testInitHideColumn() throws Exception {
         when(hideColumnCheckBox.getValue()).thenReturn(true);
         columnConfigRow.init(attributeColumn, presenter);
@@ -146,5 +203,22 @@ public class AttributeColumnConfigRowTest {
         clickCaptor.getValue().onClick(null);
         verify(editedAttributeColumn).setHideColumn(true);
         verify(decisionTable).updateColumn(attributeColumn, editedAttributeColumn);
+    }
+
+    @Test
+    public void testInitHideColumnWithoutActiveDecisionTable() throws Exception {
+        when(hideColumnCheckBox.getValue()).thenReturn(true);
+        when(presenter.getActiveDecisionTable()).thenReturn(Optional.empty());
+
+        columnConfigRow.init(attributeColumn,
+                             presenter);
+        verify(view).addHideColumnCheckBox(eq(attributeColumn),
+                                           clickCaptor.capture());
+        //Simulates that checkbox was clicked
+        clickCaptor.getValue().onClick(null);
+
+        verify(decisionTable,
+               never()).updateColumn(any(AttributeCol52.class),
+                                     any(AttributeCol52.class));
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImplTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanager;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
@@ -61,12 +62,12 @@ public class GuidedDecisionTableLockManagerImplTest {
     @Mock
     private User user;
 
-    private Event<ChangeTitleWidgetEvent> changeTitleEvent = spy( new EventSourceMock<ChangeTitleWidgetEvent>() {
+    private Event<ChangeTitleWidgetEvent> changeTitleEvent = spy(new EventSourceMock<ChangeTitleWidgetEvent>() {
         @Override
-        public void fire( final ChangeTitleWidgetEvent event ) {
+        public void fire(final ChangeTitleWidgetEvent event) {
             //Do nothing. Default implementation throws an exception.
         }
-    } );
+    });
 
     @Mock
     private GuidedDecisionTableModellerView.Presenter modellerPresenter;
@@ -78,77 +79,76 @@ public class GuidedDecisionTableLockManagerImplTest {
 
     @Before
     public void setup() throws NoSuchFieldException, IllegalAccessException {
-        GwtMockito.useProviderForType( WorkbenchResources.class,
-                                       ( type ) -> null );
+        GwtMockito.useProviderForType(WorkbenchResources.class,
+                                      (type) -> null);
 
         lockManager = new GuidedDecisionTableLockManagerImpl();
 
-        setLockManagerField( "lockService",
-                             lockService );
-        setLockManagerField( "lockInfo",
-                             lockInfo );
-        setLockManagerField( "changeTitleEvent",
-                             changeTitleEvent );
-        setLockManagerField( "user",
-                             user );
+        setLockManagerField("lockService",
+                            lockService);
+        setLockManagerField("lockInfo",
+                            lockInfo);
+        setLockManagerField("changeTitleEvent",
+                            changeTitleEvent);
+        setLockManagerField("user",
+                            user);
 
-        when( lockInfo.getFile() ).thenReturn( dtPath );
-        when( user.getIdentifier() ).thenReturn( "user" );
+        when(lockInfo.getFile()).thenReturn(dtPath);
+        when(user.getIdentifier()).thenReturn("user");
     }
 
-    private void setLockManagerField( final String fieldName,
-                                      final Object value ) {
+    private void setLockManagerField(final String fieldName,
+                                     final Object value) {
         try {
-            final Field field = LockManagerImpl.class.getDeclaredField( fieldName );
-            field.setAccessible( true );
-            field.set( lockManager,
-                       value );
-        } catch ( NoSuchFieldException | IllegalAccessException e ) {
-            fail( e.getMessage() );
+            final Field field = LockManagerImpl.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(lockManager,
+                      value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(e.getMessage());
         }
     }
 
     @Test
     public void testFireChangeTitleEvent_NoActiveDecisionTable() {
-        lockManager.init( mock( LockTarget.class ),
-                          modellerPresenter );
+        lockManager.init(mock(LockTarget.class),
+                         modellerPresenter);
 
-        when( modellerPresenter.getActiveDecisionTable() ).thenReturn( null );
+        when(modellerPresenter.getActiveDecisionTable()).thenReturn(Optional.empty());
 
         lockManager.fireChangeTitleEvent();
 
-        verify( changeTitleEvent,
-                never() ).fire( any( ChangeTitleWidgetEvent.class ) );
+        verify(changeTitleEvent,
+               never()).fire(any(ChangeTitleWidgetEvent.class));
     }
 
     @Test
     public void testFireChangeTitleEvent_LockInfoUpdateForActiveDecisionTable() {
-        lockManager.init( mock( LockTarget.class ),
-                          modellerPresenter );
+        lockManager.init(mock(LockTarget.class),
+                         modellerPresenter);
 
-        final GuidedDecisionTableView.Presenter dtPresenter = mock( GuidedDecisionTableView.Presenter.class );
-        when( dtPresenter.getCurrentPath() ).thenReturn( new ObservablePathImpl().wrap( dtPath ) );
-        when( modellerPresenter.getActiveDecisionTable() ).thenReturn( dtPresenter );
+        final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
+        when(dtPresenter.getCurrentPath()).thenReturn(new ObservablePathImpl().wrap(dtPath));
+        when(modellerPresenter.getActiveDecisionTable()).thenReturn(Optional.of(dtPresenter));
 
         lockManager.fireChangeTitleEvent();
 
-        verify( changeTitleEvent,
-                times( 1 ) ).fire( any( ChangeTitleWidgetEvent.class ) );
+        verify(changeTitleEvent,
+               times(1)).fire(any(ChangeTitleWidgetEvent.class));
     }
 
     @Test
     public void testFireChangeTitleEvent_LockInfoUpdateForNonActiveDecisionTable() {
-        lockManager.init( mock( LockTarget.class ),
-                          modellerPresenter );
+        lockManager.init(mock(LockTarget.class),
+                         modellerPresenter);
 
-        final GuidedDecisionTableView.Presenter dtPresenter = mock( GuidedDecisionTableView.Presenter.class );
-        when( dtPresenter.getCurrentPath() ).thenReturn( mock( ObservablePath.class ) );
-        when( modellerPresenter.getActiveDecisionTable() ).thenReturn( dtPresenter );
+        final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
+        when(dtPresenter.getCurrentPath()).thenReturn(mock(ObservablePath.class));
+        when(modellerPresenter.getActiveDecisionTable()).thenReturn(Optional.of(dtPresenter));
 
         lockManager.fireChangeTitleEvent();
 
-        verify( changeTitleEvent,
-                never() ).fire( any( ChangeTitleWidgetEvent.class ) );
+        verify(changeTitleEvent,
+               never()).fire(any(ChangeTitleWidgetEvent.class));
     }
-
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2371

The problem I found was that with a GDT open and then opening a GDTG(raph) and adding the same GDT a ```DecisionTableSelectedEvent``` was raised. The event held a different instance of the first GDT and hence the singular GDT editor set its "active decision table" to ```null```. However the same event also causes the "Columns" tab to refresh itself assuming the "active decision table" is not null... <bang!>

This PR fixes that and also safe guards against similar (undetected) issues by making "active decision table" a ```java.util.Optional``` and refactoring the old use of it accordingly. There will no doubt need to be some tests written (there are no new ones in this PR at the moment) but I thought it worth checking with you both that this does indeed fix the issues you encountered.