### PR TITLE
BAQE-381: Increase coverage of guided rule date attributes

### DIFF
--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/EditAttributeWidgetFactory.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/EditAttributeWidgetFactory.java
@@ -16,15 +16,23 @@
 
 package org.drools.workbench.screens.guided.rule.client.widget.attribute;
 
+import java.util.Date;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
 import org.drools.workbench.models.datamodel.rule.RuleAttribute;
 import org.gwtbootstrap3.client.ui.TextBox;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.widget.TextBoxFactory;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
 
 public class EditAttributeWidgetFactory {
 
+    private static final String DATE_FORMAT = ApplicationPreferences.getDroolsDateFormat();
+    private static final DateTimeFormat DATE_FORMATTER = DateTimeFormat.getFormat(DATE_FORMAT);
+
     final boolean isReadOnly;
 
-    public EditAttributeWidgetFactory(boolean isReadOnly) {
+    public EditAttributeWidgetFactory(final boolean isReadOnly) {
         this.isReadOnly = isReadOnly;
     }
 
@@ -34,11 +42,41 @@ public class EditAttributeWidgetFactory {
         return textBox;
     }
 
+    public DatePicker datePicker(final RuleAttribute ruleAttribute, final boolean allowEmptyValues) {
+        final DatePicker datePicker = new DatePicker(allowEmptyValues);
+        initDatePickerByRuleAttribute(datePicker, ruleAttribute);
+        return datePicker;
+    }
+
     protected void initTextBoxByRuleAttribute(final TextBox textBox, final RuleAttribute ruleAttribute) {
         textBox.setEnabled(!isReadOnly);
         if (!isReadOnly) {
             textBox.addValueChangeHandler(event -> ruleAttribute.setValue(textBox.getValue()));
         }
         textBox.setValue(ruleAttribute.getValue());
+    }
+
+    protected void initDatePickerByRuleAttribute(final DatePicker datePicker, final RuleAttribute ruleAttribute) {
+        datePicker.addValueChangeHandler(event -> {
+            final Date date = datePicker.getValue();
+            final String sDate = (date == null ? null : DATE_FORMATTER.format(datePicker.getValue()));
+            ruleAttribute.setValue(sDate);
+        });
+
+        datePicker.setFormat(DATE_FORMAT);
+        datePicker.setValue(assertDateValue(ruleAttribute));
+    }
+
+    private Date assertDateValue(final RuleAttribute ruleAttribute) {
+        if (ruleAttribute == null || ruleAttribute.getValue() == null) {
+            return null;
+        }
+
+        try {
+            final Date d = DATE_FORMATTER.parse(ruleAttribute.getValue());
+            return d;
+        } catch (IllegalArgumentException iae) {
+            return null;
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/RuleAttributeWidget.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/RuleAttributeWidget.java
@@ -16,8 +16,6 @@
 
 package org.drools.workbench.screens.guided.rule.client.widget.attribute;
 
-import java.util.Date;
-
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -26,9 +24,6 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -44,9 +39,7 @@ import org.gwtbootstrap3.client.ui.CheckBox;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.kie.soup.project.datamodel.oracle.DataType;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.resources.ItemImages;
-import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.widgets.common.client.common.DirtyableHorizontalPane;
 import org.uberfire.ext.widgets.common.client.common.FormStyleLayout;
 import org.uberfire.ext.widgets.common.client.common.InfoPopup;
@@ -58,9 +51,6 @@ import org.uberfire.ext.widgets.common.client.common.SmallLabel;
  * Added support for metadata - Michael Rhoden 10/17/08
  */
 public class RuleAttributeWidget extends Composite {
-
-    private static final String DATE_FORMAT = ApplicationPreferences.getDroolsDateFormat();
-    private static final DateTimeFormat DATE_FORMATTER = DateTimeFormat.getFormat(DATE_FORMAT);
 
     /**
      * These are the names of all of the rule attributes for this widget
@@ -182,22 +172,7 @@ public class RuleAttributeWidget extends Composite {
             if (isReadOnly) {
                 editor = editAttributeWidgetFactory.textBox(at, DataType.TYPE_STRING);
             } else {
-                final DatePicker datePicker = new DatePicker(false);
-
-                // Wire up update handler
-                datePicker.addValueChangeHandler(new ValueChangeHandler<Date>() {
-                    @Override
-                    public void onValueChange(final ValueChangeEvent<Date> event) {
-                        final Date date = datePicker.getValue();
-                        final String sDate = (date == null ? null : DATE_FORMATTER.format(datePicker.getValue()));
-                        at.setValue(sDate);
-                    }
-                });
-
-                datePicker.setFormat(DATE_FORMAT);
-                datePicker.setValue(assertDateValue(at));
-
-                editor = datePicker;
+                editor = editAttributeWidgetFactory.datePicker(at, false);
             }
         } else if (attributeName.equals(DIALECT_ATTR)) {
             final ListBox lb = new ListBox();
@@ -239,18 +214,6 @@ public class RuleAttributeWidget extends Composite {
         }
 
         return horiz;
-    }
-
-    private Date assertDateValue(final RuleAttribute at) {
-        if (at.getValue() == null) {
-            return null;
-        }
-
-        try {
-            return DATE_FORMATTER.parse(at.getValue());
-        } catch (IllegalArgumentException iae) {
-            return null;
-        }
     }
 
     private Widget getEditorWidget(final RuleMetadata rm,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/EditAttributeWidgetFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/EditAttributeWidgetFactoryTest.java
@@ -16,7 +16,10 @@
 
 package org.drools.workbench.screens.guided.rule.client.widget.attribute;
 
+import java.util.Date;
+
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.rule.RuleAttribute;
@@ -29,9 +32,14 @@ import org.kie.workbench.common.widgets.client.widget.LiteralTextBox;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.widgets.common.client.common.NumericLongTextBox;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -39,7 +47,7 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 // Need to stub used things from: org.kie.workbench.common.widgets.client.widget.TextBoxFactory.getTextBox()
-@WithClassesToStub({NumericLongTextBox.class, LiteralTextBox.class})
+@WithClassesToStub({NumericLongTextBox.class, LiteralTextBox.class, DatePicker.class, DateTimeFormat.class})
 public class EditAttributeWidgetFactoryTest {
 
     private boolean isReadOnly = false;
@@ -72,6 +80,12 @@ public class EditAttributeWidgetFactoryTest {
     }
 
     @Test
+    public void testDatePicker() {
+        final DatePicker picker = factory.datePicker(ruleAttribute, false);
+        verify(factory).initDatePickerByRuleAttribute(picker, ruleAttribute);
+    }
+
+    @Test
     public void testInitTextBoxByRuleAttribute() {
         final TextBox textBox = mock(TextBox.class);
         final String attributeValue = "123";
@@ -83,7 +97,7 @@ public class EditAttributeWidgetFactoryTest {
     }
 
     @Test
-    public void testValueChangeHandler() {
+    public void testTextBoxValueChangeHandler() {
         final TextBox textBox = mock(TextBox.class);
         final String textBoxValue = "123";
         doReturn(textBoxValue).when(textBox).getValue();
@@ -93,5 +107,44 @@ public class EditAttributeWidgetFactoryTest {
 
         valueChangeHandlerArgumentCaptor.getValue().onValueChange(null);
         verify(ruleAttribute).setValue(textBoxValue);
+    }
+
+    @Test
+    public void testInitDatePickerByRuleAttribute() {
+        final DatePicker datePicker = mock(DatePicker.class);
+        final String attributeValue = "31-May-2018";
+        doReturn(attributeValue).when(ruleAttribute).getValue();
+
+        factory.initDatePickerByRuleAttribute(datePicker, ruleAttribute);
+        // not robust verifications because of Date formatting / parsing is mocked by GwtMockito
+        verify(datePicker).setFormat(any());
+        verify(datePicker).setValue(notNull(Date.class));
+    }
+
+    @Test
+    public void testDatePickerValueChangeHandler() {
+        final DatePicker datePicker = mock(DatePicker.class);
+        final Date datePickerValue = new Date();
+        doReturn(datePickerValue).when(datePicker).getValue();
+
+        factory.initDatePickerByRuleAttribute(datePicker, ruleAttribute);
+        verify(datePicker).addValueChangeHandler(valueChangeHandlerArgumentCaptor.capture());
+
+        valueChangeHandlerArgumentCaptor.getValue().onValueChange(null);
+        // not robust verifications because of Date formatting / parsing is mocked by GwtMockito
+        verify(ruleAttribute).setValue(anyString());
+    }
+
+    @Test
+    public void testDatePickerValueChangeHandlerNullValue() {
+        final DatePicker datePicker = mock(DatePicker.class);
+        final Date datePickerValue = null;
+        doReturn(datePickerValue).when(datePicker).getValue();
+
+        factory.initDatePickerByRuleAttribute(datePicker, ruleAttribute);
+        verify(datePicker).addValueChangeHandler(valueChangeHandlerArgumentCaptor.capture());
+
+        valueChangeHandlerArgumentCaptor.getValue().onValueChange(null);
+        verify(ruleAttribute).setValue(eq(null));
     }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/RuleAttributeWidgetTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/widget/attribute/RuleAttributeWidgetTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.widgets.client.widget.LiteralTextBox;
 import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.widgets.common.client.common.DirtyableHorizontalPane;
 import org.uberfire.ext.widgets.common.client.common.FormStyleLayout;
 import org.uberfire.ext.widgets.common.client.common.NumericIntegerTextBox;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
-@WithClassesToStub({DateTimeFormat.class})
+@WithClassesToStub({DateTimeFormat.class, DatePicker.class})
 public class RuleAttributeWidgetTest {
 
     @Mock
@@ -116,5 +117,31 @@ public class RuleAttributeWidgetTest {
         verify(layout).addAttribute(eq(RuleAttributeWidget.SALIENCE_ATTR),
                                     eq(dirtyableHorizontalPane));
         verify(dirtyableHorizontalPane).add(isA(NumericIntegerTextBox.class));
+    }
+
+    @Test
+    public void testDateEffectiveAttribute() {
+        ruleModel.addAttribute(new RuleAttribute(RuleAttributeWidget.DATE_EFFECTIVE_ATTR, ""));
+
+        ruleAttributeWidget = new RuleAttributeWidget(ruleModeller,
+                                                      ruleModel,
+                                                      isReadOnly);
+
+        verify(layout).addAttribute(eq(RuleAttributeWidget.DATE_EFFECTIVE_ATTR),
+                                    eq(dirtyableHorizontalPane));
+        verify(dirtyableHorizontalPane).add(isA(DatePicker.class));
+    }
+
+    @Test
+    public void testDateExpiresAttribute() {
+        ruleModel.addAttribute(new RuleAttribute(RuleAttributeWidget.DATE_EXPIRES_ATTR, ""));
+
+        ruleAttributeWidget = new RuleAttributeWidget(ruleModeller,
+                                                      ruleModel,
+                                                      isReadOnly);
+
+        verify(layout).addAttribute(eq(RuleAttributeWidget.DATE_EXPIRES_ATTR),
+                                    eq(dirtyableHorizontalPane));
+        verify(dirtyableHorizontalPane).add(isA(DatePicker.class));
     }
 }


### PR DESCRIPTION
This PR is corollary of the selenium tests migration effort. This particular PR focus on tests for date attributes widgets. For more detauls see:
https://issues.jboss.org/browse/BAQE-381

@manstis this PR is dependent on #863 . I will mark this as ready for review & merge once we get those in.
