### PR TITLE
[AF-1074]: Removed unused OrganizationalUnitManager View that made connected clients crash.

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -411,11 +411,6 @@
       <artifactId>uberfire-message-console-backend</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-organizationalunit-manager</artifactId>
-    </dependency>
-
     <!-- Common -->
     <dependency>
       <groupId>org.kie.workbench.services</groupId>
@@ -1097,7 +1092,6 @@
             <compileSourcesArtifact>org.uberfire:uberfire-project-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-message-console-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-message-console-client</compileSourcesArtifact>
-            <compileSourcesArtifact>org.uberfire:uberfire-organizationalunit-manager</compileSourcesArtifact>
 
             <!-- Common dependencies -->
             <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-library-client</compileSourcesArtifact>

--- a/drools-wb-webapp/src/main/resources/org/drools/workbench/DroolsWorkbench.gwt.xml
+++ b/drools-wb-webapp/src/main/resources/org/drools/workbench/DroolsWorkbench.gwt.xml
@@ -28,7 +28,6 @@
   <inherits name="org.guvnor.common.services.workingset.GuvnorWorkingsetAPI"/>
   <inherits name="org.guvnor.common.services.workingset.GuvnorWorkingsetClient"/>
   <inherits name="org.guvnor.messageconsole.GuvnorMessageConsoleClient"/>
-  <inherits name='org.guvnor.organizationalunit.manager.GuvnorOrganizationalUnitManager'/>
 
   <!--Common Screens -->
   <inherits name="org.kie.workbench.common.screens.library.LibraryClient"/>


### PR DESCRIPTION
https://github.com/kiegroup/appformer/pull/247
https://github.com/kiegroup/kie-wb-common/pull/1511
https://github.com/kiegroup/kie-wb-distributions/pull/709
https://github.com/kiegroup/drools-wb/pull/832