### PR TITLE
[do not merge] DROOLS-2623: Stabilize xls decision table tests

### DIFF
--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
@@ -317,5 +317,18 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables combine.children="append">
+            <drools.dateformat>dd-MM-yyyy</drools.dateformat>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilities.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilities.java
@@ -41,8 +41,7 @@ public class DTCellValueUtilities {
 
         /**
          * Called when a conversion error occurred.
-         *
-         * @param value    The value being converted.
+         * @param value The value being converted.
          * @param dataType The target data-type to which the value is being converted.
          */
         void onConversionError(final String value,
@@ -55,7 +54,6 @@ public class DTCellValueUtilities {
      * associated with the Cell Value can be incorrect for legacy models. For
      * pre-5.2 they will always be String and for pre-5.4 numerical fields are
      * always Numeric
-     *
      * @param type
      * @param dcv
      */
@@ -66,7 +64,7 @@ public class DTCellValueUtilities {
             return;
         }
 
-        //If already converted exit
+        // If already converted exit
         final DataType.DataTypes dataType = convertToTypeSafeType(type);
         if (dataType.equals(dcv.getDataType())) {
             return;

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
@@ -28,34 +28,14 @@ import org.drools.workbench.screens.dtablexls.service.DecisionTableXLSService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.guvnor.test.CDITestSetup;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 
 public class DecisionTableXLSServiceImplCDITest extends CDITestSetup {
 
     private DecisionTableXLSService xlsService;
-
-    private static String droolsDateFormat;
-
-    @BeforeClass
-    public static void setUpDateTimeFormat() {
-        droolsDateFormat = System.getProperty(ApplicationPreferences.DATE_FORMAT);
-        System.setProperty(ApplicationPreferences.DATE_FORMAT, "dd-MM-yyyy");
-    }
-
-    @AfterClass
-    public static void clearDateTimeFormat() {
-        if (droolsDateFormat != null) {
-            System.setProperty(ApplicationPreferences.DATE_FORMAT, droolsDateFormat);
-        } else {
-            System.clearProperty(ApplicationPreferences.DATE_FORMAT);
-        }
-    }
 
     @Before
     public void setUp() throws Exception {

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesStripQuotesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesStripQuotesTest.java
@@ -16,31 +16,11 @@
 
 package org.drools.workbench.screens.dtablexls.backend.server.conversion;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 
 import static org.junit.Assert.assertEquals;
 
 public class DTCellValueUtilitiesStripQuotesTest {
-
-    private static final String DATE_FORMAT = "dd/mm/yyyy";
-
-    @BeforeClass
-    public static void setup() {
-        setupPreferences();
-    }
-
-    private static void setupPreferences() {
-        final Map<String, String> preferences = new HashMap<String, String>() {{
-            put(ApplicationPreferences.DATE_FORMAT,
-                DATE_FORMAT);
-        }};
-        ApplicationPreferences.setUp(preferences);
-    }
 
     @Test
     // This test is in it's own class since DTCellValueUtilitiesTest is @Parameterized

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
@@ -37,7 +37,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class DTCellValueUtilitiesTest {
 
-    private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(SystemProperties.getProperty(ApplicationPreferences.DATE_FORMAT));
+    private static final String DATE_FORMAT = SystemProperties.getProperty(ApplicationPreferences.DATE_FORMAT);
+    private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
 
     private String type;
     private DTCellValue52 provided;
@@ -100,12 +101,13 @@ public class DTCellValueUtilitiesTest {
 
     @Test
     public void conversion() {
+        final String message = type + " " + "should equal to " + provided.getDataType().name();
+
         DTCellValueUtilities
                 .assertDTCellValue(type,
                                    provided,
-                                   (final String value, final DataType.DataTypes dataType) ->
-                                           assertTrue(type + " should equal to " + provided.getDataType().name(),
-                                                      hasConversionError));
+                                   (final String value,
+                                    final DataType.DataTypes dataType) -> assertTrue(message, hasConversionError));
         assertEquals(expectedDataType,
                      provided.getDataType());
         assertEquals(expectedValue,

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
@@ -22,11 +22,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
+import org.apache.xmlbeans.SystemProperties;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,28 +37,13 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class DTCellValueUtilitiesTest {
 
-    private static final String DATE_FORMAT = "dd/mm/yyyy";
-
-    private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
+    private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(SystemProperties.getProperty(ApplicationPreferences.DATE_FORMAT));
 
     private String type;
     private DTCellValue52 provided;
     private DataType.DataTypes expectedDataType;
     private Object expectedValue;
     private boolean hasConversionError;
-
-    @BeforeClass
-    public static void setup() {
-        setupPreferences();
-    }
-
-    private static void setupPreferences() {
-        final Map<String, String> preferences = new HashMap<String, String>() {{
-            put(ApplicationPreferences.DATE_FORMAT,
-                DATE_FORMAT);
-        }};
-        ApplicationPreferences.setUp(preferences);
-    }
 
     public DTCellValueUtilitiesTest(final String type,
                                     final DTCellValue52 provided,
@@ -87,7 +70,7 @@ public class DTCellValueUtilitiesTest {
                 {DataType.TYPE_NUMERIC_LONG, new DTCellValue52("100"), DataType.DataTypes.NUMERIC_LONG, 100l, false},
                 {DataType.TYPE_NUMERIC_SHORT, new DTCellValue52("100"), DataType.DataTypes.NUMERIC_SHORT, new Short("100"), false},
                 {DataType.TYPE_BOOLEAN, new DTCellValue52("true"), DataType.DataTypes.BOOLEAN, true, false},
-                {DataType.TYPE_DATE, new DTCellValue52("31/12/2016"), DataType.DataTypes.DATE, FORMATTER.parse("31/12/2016"), false},
+                {DataType.TYPE_DATE, new DTCellValue52("31-12-2016"), DataType.DataTypes.DATE, FORMATTER.parse("31-12-2016"), false},
                 {DataType.TYPE_STRING, new DTCellValue52("String"), DataType.DataTypes.STRING, "String", false},
 
                 {DataType.TYPE_NUMERIC, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_BIGDECIMAL, new BigDecimal(100), false},
@@ -99,7 +82,7 @@ public class DTCellValueUtilitiesTest {
                 {DataType.TYPE_NUMERIC_INTEGER, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_INTEGER, 100, false},
                 {DataType.TYPE_NUMERIC_LONG, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_LONG, 100l, false},
                 {DataType.TYPE_NUMERIC_SHORT, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_SHORT, new Short("100"), false},
-                {DataType.TYPE_DATE, new DTCellValue52("\"31/12/2016\""), DataType.DataTypes.DATE, FORMATTER.parse("31/12/2016"), false},
+                {DataType.TYPE_DATE, new DTCellValue52("\"31-12-2016\""), DataType.DataTypes.DATE, FORMATTER.parse("31-12-2016"), false},
 
                 {DataType.TYPE_NUMERIC, new DTCellValue52("a"), DataType.DataTypes.NUMERIC_BIGDECIMAL, null, true},
                 {DataType.TYPE_NUMERIC_BIGDECIMAL, new DTCellValue52("a"), DataType.DataTypes.NUMERIC_BIGDECIMAL, null, true},
@@ -117,10 +100,12 @@ public class DTCellValueUtilitiesTest {
 
     @Test
     public void conversion() {
-        DTCellValueUtilities.assertDTCellValue(type,
-                                               provided,
-                                               (final String value,
-                                                final DataType.DataTypes dataType) -> assertTrue(hasConversionError));
+        DTCellValueUtilities
+                .assertDTCellValue(type,
+                                   provided,
+                                   (final String value, final DataType.DataTypes dataType) ->
+                                           assertTrue(type + " should equal to " + provided.getDataType().name(),
+                                                      hasConversionError));
         assertEquals(expectedDataType,
                      provided.getDataType());
         assertEquals(expectedValue,

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
@@ -25,17 +25,26 @@ import java.util.Collection;
 
 import org.apache.xmlbeans.SystemProperties;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Parameterized.class)
 public class DTCellValueUtilitiesTest {
+
+    @Mock
+    private DTCellValueUtilities.ConversionErrorCallback conversionErrorCallback;
 
     private static final String DATE_FORMAT = SystemProperties.getProperty(ApplicationPreferences.DATE_FORMAT);
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
@@ -99,15 +108,22 @@ public class DTCellValueUtilitiesTest {
         });
     }
 
+    @Before
+    public void initMock() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
     @Test
     public void conversion() {
-        final String message = type + " " + "should equal to " + provided.getDataType().name();
+        DTCellValueUtilities.assertDTCellValue(type,
+                                               provided,
+                                               conversionErrorCallback);
+        if (hasConversionError) {
+            verify(conversionErrorCallback).onConversionError(anyString(), any(DataType.DataTypes.class));
+        } else {
+            verifyZeroInteractions(conversionErrorCallback);
+        }
 
-        DTCellValueUtilities
-                .assertDTCellValue(type,
-                                   provided,
-                                   (final String value,
-                                    final DataType.DataTypes dataType) -> assertTrue(message, hasConversionError));
         assertEquals(expectedDataType,
                      provided.getDataType());
         assertEquals(expectedValue,

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
@@ -45,7 +45,6 @@ import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.soup.project.datamodel.oracle.PackageDataModelOracle;
 import org.kie.workbench.common.screens.datamodeller.service.DataModelerService;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.kie.workbench.common.services.shared.project.ProjectImportsService;
@@ -121,16 +120,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
 
     @BeforeClass
     public static void setup() {
-        setupPreferences();
         setupSystemProperties();
-    }
-
-    private static void setupPreferences() {
-        final Map<String, String> preferences = new HashMap<String, String>() {{
-            put(ApplicationPreferences.DATE_FORMAT,
-                "dd/mm/yyyy");
-        }};
-        ApplicationPreferences.setUp(preferences);
     }
 
     private static void setupSystemProperties() {

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTableGeneratorListenerTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTableGeneratorListenerTest.java
@@ -63,7 +63,6 @@ import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.FieldAccessorsAndMutators;
 import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.soup.project.datamodel.oracle.PackageDataModelOracle;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
@@ -86,16 +85,7 @@ public class GuidedDecisionTableGeneratorListenerTest {
 
     @BeforeClass
     public static void setup() {
-        setupPreferences();
         setupSystemProperties();
-    }
-
-    private static void setupPreferences() {
-        final Map<String, String> preferences = new HashMap<String, String>() {{
-            put(ApplicationPreferences.DATE_FORMAT,
-                "dd/mm/yyyy");
-        }};
-        ApplicationPreferences.setUp(preferences);
     }
 
     private static void setupSystemProperties() {


### PR DESCRIPTION
Unify drools date format initialization to get tests not affecting each other
