### PR TITLE
DROOLS-2777: Guided Decision Table is changing date field value based on the timezone

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
@@ -282,6 +282,18 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ConsumerFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ConsumerFactory.java
@@ -29,6 +29,8 @@ import org.gwtbootstrap3.client.ui.TextBox;
 import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.convertFromServerTimeZone;
+
 /**
  * Factory for common consumers used by the different columns.
  */
@@ -103,11 +105,13 @@ public class ConsumerFactory {
     public static <E extends SingleValueDOMElement<Date, DatePicker>> Consumer<E> makeOnCreationCallback(final GridCell<Date> cell) {
         return (e) -> {
             final DatePicker widget = e.getWidget();
+            final Date value;
             if (hasValue(cell)) {
-                widget.setValue(cell.getValue().getValue());
+                value = cell.getValue().getValue();
             } else {
-                widget.setValue(new Date());
+                value = new Date();
             }
+            widget.setValue(convertFromServerTimeZone(value));
         };
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumn.java
@@ -20,20 +20,17 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.ait.lienzo.client.core.shape.Text;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker.DatePickerDOMElement;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker.DatePickerSingletonDOMElementFactory;
-import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class DateUiColumn extends BaseSingletonDOMElementUiColumn<Date, DatePicker, DatePickerDOMElement, DatePickerSingletonDOMElementFactory> {
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.formatWithServerTimeZone;
 
-    private static final String droolsDateFormat = ApplicationPreferences.getDroolsDateFormat();
-    private static final DateTimeFormat dateTimeFormat = DateTimeFormat.getFormat( droolsDateFormat );
+public class DateUiColumn extends BaseSingletonDOMElementUiColumn<Date, DatePicker, DatePickerDOMElement, DatePickerSingletonDOMElementFactory> {
 
     public DateUiColumn( final List<HeaderMetaData> headerMetaData,
                          final double width,
@@ -42,19 +39,23 @@ public class DateUiColumn extends BaseSingletonDOMElementUiColumn<Date, DatePick
                          final GuidedDecisionTablePresenter.Access access,
                          final DatePickerSingletonDOMElementFactory factory ) {
         super( headerMetaData,
-               new CellRenderer<Date, DatePicker, DatePickerDOMElement>( factory ) {
-                   @Override
-                   protected void doRenderCellContent( final Text t,
-                                                       final Date value,
-                                                       final GridBodyCellRenderContext context ) {
-                       t.setText( dateTimeFormat.format( value ) );
-                   }
-               },
+               makeColumnRenderer(factory),
                width,
                isResizable,
                isVisible,
                access,
                factory );
+    }
+
+    static CellRenderer<Date, DatePicker, DatePickerDOMElement> makeColumnRenderer(final DatePickerSingletonDOMElementFactory factory) {
+        return new CellRenderer<Date, DatePicker, DatePickerDOMElement>(factory) {
+            @Override
+            protected void doRenderCellContent(final Text text,
+                                               final Date value,
+                                               final GridBodyCellRenderContext context) {
+                text.setText(formatWithServerTimeZone(value));
+            }
+        };
     }
 
     @Override
@@ -65,5 +66,4 @@ public class DateUiColumn extends BaseSingletonDOMElementUiColumn<Date, DatePick
                                  ConsumerFactory.makeOnCreationCallback(cell ),
                                  ConsumerFactory.makeOnDisplayDatePickerCallback() );
     }
-
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactory.java
@@ -30,6 +30,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
 
+import static org.kie.workbench.common.widgets.client.util.TimeZoneUtils.convertToServerTimeZone;
+
 /**
  * A DOMElement Factory for single-instance TextBoxes.
  */
@@ -102,9 +104,13 @@ public class DatePickerSingletonDOMElementFactory extends SingleValueSingletonDO
 
     @Override
     protected Date getValue() {
-        if (widget != null) {
-            return widget.getValue();
+        if (getWidget() != null) {
+            return convertToServerTimeZone(getWidget().getValue());
         }
         return null;
+    }
+
+    DatePicker getWidget() {
+        return widget;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ConsumerFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ConsumerFactoryTest.java
@@ -15,23 +15,35 @@
  */
 package org.drools.workbench.screens.guided.dtable.client.widget.table.columns;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker.DatePickerDOMElement;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.listbox.MultiValueDOMElement;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.listbox.MultiValueSingletonDOMElementFactory;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.textbox.SingleValueDOMElement;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,6 +54,8 @@ public class ConsumerFactoryTest {
     private static final String KEY = "key";
 
     private static final String VALUE = "value";
+
+    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy HH:mm:ss Z";
 
     @Mock
     private MultiValueSingletonDOMElementFactory factory;
@@ -56,6 +70,16 @@ public class ConsumerFactoryTest {
     private GridCell cell;
 
     private Map<String, String> enumLookups;
+
+    @BeforeClass
+    public static void setupStatic() {
+        System.setProperty("user.timezone", "Europe/Vilnius");
+
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(KIE_TIMEZONE_OFFSET, "10800000");
+            put(DATE_FORMAT, TEST_DATE_FORMAT);
+        }});
+    }
 
     @Before
     public void setup() {
@@ -111,6 +135,22 @@ public class ConsumerFactoryTest {
         verifyMultipleSelectTest(ConsumerFactory.MAX_VISIBLE_ROWS + 1);
     }
 
+    @Test
+    public void testMakeOnCreationCallback() {
+
+        final DatePickerDOMElement datePickerDomElement = mock(DatePickerDOMElement.class);
+        final DatePicker datePickerWidget = mock(DatePicker.class);
+        final String serverDate = "05-01-2018 06:00:00 +0300";
+        final String dateConvertedFromServerTimezone = "05-01-2018 00:00:00 -0300";
+        final Consumer<SingleValueDOMElement<Date, DatePicker>> callback = ConsumerFactory.makeOnCreationCallback(makeGridCell(asDate(serverDate)));
+
+        when(datePickerDomElement.getWidget()).thenReturn(datePickerWidget);
+
+        callback.accept(datePickerDomElement);
+
+        verify(datePickerWidget).setValue(asDate(dateConvertedFromServerTimezone));
+    }
+
     private void setupMultipleSelectTest(final int enumLookupSize,
                                          final boolean isMultipleSelect) {
         IntStream.rangeClosed(1,
@@ -126,5 +166,62 @@ public class ConsumerFactoryTest {
                                                                                       eq(KEY + i)));
         verify(factory).toWidget(eq(cell),
                                  eq(multiValueWidget));
+    }
+
+    private Date asDate(final String dateString) {
+        return format().parse(dateString);
+    }
+
+    private DateTimeFormat format() {
+        return DateTimeFormat.getFormat(TEST_DATE_FORMAT);
+    }
+
+    private GridCell<Date> makeGridCell(final Date date) {
+        return new GridCell<Date>() {
+            @Override
+            public GridCellValue<Date> getValue() {
+                return () -> date;
+            }
+
+            @Override
+            public boolean isMerged() {
+                return false;
+            }
+
+            @Override
+            public int getMergedCellCount() {
+                return 0;
+            }
+
+            @Override
+            public boolean isCollapsed() {
+                return false;
+            }
+
+            @Override
+            public void collapse() {
+                // Nothing.
+            }
+
+            @Override
+            public void expand() {
+                // Nothing.
+            }
+
+            @Override
+            public void reset() {
+                // Nothing.
+            }
+
+            @Override
+            public CellSelectionStrategy getSelectionStrategy() {
+                return null;
+            }
+
+            @Override
+            public void setSelectionStrategy(final CellSelectionStrategy selectionStrategy) {
+                // Nothing.
+            }
+        };
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumnTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumnTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table.columns;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import com.ait.lienzo.client.core.shape.Text;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker.DatePickerDOMElement;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker.DatePickerSingletonDOMElementFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class DateUiColumnTest {
+
+    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy HH:mm:ss Z";
+
+    @Mock
+    private DatePickerSingletonDOMElementFactory factory;
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty("user.timezone", "Europe/Vilnius");
+
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(KIE_TIMEZONE_OFFSET, "10800000");
+            put(DATE_FORMAT, TEST_DATE_FORMAT);
+        }});
+    }
+
+    @Test
+    public void testDateUiColumnTextFormat() {
+
+        final Text text = mock(Text.class);
+        final GridBodyCellRenderContext context = mock(GridBodyCellRenderContext.class);
+        final String clientDate = "05-01-2018 00:00:00 -0300";
+        final String clientFormattedWithServerTimeZoneDate = "05-01-2018 06:00:00 +0300";
+
+        renderer().doRenderCellContent(text, date(clientDate), context);
+
+        verify(text).setText(clientFormattedWithServerTimeZoneDate);
+    }
+
+    private BaseSingletonDOMElementUiColumn.CellRenderer<Date, DatePicker, DatePickerDOMElement> renderer() {
+        return DateUiColumn.makeColumnRenderer(factory);
+    }
+
+    private Date date(final String dateString) {
+        return DateTimeFormat.getFormat(TEST_DATE_FORMAT).parse(dateString);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.datepicker;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.junit.GWTMockUtilities;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.kie.workbench.common.widgets.client.util.TimeZoneUtils;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+import static org.junit.Assert.assertEquals;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.KIE_TIMEZONE_OFFSET;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@PrepareForTest({DatePickerSingletonDOMElementFactory.class, DateTimeFormat.class, TimeZoneUtils.class})
+@RunWith(PowerMockRunner.class)
+public class DatePickerSingletonDOMElementFactoryTest {
+
+    private static final String TEST_DATE_FORMAT = "MM-dd-yyyy HH:mm:ss Z";
+
+    @Mock
+    private GridLienzoPanel gridPanel;
+
+    @Mock
+    private GridLayer gridLayer;
+
+    @Mock
+    private GuidedDecisionTableView gridWidget;
+
+    @Mock
+    private DatePicker datePicker;
+
+    @BeforeClass
+    public static void setupStatic() {
+        preventGWTCreateError();
+        setStandardTimeZone();
+        mockStaticMethods();
+        initializeApplicationPreferences();
+    }
+
+    private static void preventGWTCreateError() {
+        GWTMockUtilities.disarm();
+    }
+
+    private static void initializeApplicationPreferences() {
+        ApplicationPreferences.setUp(new HashMap<String, String>() {{
+            put(KIE_TIMEZONE_OFFSET, "10800000");
+            put(DATE_FORMAT, TEST_DATE_FORMAT);
+        }});
+    }
+
+    private static void mockStaticMethods() {
+        mockStatic(DateTimeFormat.class);
+        PowerMockito.when(DateTimeFormat.getFormat(anyString())).thenReturn(mock(DateTimeFormat.class));
+    }
+
+    private static void setStandardTimeZone() {
+        System.setProperty("user.timezone", "Europe/Vilnius");
+    }
+
+    @Test
+    public void testGetValue() {
+
+        final DatePickerSingletonDOMElementFactory factory = spy(makeFactory());
+        final Date date = mock(Date.class);
+        final Date convertedDate = mock(Date.class);
+
+        doReturn(datePicker).when(factory).getWidget();
+        when(datePicker.getValue()).thenReturn(date);
+
+        mockStatic(TimeZoneUtils.class);
+        PowerMockito.when(TimeZoneUtils.convertToServerTimeZone(date)).thenReturn(convertedDate);
+
+        final Date actualDate = factory.getValue();
+
+        assertEquals(convertedDate, actualDate);
+    }
+
+    private DatePickerSingletonDOMElementFactory makeFactory() {
+        return new DatePickerSingletonDOMElementFactory(gridPanel, gridLayer, gridWidget);
+    }
+}


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/DROOLS-2777

---

Demo:
- First, we need to set the `user.timezone` property:
![1](https://user-images.githubusercontent.com/1079279/44177253-5ba47d00-a0ed-11e8-8ca4-a77f6d42166e.gif)

- ..and then, we can change the timezone to **"Europe/Vilnius"** in the server (`systemsetup -settimezone Europe/Vilnius`):
![2](https://user-images.githubusercontent.com/1079279/44177259-5e9f6d80-a0ed-11e8-9995-9c20e6c74274.gif)

- ..or even change to **"Europe/Prague"** (`systemsetup -settimezone Europe/Prague`):
![3](https://user-images.githubusercontent.com/1079279/44177261-6232f480-a0ed-11e8-9fe4-2f277ca6057f.gif)

..the client side is always using the timezone from the server (from `user.timezone`), so the displayed value will always be consistent.

cc @etirelli 

---

Part of an ensemble:
- https://github.com/kiegroup/kie-wb-common/pull/2038
- https://github.com/kiegroup/drools-wb/pull/911
