### PR TITLE
Revert "AF-980: Indexing: Improve on false negatives during parallel Unit Test execution."

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.drltext.type.DRLResourceTypeDefinition;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameAndValueTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.drltext.type.DRLResourceTypeDefinition;
@@ -40,7 +38,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -49,7 +47,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexRuleInvalidDrlTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.drltext.type.DRLResourceTypeDefinition;
@@ -39,7 +37,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleMultipleTypesTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.drltext.type.DRLResourceTypeDefinition;
@@ -39,7 +37,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTypeTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.drltext.type.DRLResourceTypeDefinition;
@@ -40,7 +38,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTypeTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDefaultPackageDslEntriesTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDefaultPackageDslEntriesTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.dsltext.type.DSLResourceTypeDefinition;
@@ -41,7 +39,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDefaultPackageDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslEntriesTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslEntriesTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.dsltext.type.DSLResourceTypeDefinition;
@@ -41,7 +39,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -45,7 +43,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexDslInvalidDrlTest extends BaseIndexingTest<DSLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueCompositionTest.java
@@ -24,8 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
@@ -42,7 +40,6 @@ import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDecisionTableXLSAttributeNameAndValueCompositionTest extends BaseIndexingTest<DecisionTableXLSResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueTest.java
@@ -22,8 +22,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -40,7 +38,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDecisionTableXLSAttributeNameAndValueTest extends BaseIndexingTest<DecisionTableXLSResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameTest.java
@@ -22,8 +22,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.dtablexls.type.DecisionTableXLSResourceTypeDefinition;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDecisionTableXLSAttributeNameTest extends BaseIndexingTest<DecisionTableXLSResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSInvalidDrlTest.java
@@ -22,8 +22,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -48,7 +46,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexDecisionTableXLSInvalidDrlTest extends BaseIndexingTest<DecisionTableXLSResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSMultipleTypesTest.java
@@ -22,8 +22,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.dtablexls.type.DecisionTableXLSResourceTypeDefinition;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexDecisionTableXLSMultipleTypesTest extends BaseIndexingTest<DecisionTableXLSResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/EnumServiceImplCDITest.java
@@ -20,8 +20,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.enums.service.EnumService;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
@@ -32,7 +30,6 @@ import org.junit.Test;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 
-@NotThreadSafe
 public class EnumServiceImplCDITest extends CDITestSetup {
 
     private EnumService enumService;

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/indexing/IndexEnumEntriesTest.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/indexing/IndexEnumEntriesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.enums.type.EnumResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Model;
@@ -36,7 +34,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexEnumEntriesTest extends BaseIndexingTest<EnumResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/indexing/IndexGlobalsInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/indexing/IndexGlobalsInvalidDrlTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -44,11 +42,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexGlobalsInvalidDrlTest extends BaseIndexingTest<GlobalResourceTypeDefinition> {
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testIndexGlobalsInvalidDrl() throws IOException, InterruptedException {
         //Setup logging
         final Logger root = (Logger) LoggerFactory.getLogger( Logger.ROOT_LOGGER_NAME );

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/indexing/IndexGlobalsTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/indexing/IndexGlobalsTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.globals.type.GlobalResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -34,7 +32,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGlobalsTest extends BaseIndexingTest<GlobalResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableActionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableActionsTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableAttributesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableAttributesTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableAttributesTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentActionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableBRLFragmentActionsTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableBRLFragmentConditionsTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableConditionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableConditionsTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableGraphFileTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableGraphFileTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.dtable.backend.server.GuidedDTGraphXMLPersistence;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
@@ -36,7 +34,6 @@ import org.uberfire.backend.server.util.Paths;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedDecisionTableGraphFileTest extends BaseIndexingTest<GuidedDTableGraphResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -45,7 +43,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexRuleInvalidDrlTest extends BaseIndexingTest<GuidedDTreeResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -34,7 +32,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedDTreeResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTest extends BaseIndexingTest<GuidedDTreeResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTypeTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTypeTest extends BaseIndexingTest<GuidedDTreeResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -34,7 +32,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -37,7 +35,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameAndValueTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleAttributeNameTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -46,7 +44,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@NotThreadSafe
 public class IndexRuleInvalidDrlTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -34,7 +32,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTypeTest.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.guvnor.common.services.project.categories.Decision;
@@ -35,7 +33,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexRuleTypeTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/indexing/IndexGuidedScoreCardTest.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/indexing/IndexGuidedScoreCardTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.scorecard.backend.GuidedScoreCardXMLPersistence;
 import org.drools.workbench.models.guided.scorecard.shared.ScoreCardModel;
@@ -40,7 +38,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedScoreCardTest extends BaseIndexingTest<GuidedScoreCardResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateActionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.template.backend.RuleTemplateModelXMLPersistenceImpl;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedRuleTemplateActionsTest extends BaseIndexingTest<GuidedRuleTemplateResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateAttributesTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateAttributesTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.template.backend.RuleTemplateModelXMLPersistenceImpl;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
@@ -39,7 +37,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedRuleTemplateAttributesTest extends BaseIndexingTest<GuidedRuleTemplateResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateConditionsTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.guided.template.backend.RuleTemplateModelXMLPersistenceImpl;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
@@ -38,7 +36,6 @@ import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 
-@NotThreadSafe
 public class IndexGuidedRuleTemplateConditionsTest extends BaseIndexingTest<GuidedRuleTemplateResourceTypeDefinition> {
 
     @Test

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 import org.apache.lucene.search.Query;
 import org.drools.workbench.models.testscenarios.backend.util.ScenarioXMLPersistence;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
@@ -40,7 +38,6 @@ import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.workbench.category.Others;
 
-@NotThreadSafe
 public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResourceTypeDefinition> {
 
     @Test


### PR DESCRIPTION
See https://github.com/kiegroup/drools-wb/pull/801#issuecomment-399897253

This reverts commit 4e6455fd98078d07b8ad9c16ad45c3abd4b1f1b3.