### PR TITLE
[master] AF-1226: Improve error handling displaying additional info to the GenericErrorPopup

### DIFF
--- a/drools-wb-webapp/src/main/java/org/drools/workbench/client/DroolsWorkbenchEntryPoint.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/client/DroolsWorkbenchEntryPoint.java
@@ -26,6 +26,7 @@ import org.kie.workbench.common.widgets.client.handlers.workbench.configuration.
 import org.kie.workbench.common.widgets.client.handlers.workbench.configuration.WorkbenchConfigurationPresenter;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PlaceManager;
@@ -56,6 +57,8 @@ public class DroolsWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
 
     protected LanguageConfigurationHandler languageConfigurationHandler;
 
+
+
     @Inject
     public DroolsWorkbenchEntryPoint(final Caller<AppConfigService> appConfigService,
                                      final ActivityBeansCache activityBeansCache,
@@ -66,9 +69,11 @@ public class DroolsWorkbenchEntryPoint extends DefaultWorkbenchEntryPoint {
                                      final DefaultAdminPageHelper adminPageHelper,
                                      final PreferenceScopeFactory scopeFactory,
                                      final WorkbenchConfigurationPresenter workbenchConfigurationPresenter,
-                                     final LanguageConfigurationHandler languageConfigurationHandler) {
+                                     final LanguageConfigurationHandler languageConfigurationHandler,
+                                     final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.placeManager = placeManager;
         this.menusHelper = menusHelper;
         this.menuBar = menuBar;

--- a/drools-wb-webapp/src/test/java/org/drools/workbench/client/DroolsWorkbenchEntryPointTest.java
+++ b/drools-wb-webapp/src/test/java/org/drools/workbench/client/DroolsWorkbenchEntryPointTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.widgets.client.handlers.workbench.configuration.LanguageConfigurationHandler;
 import org.kie.workbench.common.widgets.client.handlers.workbench.configuration.WorkbenchConfigurationPresenter;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -80,6 +81,9 @@ public class DroolsWorkbenchEntryPointTest {
     @Mock
     protected LanguageConfigurationHandler languageConfigurationHandler;
 
+    @Mock
+    protected DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private DroolsWorkbenchEntryPoint droolsWorkbenchEntryPoint;
 
     @Before
@@ -96,7 +100,7 @@ public class DroolsWorkbenchEntryPointTest {
                                                                       scopeFactory,
                                                                       workbenchConfigurationPresenter,
                                                                       languageConfigurationHandler,
-                                                                      null));
+                                                                      defaultWorkbenchErrorCallback));
         mockMenuHelper();
         mockConstants();
     }

--- a/drools-wb-webapp/src/test/java/org/drools/workbench/client/DroolsWorkbenchEntryPointTest.java
+++ b/drools-wb-webapp/src/test/java/org/drools/workbench/client/DroolsWorkbenchEntryPointTest.java
@@ -95,7 +95,8 @@ public class DroolsWorkbenchEntryPointTest {
                                                                       adminPageHelper,
                                                                       scopeFactory,
                                                                       workbenchConfigurationPresenter,
-                                                                      languageConfigurationHandler));
+                                                                      languageConfigurationHandler,
+                                                                      null));
         mockMenuHelper();
         mockConstants();
     }


### PR DESCRIPTION
This is already merged in 7.7.x. Cherry-picking to master.

Related:
https://github.com/errai/errai/pull/352
https://github.com/kiegroup/appformer/pull/412
https://github.com/kiegroup/kie-wb-common/pull/1951
https://github.com/kiegroup/drools-wb/pull/883
https://github.com/kiegroup/jbpm-wb/pull/1169
https://github.com/kiegroup/optaplanner-wb/pull/290
https://github.com/kiegroup/kie-wb-distributions/pull/776
