### PR TITLE
RHBA-415: After rename, designer is not marked as dirty more

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImpl.java
@@ -49,7 +49,7 @@ public class GuidedDecisionTableLockManagerImpl extends LockManagerImpl implemen
             if (dtPath == null) {
                 return;
             }
-            if (dtPath.equals(path)) {
+            if (path.equals(dtPath)) {
                 super.fireChangeTitleEvent();
             }
         });

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/lockmanager/GuidedDecisionTableLockManagerImplTest.java
@@ -19,8 +19,6 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanag
 import java.lang.reflect.Field;
 import java.util.Optional;
 
-import javax.enterprise.event.Event;
-
 import com.google.gwtmockito.GwtMockito;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
@@ -32,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.backend.vfs.impl.LockInfo;
 import org.uberfire.backend.vfs.impl.ObservablePathImpl;
 import org.uberfire.client.mvp.LockManagerImpl;
@@ -62,7 +61,7 @@ public class GuidedDecisionTableLockManagerImplTest {
     @Mock
     private User user;
 
-    private Event<ChangeTitleWidgetEvent> changeTitleEvent = spy(new EventSourceMock<ChangeTitleWidgetEvent>() {
+    private EventSourceMock<ChangeTitleWidgetEvent> changeTitleEvent = spy(new EventSourceMock<ChangeTitleWidgetEvent>() {
         @Override
         public void fire(final ChangeTitleWidgetEvent event) {
             //Do nothing. Default implementation throws an exception.
@@ -72,13 +71,13 @@ public class GuidedDecisionTableLockManagerImplTest {
     @Mock
     private GuidedDecisionTableModellerView.Presenter modellerPresenter;
 
-    @Mock
-    private Path dtPath;
-
     private GuidedDecisionTableLockManagerImpl lockManager;
 
     @Before
     public void setup() throws NoSuchFieldException, IllegalAccessException {
+
+        final PathFactory.PathImpl filename = makePathImpl("filename");
+
         GwtMockito.useProviderForType(WorkbenchResources.class,
                                       (type) -> null);
 
@@ -93,7 +92,7 @@ public class GuidedDecisionTableLockManagerImplTest {
         setLockManagerField("user",
                             user);
 
-        when(lockInfo.getFile()).thenReturn(dtPath);
+        when(lockInfo.getFile()).thenReturn(filename);
         when(user.getIdentifier()).thenReturn("user");
     }
 
@@ -128,7 +127,11 @@ public class GuidedDecisionTableLockManagerImplTest {
                          modellerPresenter);
 
         final GuidedDecisionTableView.Presenter dtPresenter = mock(GuidedDecisionTableView.Presenter.class);
-        when(dtPresenter.getCurrentPath()).thenReturn(new ObservablePathImpl().wrap(dtPath));
+        final PathFactory.PathImpl lockInfoPath = makePathImpl("filename");
+        final ObservablePath presenterPath = makeObservablePath("filename");
+
+        when(lockInfo.getFile()).thenReturn(lockInfoPath);
+        when(dtPresenter.getCurrentPath()).thenReturn(presenterPath);
         when(modellerPresenter.getActiveDecisionTable()).thenReturn(Optional.of(dtPresenter));
 
         lockManager.fireChangeTitleEvent();
@@ -150,5 +153,43 @@ public class GuidedDecisionTableLockManagerImplTest {
 
         verify(changeTitleEvent,
                never()).fire(any(ChangeTitleWidgetEvent.class));
+    }
+
+    private PathFactory.PathImpl makePathImpl(final String name) {
+
+        return new PathFactory.PathImpl() {
+            @Override
+            public String getFileName() {
+                return name + ".txt";
+            }
+
+            @Override
+            public String toURI() {
+                return "/directory/" + name + ".txt";
+            }
+        };
+    }
+
+    private ObservablePath makeObservablePath(final String name) {
+        return new ObservablePathImpl().wrap(makePath(name));
+    }
+
+    private Path makePath(final String name) {
+        return new Path() {
+            @Override
+            public String getFileName() {
+                return name + ".txt";
+            }
+
+            @Override
+            public String toURI() {
+                return "/directory/" + name + ".txt";
+            }
+
+            @Override
+            public int compareTo(final Path o) {
+                return 0;
+            }
+        };
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBA-415

Before:
![before-1](https://user-images.githubusercontent.com/1079279/38328702-f2123d02-3821-11e8-9eef-1adb3416492b.gif)
![before-2](https://user-images.githubusercontent.com/1079279/38328740-058ea9ba-3822-11e8-8ac3-2473cadddae3.gif)

After:
![after-1](https://user-images.githubusercontent.com/1079279/38328748-0baaa72c-3822-11e8-9ad2-f2575ea9672c.gif)
![after-2](https://user-images.githubusercontent.com/1079279/38328841-532649da-3822-11e8-8031-ae006e43956b.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/275
- https://github.com/kiegroup/drools-wb/pull/842
