### PR TITLE
DROOLS-2689 : The ability to hide an asset based on a flag

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/service/ScenarioSimulationService.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/service/ScenarioSimulationService.java
@@ -36,5 +36,7 @@ public interface ScenarioSimulationService
         SupportsDelete,
         SupportsCopy {
 
+    String SCENARIO_SIMULATION_ENABLED = "org.kie.verification.enable-scenario-simulation";
+
     ScenarioSimulationModelContent loadContent(final Path path);
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/preferences/ScenarioSimulationApplicationPreferencesLoader.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/preferences/ScenarioSimulationApplicationPreferencesLoader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.backend.server.preferences;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
+import org.guvnor.common.services.backend.preferences.ApplicationPreferencesLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class ScenarioSimulationApplicationPreferencesLoader
+        implements ApplicationPreferencesLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(ScenarioSimulationApplicationPreferencesLoader.class);
+
+    @Override
+    public Map<String, String> load() {
+        final Map<String, String> preferences = new HashMap<>();
+
+        final String property = getProperty();
+        log.info("Setting preference '" + ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED + "' to '" + property + "'.");
+        preferences.put(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED,
+                        property);
+
+        return preferences;
+    }
+
+    private String getProperty() {
+        final String property = System.getProperty(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED);
+        if (property == null) {
+            return "false";
+        } else {
+            return property;
+        }
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/preferences/ScenarioSimulationApplicationPreferencesLoaderTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/preferences/ScenarioSimulationApplicationPreferencesLoaderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.backend.server.preferences;
+
+import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScenarioSimulationApplicationPreferencesLoaderTest {
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED);
+    }
+
+    @Test
+    public void notSet() throws Exception {
+
+        assertEquals("false", new ScenarioSimulationApplicationPreferencesLoader().load().get(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED));
+    }
+
+    @Test
+    public void setTrue() throws Exception {
+        System.setProperty(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED, "true");
+
+        assertEquals("true", new ScenarioSimulationApplicationPreferencesLoader().load().get(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED));
+    }
+
+    @Test
+    public void setFalse() throws Exception {
+        System.setProperty(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED, "false");
+
+        assertEquals("false", new ScenarioSimulationApplicationPreferencesLoader().load().get(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED));
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/NewScenarioSimulationHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/NewScenarioSimulationHandler.java
@@ -29,6 +29,7 @@ import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationM
 import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
 import org.guvnor.common.services.project.model.Package;
 import org.jboss.errai.common.client.api.Caller;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.handlers.DefaultNewResourceHandler;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.kie.workbench.common.widgets.client.handlers.NewResourceSuccessEvent;
@@ -91,5 +92,15 @@ public class NewScenarioSimulationHandler
                                                                                                                          resourceType),
                                                                                                            new ScenarioSimulationModel(),
                                                                                                            "");
+    }
+
+    @Override
+    public boolean canCreate() {
+
+        if (ApplicationPreferences.getStringPref(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED) != null) {
+            return ApplicationPreferences.getBooleanPref(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED);
+        } else {
+            return false;
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/NewScenarioSimulationHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/NewScenarioSimulationHandlerTest.java
@@ -15,6 +15,9 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.type.ScenarioSimulationResourceType;
 import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
@@ -22,6 +25,7 @@ import org.guvnor.common.services.project.model.Package;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
@@ -31,6 +35,8 @@ import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -81,5 +87,32 @@ public class NewScenarioSimulationHandlerTest {
         verify(notificationEvent).fire(any(NotificationEvent.class));
         verify(newResourceSuccessEvent).fire(any(NewResourcePresenter.class));
         verify(placeManager).goTo(any(Path.class));
+    }
+
+    @Test
+    public void disabledByDefault() throws Exception {
+        assertFalse(handler.canCreate());
+    }
+
+    @Test
+    public void disabledWhenDisabled() throws Exception {
+
+        final Map<String, String> preferences = new HashMap<String, String>() {{
+            put(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED,
+                "false");
+        }};
+        ApplicationPreferences.setUp(preferences);
+        assertFalse(handler.canCreate());
+    }
+
+    @Test
+    public void enabledWhenEnabled() throws Exception {
+
+        final Map<String, String> preferences = new HashMap<String, String>() {{
+            put(ScenarioSimulationService.SCENARIO_SIMULATION_ENABLED,
+                "true");
+        }};
+        ApplicationPreferences.setUp(preferences);
+        assertTrue(handler.canCreate());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2689

By default the new asset handler for scenario simulation is hidden. Setting the flag to true makes it show up.