### PR TITLE
PLANNER-1159: Improve categories

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/type/TestScenarioResourceTypeDefinition.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/type/TestScenarioResourceTypeDefinition.java
@@ -20,10 +20,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
+import org.guvnor.common.services.project.categories.Decision;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.workbench.annotations.VisibleAsset;
 import org.uberfire.workbench.category.Category;
-import org.uberfire.workbench.category.Others;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 @Default
@@ -38,7 +38,7 @@ public class TestScenarioResourceTypeDefinition
     }
 
     @Inject
-    public TestScenarioResourceTypeDefinition(final Others category) {
+    public TestScenarioResourceTypeDefinition(final Decision category) {
         this.category = category;
     }
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.Query;
 import org.drools.workbench.models.testscenarios.backend.util.ScenarioXMLPersistence;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.type.TestScenarioResourceTypeDefinition;
+import org.guvnor.common.services.project.categories.Decision;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.imports.Import;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
@@ -36,7 +37,6 @@ import org.kie.workbench.common.services.refactoring.service.PartType;
 import org.kie.workbench.common.services.refactoring.service.ResourceType;
 import org.uberfire.ext.metadata.io.KObjectUtil;
 import org.uberfire.java.nio.file.Path;
-import org.uberfire.workbench.category.Others;
 
 public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResourceTypeDefinition> {
 
@@ -139,7 +139,7 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
 
     @Override
     protected TestScenarioResourceTypeDefinition getResourceTypeDefinition() {
-        return new TestScenarioResourceTypeDefinition(new Others());
+        return new TestScenarioResourceTypeDefinition(new Decision());
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/type/TestScenarioResourceType.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/type/TestScenarioResourceType.java
@@ -23,8 +23,8 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.drools.workbench.screens.testscenario.client.resources.images.TestScenarioAltedImages;
 import org.drools.workbench.screens.testscenario.type.TestScenarioResourceTypeDefinition;
+import org.guvnor.common.services.project.categories.Decision;
 import org.uberfire.client.workbench.type.ClientResourceType;
-import org.uberfire.workbench.category.Others;
 
 @ApplicationScoped
 public class TestScenarioResourceType
@@ -35,7 +35,7 @@ public class TestScenarioResourceType
     }
 
     @Inject
-    public TestScenarioResourceType(final Others category) {
+    public TestScenarioResourceType(final Decision category) {
         super(category);
     }
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenterTest.java
@@ -33,6 +33,7 @@ import org.drools.workbench.screens.testscenario.client.type.TestScenarioResourc
 import org.drools.workbench.screens.testscenario.model.TestScenarioModelContent;
 import org.drools.workbench.screens.testscenario.model.TestScenarioResult;
 import org.drools.workbench.screens.testscenario.service.ScenarioTestEditorService;
+import org.guvnor.common.services.project.categories.Decision;
 import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.common.services.project.model.WorkspaceProject;
@@ -71,7 +72,6 @@ import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
-import org.uberfire.workbench.category.Others;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
@@ -170,7 +170,7 @@ public class ScenarioEditorPresenterTest {
                                                  importsWidget,
                                                  fakeService,
                                                  new CallerMock<>(testService),
-                                                 new TestScenarioResourceType(new Others()),
+                                                 new TestScenarioResourceType(new Decision()),
                                                  modelOracleFactory,
                                                  settingsPage,
                                                  auditPage) {


### PR DESCRIPTION
- Move Test Scenario resource type to Decision category.
- ~Move WorkItem resource type to Process category.~

Related PRs:
kiegroup/appformer/pull/438
kiegroup/kie-wb-common/pull/2048
kiegroup/drools-wb/pull/914
kiegroup/optaplanner-wb/pull/296

## Asset List
![kie workbench - google chrome_070](https://user-images.githubusercontent.com/673386/44389068-269f8c80-a52a-11e8-909b-cf315e962a86.png)
![kie workbench - google chrome_069](https://user-images.githubusercontent.com/673386/44389074-2acbaa00-a52a-11e8-88ba-df9e820e4d20.png)

## Add Asset
![screenshot from 2018-08-20 16-53-16](https://user-images.githubusercontent.com/673386/44389574-7b8fd280-a52b-11e8-856a-34da8ebff1b0.png)
![screenshot from 2018-08-20 16-53-07](https://user-images.githubusercontent.com/673386/44389575-7df22c80-a52b-11e8-8330-a5eb4349af86.png)
