### PR TITLE
AF-1248: Add profile to enable skipping of gwt compilation of showcases

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -95,7 +95,7 @@
       <artifactId>kie-wb-common-wf-sdm-extensions</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
     <!-- dependencies added because of new illegal transitive dependency check -->
     <dependency>
       <groupId>org.apache.lucene</groupId>
@@ -1330,4 +1330,21 @@
 
   </build>
 
+  <profiles>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Hello @manstis,

I'm introducing a new profile that will enable to skip gwt compilation of showcases in `downstream-pullrequests` jobs. In normal build, nothing is skipped. Only when you add `-Pno-showcase` to mvn command line, the showcases won't be gwt-compiled.

Part of an ensemble:
https://github.com/kiegroup/jbpm-wb/pull/1160
https://github.com/kiegroup/kie-wb-common/pull/1917
https://github.com/kiegroup/drools-wb/pull/877
https://github.com/kiegroup/appformer/pull/401