### PR TITLE
[6.5.x] GUVNOR-3244 (RHBRMS-3103): [GSS] (6.4.z) "Parameter named 'fieldName' should be not null" when indexing a GDST with BRL fragment eval

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedRuleModelIndexVisitor.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedRuleModelIndexVisitor.java
@@ -45,6 +45,8 @@ import org.kie.workbench.common.services.refactoring.model.index.terms.valueterm
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.commons.validation.PortablePreconditions;
 
@@ -53,208 +55,219 @@ import org.uberfire.commons.validation.PortablePreconditions;
  */
 public class GuidedRuleModelIndexVisitor {
 
+    private static final Logger logger = LoggerFactory.getLogger(GuidedRuleModelIndexVisitor.class);
+
     private final DefaultIndexBuilder builder;
     private final RuleModel model;
 
-    public GuidedRuleModelIndexVisitor( final DefaultIndexBuilder builder,
-                                        final RuleModel model ) {
-        this.builder = PortablePreconditions.checkNotNull( "builder",
-                                                           builder );
-        this.model = PortablePreconditions.checkNotNull( "model",
-                                                         model );
+    public GuidedRuleModelIndexVisitor(final DefaultIndexBuilder builder,
+                                       final RuleModel model) {
+        this.builder = PortablePreconditions.checkNotNull("builder",
+                                                          builder);
+        this.model = PortablePreconditions.checkNotNull("model",
+                                                        model);
     }
 
     public Set<Pair<String, String>> visit() {
-        visit( model );
+        visit(model);
         return builder.build();
     }
 
-    private void visit( final Object o ) {
-        if ( o instanceof RuleModel ) {
-            visitRuleModel( (RuleModel) o );
-        } else if ( o instanceof RuleAttribute ) {
-            visitRuleAttribute( (RuleAttribute) o );
-        } else if ( o instanceof FactPattern ) {
-            visitFactPattern( (FactPattern) o );
-        } else if ( o instanceof CompositeFieldConstraint ) {
-            visitCompositeFieldConstraint( (CompositeFieldConstraint) o );
-        } else if ( o instanceof SingleFieldConstraintEBLeftSide ) {
-            visitSingleFieldConstraint( (SingleFieldConstraintEBLeftSide) o );
-        } else if ( o instanceof SingleFieldConstraint ) {
-            visitSingleFieldConstraint( (SingleFieldConstraint) o );
-        } else if ( o instanceof ConnectiveConstraint ) {
-            visitConnectiveConstraint( (ConnectiveConstraint) o );
-        } else if ( o instanceof CompositeFactPattern ) {
-            visitCompositeFactPattern( (CompositeFactPattern) o );
-        } else if ( o instanceof FreeFormLine ) {
-            visitFreeFormLine( (FreeFormLine) o );
-        } else if ( o instanceof FromAccumulateCompositeFactPattern ) {
-            visitFromAccumulateCompositeFactPattern( (FromAccumulateCompositeFactPattern) o );
-        } else if ( o instanceof FromCollectCompositeFactPattern ) {
-            visitFromCollectCompositeFactPattern( (FromCollectCompositeFactPattern) o );
-        } else if ( o instanceof FromCompositeFactPattern ) {
-            visitFromCompositeFactPattern( (FromCompositeFactPattern) o );
-        } else if ( o instanceof DSLSentence ) {
-            visitDSLSentence( (DSLSentence) o );
-        } else if ( o instanceof ActionInsertFact ) {
-            visitActionFieldList( (ActionInsertFact) o );
+    private void visit(final Object o) {
+        if (o instanceof RuleModel) {
+            visitRuleModel((RuleModel) o);
+        } else if (o instanceof RuleAttribute) {
+            visitRuleAttribute((RuleAttribute) o);
+        } else if (o instanceof FactPattern) {
+            visitFactPattern((FactPattern) o);
+        } else if (o instanceof CompositeFieldConstraint) {
+            visitCompositeFieldConstraint((CompositeFieldConstraint) o);
+        } else if (o instanceof SingleFieldConstraintEBLeftSide) {
+            visitSingleFieldConstraint((SingleFieldConstraintEBLeftSide) o);
+        } else if (o instanceof SingleFieldConstraint) {
+            visitSingleFieldConstraint((SingleFieldConstraint) o);
+        } else if (o instanceof ConnectiveConstraint) {
+            visitConnectiveConstraint((ConnectiveConstraint) o);
+        } else if (o instanceof CompositeFactPattern) {
+            visitCompositeFactPattern((CompositeFactPattern) o);
+        } else if (o instanceof FreeFormLine) {
+            visitFreeFormLine((FreeFormLine) o);
+        } else if (o instanceof FromAccumulateCompositeFactPattern) {
+            visitFromAccumulateCompositeFactPattern((FromAccumulateCompositeFactPattern) o);
+        } else if (o instanceof FromCollectCompositeFactPattern) {
+            visitFromCollectCompositeFactPattern((FromCollectCompositeFactPattern) o);
+        } else if (o instanceof FromCompositeFactPattern) {
+            visitFromCompositeFactPattern((FromCompositeFactPattern) o);
+        } else if (o instanceof DSLSentence) {
+            visitDSLSentence((DSLSentence) o);
+        } else if (o instanceof ActionInsertFact) {
+            visitActionFieldList((ActionInsertFact) o);
         }
     }
 
-    private void visitRuleAttribute( final RuleAttribute attr ) {
-        builder.addGenerator( new org.kie.workbench.common.services.refactoring.model.index.RuleAttribute( new ValueRuleAttributeIndexTerm( attr.getAttributeName() ),
-                                                                                                           new ValueRuleAttributeValueIndexTerm( attr.getValue() ) ) );
+    private void visitRuleAttribute(final RuleAttribute attr) {
+        builder.addGenerator(new org.kie.workbench.common.services.refactoring.model.index.RuleAttribute(new ValueRuleAttributeIndexTerm(attr.getAttributeName()),
+                                                                                                         new ValueRuleAttributeValueIndexTerm(attr.getValue())));
     }
 
     //ActionInsertFact, ActionSetField, ActionUpdateField
-    private void visitActionFieldList( final ActionInsertFact afl ) {
-        builder.addGenerator( new Type( new ValueTypeIndexTerm( getFullyQualifiedClassName( afl.getFactType() ) ) ) );
+    private void visitActionFieldList(final ActionInsertFact afl) {
+        builder.addGenerator(new Type(new ValueTypeIndexTerm(getFullyQualifiedClassName(afl.getFactType()))));
     }
 
-    private void visitActionFieldList( final String fullyQualifiedClassName,
-                                       final ActionSetField afl ) {
-        for ( ActionFieldValue afv : afl.getFieldValues() ) {
-            visit( fullyQualifiedClassName,
-                   afv );
+    private void visitActionFieldList(final String fullyQualifiedClassName,
+                                      final ActionSetField afl) {
+        for (ActionFieldValue afv : afl.getFieldValues()) {
+            visit(fullyQualifiedClassName,
+                  afv);
         }
     }
 
-    private void visitCompositeFactPattern( final CompositeFactPattern pattern ) {
-        builder.addGenerator( new Type( new ValueTypeIndexTerm( getFullyQualifiedClassName( pattern.getType() ) ) ) );
-        if ( pattern.getPatterns() != null ) {
-            for ( IFactPattern fp : pattern.getPatterns() ) {
-                visit( fp );
+    private void visitCompositeFactPattern(final CompositeFactPattern pattern) {
+        builder.addGenerator(new Type(new ValueTypeIndexTerm(getFullyQualifiedClassName(pattern.getType()))));
+        if (pattern.getPatterns() != null) {
+            for (IFactPattern fp : pattern.getPatterns()) {
+                visit(fp);
             }
         }
     }
 
-    private void visitCompositeFieldConstraint( final CompositeFieldConstraint cfc ) {
-        if ( cfc.getConstraints() != null ) {
-            for ( int i = 0; i < cfc.getConstraints().length; i++ ) {
-                FieldConstraint fc = cfc.getConstraints()[ i ];
-                visit( fc );
+    private void visitCompositeFieldConstraint(final CompositeFieldConstraint cfc) {
+        if (cfc.getConstraints() != null) {
+            for (int i = 0; i < cfc.getConstraints().length; i++) {
+                FieldConstraint fc = cfc.getConstraints()[i];
+                visit(fc);
             }
         }
     }
 
-    private void visitDSLSentence( final DSLSentence sentence ) {
+    private void visitDSLSentence(final DSLSentence sentence) {
         //TODO - Index DSLSentences
     }
 
-    private void visitFactPattern( final FactPattern pattern ) {
-        builder.addGenerator( new Type( new ValueTypeIndexTerm( getFullyQualifiedClassName( pattern.getFactType() ) ) ) );
-        for ( FieldConstraint fc : pattern.getFieldConstraints() ) {
-            visit( fc );
+    private void visitFactPattern(final FactPattern pattern) {
+        builder.addGenerator(new Type(new ValueTypeIndexTerm(getFullyQualifiedClassName(pattern.getFactType()))));
+        for (FieldConstraint fc : pattern.getFieldConstraints()) {
+            visit(fc);
         }
     }
 
-    private void visitFreeFormLine( final FreeFormLine ffl ) {
+    private void visitFreeFormLine(final FreeFormLine ffl) {
         //TODO - Index FreeFormLines
     }
 
-    private void visitFromAccumulateCompositeFactPattern( final FromAccumulateCompositeFactPattern pattern ) {
-        visit( pattern.getFactPattern() );
-        visit( pattern.getExpression() );
-        visit( pattern.getSourcePattern() );
+    private void visitFromAccumulateCompositeFactPattern(final FromAccumulateCompositeFactPattern pattern) {
+        visit(pattern.getFactPattern());
+        visit(pattern.getExpression());
+        visit(pattern.getSourcePattern());
     }
 
-    private void visitFromCollectCompositeFactPattern( final FromCollectCompositeFactPattern pattern ) {
-        visit( pattern.getExpression() );
-        visit( pattern.getFactPattern() );
-        visit( pattern.getRightPattern() );
+    private void visitFromCollectCompositeFactPattern(final FromCollectCompositeFactPattern pattern) {
+        visit(pattern.getExpression());
+        visit(pattern.getFactPattern());
+        visit(pattern.getRightPattern());
     }
 
-    private void visitFromCompositeFactPattern( final FromCompositeFactPattern pattern ) {
-        visit( pattern.getExpression() );
-        visit( pattern.getFactPattern() );
+    private void visitFromCompositeFactPattern(final FromCompositeFactPattern pattern) {
+        visit(pattern.getExpression());
+        visit(pattern.getFactPattern());
     }
 
-    public void visitRuleModel( final RuleModel model ) {
-        if ( model.attributes != null ) {
-            for ( int i = 0; i < model.attributes.length; i++ ) {
-                RuleAttribute attr = model.attributes[ i ];
-                visit( attr );
+    public void visitRuleModel(final RuleModel model) {
+        if (model.attributes != null) {
+            for (int i = 0; i < model.attributes.length; i++) {
+                RuleAttribute attr = model.attributes[i];
+                visit(attr);
             }
         }
-        if ( model.lhs != null ) {
-            for ( int i = 0; i < model.lhs.length; i++ ) {
-                IPattern pattern = model.lhs[ i ];
-                visit( pattern );
+        if (model.lhs != null) {
+            for (int i = 0; i < model.lhs.length; i++) {
+                IPattern pattern = model.lhs[i];
+                visit(pattern);
             }
         }
-        if ( model.rhs != null ) {
-            for ( int i = 0; i < model.rhs.length; i++ ) {
-                IAction action = model.rhs[ i ];
-                if ( action instanceof ActionSetField ) {
+        if (model.rhs != null) {
+            for (int i = 0; i < model.rhs.length; i++) {
+                IAction action = model.rhs[i];
+                if (action instanceof ActionSetField) {
                     final ActionSetField asf = (ActionSetField) action;
-                    final String typeName = getTypeNameForBinding( asf.getVariable() );
-                    if ( typeName != null ) {
-                        final String fullyQualifiedClassName = getFullyQualifiedClassName( typeName );
-                        visitActionFieldList( fullyQualifiedClassName,
-                                              asf );
+                    final String typeName = getTypeNameForBinding(asf.getVariable());
+                    if (typeName != null) {
+                        final String fullyQualifiedClassName = getFullyQualifiedClassName(typeName);
+                        visitActionFieldList(fullyQualifiedClassName,
+                                             asf);
                     }
                 } else {
-                    visit( action );
+                    visit(action);
                 }
             }
         }
     }
 
-    private String getTypeNameForBinding( final String binding ) {
-        if ( model.getAllLHSVariables().contains( binding ) ) {
-            return model.getLHSBindingType( binding );
-        } else if ( model.getAllRHSVariables().contains( binding ) ) {
-            return model.getRHSBoundFact( binding ).getFactType();
+    private String getTypeNameForBinding(final String binding) {
+        if (model.getAllLHSVariables().contains(binding)) {
+            return model.getLHSBindingType(binding);
+        } else if (model.getAllRHSVariables().contains(binding)) {
+            return model.getRHSBoundFact(binding).getFactType();
         }
         return null;
     }
 
-    private void visitSingleFieldConstraint( final SingleFieldConstraint sfc ) {
-        builder.addGenerator( new TypeField( new ValueFieldIndexTerm( sfc.getFieldName() ),
-                                             new ValueTypeIndexTerm( getFullyQualifiedClassName( sfc.getFieldType() ) ),
-                                             new ValueTypeIndexTerm( getFullyQualifiedClassName( sfc.getFactType() ) ) ) );
-        if ( sfc.getConnectives() != null ) {
-            for ( int i = 0; i < sfc.getConnectives().length; i++ ) {
-                visit( sfc.getConnectives()[ i ] );
+    private void visitSingleFieldConstraint(final SingleFieldConstraint sfc) {
+        final String fieldName = sfc.getFieldName();
+        final String fieldType = getFullyQualifiedClassName(sfc.getFieldType());
+        final String factType = getFullyQualifiedClassName(sfc.getFactType());
+        if (fieldName != null && fieldType != null && factType != null) {
+            builder.addGenerator(new TypeField(new ValueFieldIndexTerm(fieldName),
+                                               new ValueTypeIndexTerm(fieldType),
+                                               new ValueTypeIndexTerm(factType)));
+        } else {
+            logger.info("Unable to index constraint FactType[" + factType + "], FieldName[" + fieldName + "], FieldType[" + fieldType + "]. Skipping.");
+        }
+        if (sfc.getConnectives() != null) {
+            for (int i = 0; i < sfc.getConnectives().length; i++) {
+                visit(sfc.getConnectives()[i]);
             }
         }
     }
 
-    private void visitConnectiveConstraint( final ConnectiveConstraint cc ) {
-        builder.addGenerator( new TypeField( new ValueFieldIndexTerm( cc.getFieldName() ),
-                                             new ValueTypeIndexTerm( getFullyQualifiedClassName( cc.getFieldType() ) ),
-                                             new ValueTypeIndexTerm( getFullyQualifiedClassName( cc.getFactType() ) ) ) );
+    private void visitConnectiveConstraint(final ConnectiveConstraint cc) {
+        builder.addGenerator(new TypeField(new ValueFieldIndexTerm(cc.getFieldName()),
+                                           new ValueTypeIndexTerm(getFullyQualifiedClassName(cc.getFieldType())),
+                                           new ValueTypeIndexTerm(getFullyQualifiedClassName(cc.getFactType()))));
     }
 
-    private void visitSingleFieldConstraint( final SingleFieldConstraintEBLeftSide sfexp ) {
-        visit( sfexp.getExpressionLeftSide() );
-        visit( sfexp.getExpressionValue() );
-        if ( sfexp.getConnectives() != null ) {
-            for ( int i = 0; i < sfexp.getConnectives().length; i++ ) {
-                visit( sfexp.getConnectives()[ i ] );
+    private void visitSingleFieldConstraint(final SingleFieldConstraintEBLeftSide sfexp) {
+        visit(sfexp.getExpressionLeftSide());
+        visit(sfexp.getExpressionValue());
+        if (sfexp.getConnectives() != null) {
+            for (int i = 0; i < sfexp.getConnectives().length; i++) {
+                visit(sfexp.getConnectives()[i]);
             }
         }
     }
 
-    private void visit( final String fullyQualifiedClassName,
-                        final ActionFieldValue afv ) {
-        builder.addGenerator( new TypeField( new ValueFieldIndexTerm( afv.getField() ),
-                                             new ValueTypeIndexTerm( getFullyQualifiedClassName( afv.getType() ) ),
-                                             new ValueTypeIndexTerm( fullyQualifiedClassName ) ) );
+    private void visit(final String fullyQualifiedClassName,
+                       final ActionFieldValue afv) {
+        builder.addGenerator(new TypeField(new ValueFieldIndexTerm(afv.getField()),
+                                           new ValueTypeIndexTerm(getFullyQualifiedClassName(afv.getType())),
+                                           new ValueTypeIndexTerm(fullyQualifiedClassName)));
     }
 
-    private String getFullyQualifiedClassName( final String typeName ) {
-        if ( typeName.contains( "." ) ) {
+    private String getFullyQualifiedClassName(final String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+        if (typeName.contains(".")) {
             return typeName;
         }
 
-        for ( Import i : model.getImports().getImports() ) {
-            if ( i.getType().endsWith( typeName ) ) {
+        for (Import i : model.getImports().getImports()) {
+            if (i.getType().endsWith(typeName)) {
                 return i.getType();
             }
         }
         final String packageName = model.getPackageName();
-        return ( !( packageName == null || packageName.isEmpty() ) ? packageName + "." + typeName : typeName );
+        return (!(packageName == null || packageName.isEmpty()) ? packageName + "." + typeName : typeName);
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedRuleModelIndexVisitor.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedRuleModelIndexVisitor.java
@@ -222,7 +222,8 @@ public class GuidedRuleModelIndexVisitor {
                                                new ValueTypeIndexTerm(fieldType),
                                                new ValueTypeIndexTerm(factType)));
         } else {
-            logger.info("Unable to index constraint FactType[" + factType + "], FieldName[" + fieldName + "], FieldType[" + fieldType + "]. Skipping.");
+            final String rule = model.name == null ? "" : "of '" + model.name + "' ";
+            logger.info("Constraint " + rule + "has FactType, FieldName or FieldType that is null. Skipping indexing of constraint.");
         }
         if (sfc.getConnectives() != null) {
             for (int i = 0; i < sfc.getConnectives().length; i++) {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFactory.java
@@ -41,191 +41,227 @@ import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 
 public class GuidedDecisionTableFactory {
 
-    public static GuidedDecisionTable52 makeTableWithAttributeCol( final String packageName,
-                                                                   final Collection<Import> imports,
-                                                                   final String tableName ) {
+    public static GuidedDecisionTable52 makeTableWithAttributeCol(final String packageName,
+                                                                  final Collection<Import> imports,
+                                                                  final String tableName) {
         final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
-        dt.setPackageName( packageName );
-        dt.getImports().getImports().addAll( imports );
-        dt.setTableName( tableName );
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
 
         AttributeCol52 attr = new AttributeCol52();
-        attr.setAttribute( "ruleflow-group" );
-        dt.getAttributeCols().add( attr );
+        attr.setAttribute("ruleflow-group");
+        dt.getAttributeCols().add(attr);
 
-        dt.setData( DataUtilities.makeDataLists( new String[][]{
-                new String[]{ "1", "desc", "myRuleFlowGroup" }
-        } ) );
+        dt.setData(DataUtilities.makeDataLists(new String[][]{
+                new String[]{"1", "desc", "myRuleFlowGroup"}
+        }));
 
         return dt;
     }
 
-    public static GuidedDecisionTable52 makeTableWithConditionCol( final String packageName,
-                                                                   final Collection<Import> imports,
-                                                                   final String tableName ) {
+    public static GuidedDecisionTable52 makeTableWithConditionCol(final String packageName,
+                                                                  final Collection<Import> imports,
+                                                                  final String tableName) {
         final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
-        dt.setPackageName( packageName );
-        dt.getImports().getImports().addAll( imports );
-        dt.setTableName( tableName );
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
 
         Pattern52 p1 = new Pattern52();
-        p1.setBoundName( "$a" );
-        p1.setFactType( "Applicant" );
+        p1.setBoundName("$a");
+        p1.setFactType("Applicant");
 
         ConditionCol52 con1 = new ConditionCol52();
-        con1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
-        con1.setFieldType( DataType.TYPE_NUMERIC_INTEGER );
-        con1.setFactField( "age" );
-        con1.setHeader( "Applicant age" );
-        con1.setOperator( "==" );
-        p1.getChildColumns().add( con1 );
+        con1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        con1.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        con1.setFactField("age");
+        con1.setHeader("Applicant age");
+        con1.setOperator("==");
+        p1.getChildColumns().add(con1);
 
-        dt.getConditions().add( p1 );
+        dt.getConditions().add(p1);
 
         Pattern52 p2 = new Pattern52();
-        p2.setBoundName( "$m" );
-        p2.setFactType( "Mortgage" );
+        p2.setBoundName("$m");
+        p2.setFactType("Mortgage");
 
         ConditionCol52 con2 = new ConditionCol52();
-        con2.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
-        con2.setFieldType( DataType.TYPE_NUMERIC_INTEGER );
-        con2.setFactField( "amount" );
-        con2.setHeader( "Mortgage amount" );
-        con2.setOperator( "==" );
-        p2.getChildColumns().add( con2 );
+        con2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        con2.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        con2.setFactField("amount");
+        con2.setHeader("Mortgage amount");
+        con2.setOperator("==");
+        p2.getChildColumns().add(con2);
 
-        dt.getConditions().add( p2 );
+        dt.getConditions().add(p2);
 
-        dt.setData( DataUtilities.makeDataLists( new String[][]{
-                new String[]{ "1", "desc", "33", "" }
-        } ) );
+        dt.setData(DataUtilities.makeDataLists(new String[][]{
+                new String[]{"1", "desc", "33", ""}
+        }));
 
         return dt;
     }
 
-    public static GuidedDecisionTable52 makeTableWithActionCol( final String packageName,
-                                                                final Collection<Import> imports,
-                                                                final String tableName ) {
+    public static GuidedDecisionTable52 makeTableWithActionCol(final String packageName,
+                                                               final Collection<Import> imports,
+                                                               final String tableName) {
         final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
-        dt.setPackageName( packageName );
-        dt.getImports().getImports().addAll( imports );
-        dt.setTableName( tableName );
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
 
         ActionInsertFactCol52 ins = new ActionInsertFactCol52();
-        ins.setBoundName( "$i" );
-        ins.setFactType( "Applicant" );
-        ins.setFactField( "age" );
-        ins.setType( DataType.TYPE_NUMERIC_INTEGER );
-        dt.getActionCols().add( ins );
+        ins.setBoundName("$i");
+        ins.setFactType("Applicant");
+        ins.setFactField("age");
+        ins.setType(DataType.TYPE_NUMERIC_INTEGER);
+        dt.getActionCols().add(ins);
 
-        dt.setData( DataUtilities.makeDataLists( new String[][]{
-                new String[]{ "1", "desc", "33" }
-        } ) );
+        dt.setData(DataUtilities.makeDataLists(new String[][]{
+                new String[]{"1", "desc", "33"}
+        }));
 
         return dt;
     }
 
-    public static GuidedDecisionTable52 makeTableWithBRLFragmentConditionCol( final String packageName,
-                                                                              final Collection<Import> imports,
-                                                                              final String tableName ) {
+    public static GuidedDecisionTable52 makeTableWithBRLFragmentConditionCol(final String packageName,
+                                                                             final Collection<Import> imports,
+                                                                             final String tableName) {
         final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
-        dt.setPackageName( packageName );
-        dt.getImports().getImports().addAll( imports );
-        dt.setTableName( tableName );
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
 
         final BRLConditionColumn brl = new BRLConditionColumn();
 
         final FactPattern fp1 = new FactPattern();
-        fp1.setFactType( "Applicant" );
+        fp1.setFactType("Applicant");
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
-        sfc1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_TEMPLATE );
-        sfc1.setFactType( "Applicant" );
-        sfc1.setOperator( "==" );
-        sfc1.setFieldName( "age" );
-        sfc1.setValue( "f1" );
-        fp1.addConstraint( sfc1 );
+        sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        sfc1.setFactType("Applicant");
+        sfc1.setOperator("==");
+        sfc1.setFieldName("age");
+        sfc1.setValue("f1");
+        fp1.addConstraint(sfc1);
 
         final FactPattern fp2 = new FactPattern();
-        fp2.setFactType( "Mortgage" );
+        fp2.setFactType("Mortgage");
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
-        sfc2.setConstraintValueType( BaseSingleFieldConstraint.TYPE_TEMPLATE );
-        sfc2.setFactType( "Mortgage" );
-        sfc2.setOperator( "==" );
-        sfc2.setFieldName( "amount" );
-        sfc2.setValue( "f2" );
-        fp2.addConstraint( sfc2 );
+        sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_TEMPLATE);
+        sfc2.setFactType("Mortgage");
+        sfc2.setOperator("==");
+        sfc2.setFieldName("amount");
+        sfc2.setValue("f2");
+        fp2.addConstraint(sfc2);
 
-        brl.getDefinition().add( fp1 );
-        brl.getDefinition().add( fp2 );
-        brl.getChildColumns().add( new BRLConditionVariableColumn( "f1",
-                                                                   DataType.TYPE_NUMERIC_INTEGER ) );
-        brl.getChildColumns().add( new BRLConditionVariableColumn( "f2",
-                                                                   DataType.TYPE_NUMERIC_INTEGER ) );
-        dt.getConditions().add( brl );
+        brl.getDefinition().add(fp1);
+        brl.getDefinition().add(fp2);
+        brl.getChildColumns().add(new BRLConditionVariableColumn("f1",
+                                                                 DataType.TYPE_NUMERIC_INTEGER));
+        brl.getChildColumns().add(new BRLConditionVariableColumn("f2",
+                                                                 DataType.TYPE_NUMERIC_INTEGER));
+        dt.getConditions().add(brl);
 
-        dt.setData( DataUtilities.makeDataLists( new String[][]{
-                new String[]{ "1", "desc", "33", "" }
-        } ) );
+        dt.setData(DataUtilities.makeDataLists(new String[][]{
+                new String[]{"1", "desc", "33", ""}
+        }));
 
         return dt;
     }
 
-    public static GuidedDecisionTable52 makeTableWithBRLFragmentActionCol( final String packageName,
-                                                                           final Collection<Import> imports,
-                                                                           final String tableName ) {
+    public static GuidedDecisionTable52 makeTableWithBRLFragmentConditionColWithPredicate(final String packageName,
+                                                                                          final Collection<Import> imports,
+                                                                                          final String tableName) {
         final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
-        dt.setPackageName( packageName );
-        dt.getImports().getImports().addAll( imports );
-        dt.setTableName( tableName );
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
+
+        final BRLConditionColumn brl = new BRLConditionColumn();
+
+        final FactPattern fp1 = new FactPattern();
+        fp1.setFactType("Applicant");
+        final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
+        sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
+        sfc1.setValue("age = 45");
+        fp1.addConstraint(sfc1);
+
+        final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
+        sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        sfc2.setFactType("Applicant");
+        sfc2.setOperator("==");
+        sfc2.setFieldName("age");
+        sfc2.setValue("45");
+        fp1.addConstraint(sfc2);
+
+        brl.getDefinition().add(fp1);
+        brl.getChildColumns().add(new BRLConditionVariableColumn("f1",
+                                                                 DataType.TYPE_BOOLEAN));
+        dt.getConditions().add(brl);
+
+        dt.setData(DataUtilities.makeDataLists(new Object[][]{
+                new Object[]{"1", "desc", true}
+        }));
+
+        return dt;
+    }
+
+    public static GuidedDecisionTable52 makeTableWithBRLFragmentActionCol(final String packageName,
+                                                                          final Collection<Import> imports,
+                                                                          final String tableName) {
+        final GuidedDecisionTable52 dt = new GuidedDecisionTable52();
+        dt.setPackageName(packageName);
+        dt.getImports().getImports().addAll(imports);
+        dt.setTableName(tableName);
 
         final BRLActionColumn brl = new BRLActionColumn();
 
         final ActionInsertFact ifc1 = new ActionInsertFact();
-        ifc1.setFactType( "Applicant" );
-        ifc1.setBoundName( "$a" );
+        ifc1.setFactType("Applicant");
+        ifc1.setBoundName("$a");
         final ActionFieldValue afv1 = new ActionFieldValue();
-        afv1.setNature( FieldNatureType.TYPE_TEMPLATE );
-        afv1.setField( "age" );
-        afv1.setValue( "f1" );
-        ifc1.addFieldValue( afv1 );
+        afv1.setNature(FieldNatureType.TYPE_TEMPLATE);
+        afv1.setField("age");
+        afv1.setValue("f1");
+        ifc1.addFieldValue(afv1);
 
         final ActionInsertFact ifc2 = new ActionInsertFact();
-        ifc2.setFactType( "Mortgage" );
-        ifc2.setBoundName( "$m" );
+        ifc2.setFactType("Mortgage");
+        ifc2.setBoundName("$m");
         final ActionFieldValue afv2 = new ActionFieldValue();
-        afv2.setNature( FieldNatureType.TYPE_TEMPLATE );
-        afv2.setField( "amount" );
-        afv2.setValue( "f2" );
-        ifc2.addFieldValue( afv2 );
+        afv2.setNature(FieldNatureType.TYPE_TEMPLATE);
+        afv2.setField("amount");
+        afv2.setValue("f2");
+        ifc2.addFieldValue(afv2);
 
         final ActionSetField asf = new ActionSetField();
-        asf.setVariable( "$a" );
-        asf.addFieldValue( new ActionFieldValue( "age",
-                                                 "33",
-                                                 DataType.TYPE_NUMERIC_INTEGER ) );
+        asf.setVariable("$a");
+        asf.addFieldValue(new ActionFieldValue("age",
+                                               "33",
+                                               DataType.TYPE_NUMERIC_INTEGER));
 
         final ActionUpdateField auf = new ActionUpdateField();
-        asf.setVariable( "$m" );
-        asf.addFieldValue( new ActionFieldValue( "amount",
-                                                 "10000",
-                                                 DataType.TYPE_NUMERIC_INTEGER ) );
+        asf.setVariable("$m");
+        asf.addFieldValue(new ActionFieldValue("amount",
+                                               "10000",
+                                               DataType.TYPE_NUMERIC_INTEGER));
 
-        brl.getDefinition().add( ifc1 );
-        brl.getDefinition().add( ifc2 );
-        brl.getChildColumns().add( new BRLActionVariableColumn( "f1",
-                                                                DataType.TYPE_NUMERIC_INTEGER ) );
-        brl.getChildColumns().add( new BRLActionVariableColumn( "f2",
-                                                                DataType.TYPE_NUMERIC_INTEGER ) );
-        brl.getDefinition().add( asf );
-        brl.getDefinition().add( auf );
+        brl.getDefinition().add(ifc1);
+        brl.getDefinition().add(ifc2);
+        brl.getChildColumns().add(new BRLActionVariableColumn("f1",
+                                                              DataType.TYPE_NUMERIC_INTEGER));
+        brl.getChildColumns().add(new BRLActionVariableColumn("f2",
+                                                              DataType.TYPE_NUMERIC_INTEGER));
+        brl.getDefinition().add(asf);
+        brl.getDefinition().add(auf);
 
-        dt.getConditions().add( brl );
+        dt.getConditions().add(brl);
 
-        dt.setData( DataUtilities.makeDataLists( new String[][]{
-                new String[]{ "1", "desc", "33", "" }
-        } ) );
+        dt.setData(DataUtilities.makeDataLists(new String[][]{
+                new String[]{"1", "desc", "33", ""}
+        }));
 
         return dt;
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/GuidedDecisionTableFactory.java
@@ -182,18 +182,25 @@ public class GuidedDecisionTableFactory {
 
         final FactPattern fp1 = new FactPattern();
         fp1.setFactType("Applicant");
+
         final SingleFieldConstraint sfc1 = new SingleFieldConstraint();
-        sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
-        sfc1.setValue("age = 45");
+        sfc1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        sfc1.setFactType("Applicant");
+        sfc1.setFieldName("age");
+        sfc1.setFieldBinding("$age");
         fp1.addConstraint(sfc1);
 
         final SingleFieldConstraint sfc2 = new SingleFieldConstraint();
         sfc2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         sfc2.setFactType("Applicant");
-        sfc2.setOperator("==");
-        sfc2.setFieldName("age");
-        sfc2.setValue("45");
+        sfc2.setFieldName("height");
+        sfc2.setFieldBinding("$height");
         fp1.addConstraint(sfc2);
+
+        final SingleFieldConstraint sfc3 = new SingleFieldConstraint();
+        sfc3.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
+        sfc3.setValue("$age >= $height");
+        fp1.addConstraint(sfc3);
 
         brl.getDefinition().add(fp1);
         brl.getChildColumns().add(new BRLConditionVariableColumn("f1",

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.backend.server.indexing;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopScoreDocCollector;
+import org.drools.workbench.models.datamodel.imports.Import;
+import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.type.GuidedDTableResourceTypeDefinition;
+import org.junit.Test;
+import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
+import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
+import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
+import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+import org.uberfire.ext.metadata.backend.lucene.util.KObjectUtil;
+import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.java.nio.file.Path;
+
+import static org.apache.lucene.util.Version.LUCENE_40;
+import static org.junit.Assert.assertEquals;
+
+public class IndexGuidedDecisionTableBRLFragmentConditionsPredicateTest extends BaseIndexingTest<GuidedDTableResourceTypeDefinition> {
+
+    @Test
+    public void checkSingleFieldConstraintPredicate() throws IOException, InterruptedException {
+        //Add test files
+        final Path path = basePath.resolve("dtable1.gdst");
+        final GuidedDecisionTable52 model = GuidedDecisionTableFactory.makeTableWithBRLFragmentConditionColWithPredicate("org.drools.workbench.screens.guided.dtable.backend.server.indexing",
+                                                                                                                         new ArrayList<Import>() {{
+                                                                                                                             add(new Import("org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant"));
+                                                                                                                             add(new Import("org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage"));
+                                                                                                                         }},
+                                                                                                                         "dtable1");
+        final String xml = GuidedDTXMLPersistence.getInstance().marshal(model);
+        ioService().write(path,
+                          xml);
+
+        Thread.sleep(7500); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        final Index index = getConfig().getIndexManager().get(org.uberfire.ext.metadata.io.KObjectUtil.toKCluster(basePath.getFileSystem()));
+
+        {
+            final IndexSearcher searcher = ((LuceneIndex) index).nrtSearcher();
+            final TopScoreDocCollector collector = TopScoreDocCollector.create(10,
+                                                                               true);
+            final Query query = new BasicQueryBuilder()
+                    .addTerm(new ValueTypeIndexTerm("org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant"))
+                    .build();
+
+            searcher.search(query,
+                            collector);
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            assertEquals(1,
+                         hits.length);
+
+            final List<KObject> results = new ArrayList<KObject>();
+            for (int i = 0; i < hits.length; i++) {
+                results.add(KObjectUtil.toKObject(searcher.doc(hits[i].doc)));
+            }
+            assertContains(results,
+                           path);
+
+            ((LuceneIndex) index).nrtRelease(searcher);
+        }
+    }
+
+    @Override
+    protected TestIndexer getIndexer() {
+        return new TestGuidedDecisionTableFileIndexer();
+    }
+
+    @Override
+    public Map<String, Analyzer> getAnalyzers() {
+        return new HashMap<String, Analyzer>() {{
+            put(RuleAttributeIndexTerm.TERM,
+                new RuleAttributeNameAnalyzer(LUCENE_40));
+        }};
+    }
+
+    @Override
+    protected GuidedDTableResourceTypeDefinition getResourceTypeDefinition() {
+        return new GuidedDTableResourceTypeDefinition();
+    }
+
+    @Override
+    protected String getRepositoryName() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/classes/Applicant.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/classes/Applicant.java
@@ -19,8 +19,13 @@ public class Applicant {
 
     private int age;
 
+    private int height;
+
     public int getAge() {
         return age;
     }
 
+    public int getHeight() {
+        return height;
+    }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-3103

The fix for ```6.5.x``` is to skip constraints that cannot be indexed (vs throwing the NPE).

This is different to ```master``` as the codebases have diverged and ```master``` does not _visit_ the model. 