### PR TITLE
DROOLS-2934 Use the new views on the test result panel

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
@@ -62,6 +62,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-message-console-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-message-console-client</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreen.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreen.java
@@ -33,7 +33,7 @@ import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.Position;
 
 @ApplicationScoped
-@WorkbenchScreen(identifier = "org.kie.guvnor.TestResults")
+@WorkbenchScreen(identifier = "org.kie.guvnor.TestResults", preferredWidth = 437)
 public class TestRunnerReportingScreen
         implements TestRunnerReportingView.Presenter {
 
@@ -53,7 +53,7 @@ public class TestRunnerReportingScreen
 
     @DefaultPosition
     public Position getDefaultPosition() {
-        return CompassPosition.SOUTH;
+        return CompassPosition.EAST;
     }
 
     @WorkbenchPartTitle

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreen.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreen.java
@@ -81,7 +81,9 @@ public class TestRunnerReportingScreen
             }
             view.showFailure();
         }
-        view.setRunStatus(getCompletedAt(), getScenariosRun(testResultMessage), getDuration(testResultMessage));
+        view.setRunStatus(getCompletedAt(),
+                          getScenariosRun(testResultMessage),
+                          getDuration(testResultMessage));
     }
 
     private SystemMessage convert(Failure failure) {
@@ -92,31 +94,29 @@ public class TestRunnerReportingScreen
         return systemMessage;
     }
 
-    private String getCompletedAt(){
+    private String getCompletedAt() {
         DateTimeFormat timeFormat = DateTimeFormat.getFormat("HH:mm:ss.SSS");
         return timeFormat.format(new Date());
     }
 
-    private String getScenariosRun(TestResultMessage testResultMessage){
+    private String getScenariosRun(TestResultMessage testResultMessage) {
         return String.valueOf(testResultMessage.getRunCount());
     }
 
-    private String getDuration(TestResultMessage testResultMessage){
+    private String getDuration(TestResultMessage testResultMessage) {
         Long runTime = testResultMessage.getRunTime();
         Date runtime = new Date(runTime);
 
-        DateTimeFormat secondsFormat = DateTimeFormat.getFormat("s");
-        DateTimeFormat minutesFormat = DateTimeFormat.getFormat("m");
+        String milliseconds = DateTimeFormat.getFormat("SSS").format(runtime) + " milliseconds";
+        String seconds = DateTimeFormat.getFormat("s").format(runtime) + " seconds";
+        String minutes = DateTimeFormat.getFormat("m").format(runtime) + " minutes";
 
-        String seconds = secondsFormat.format(runtime) + " seconds";
-
-        if (runTime >= 60000) {
-            return minutesFormat.format(runtime) + " minutes and " + seconds;
-        } else if (runTime >= 1000) {
-            DateTimeFormat miliSecondsFormat = DateTimeFormat.getFormat("SSS");
-            return seconds + " and " + miliSecondsFormat.format(runtime)+ " milliseconds";
+        if (runTime < 1000) {
+            return milliseconds;
+        } else if (runTime < 60000) {
+            return seconds + " and " + milliseconds;
         } else {
-            return runTime + " milliseconds";
+            return minutes + " and " + seconds;
         }
     }
 

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
@@ -16,7 +16,10 @@
 
 package org.drools.workbench.screens.testscenario.client.reporting;
 
+import java.util.List;
+
 import com.google.gwt.user.client.ui.IsWidget;
+import org.guvnor.messageconsole.events.SystemMessage;
 
 public interface TestRunnerReportingView
         extends IsWidget {
@@ -27,10 +30,13 @@ public interface TestRunnerReportingView
 
     void setPresenter(Presenter presenter);
 
+    void setSystemMessages(List<SystemMessage> systemMessages);
+
     void showSuccess();
 
     void showFailure();
 
-    void setRunStatus(int runCount,
-                      long runTime);
+    void setRunStatus(String completedAt,
+                      String ScenariosRun,
+                      String duration);
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.testscenario.client.reporting;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.testscenario.client.service.TestRuntimeReportingService;
 import org.guvnor.common.services.shared.test.Failure;
+import org.guvnor.messageconsole.client.console.MessageConsoleService;
 
 public interface TestRunnerReportingView
         extends IsWidget {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,20 @@
 package org.drools.workbench.screens.testscenario.client.reporting;
 
 import com.google.gwt.user.client.ui.IsWidget;
-import org.drools.workbench.screens.testscenario.client.service.TestRuntimeReportingService;
-import org.guvnor.common.services.shared.test.Failure;
-import org.guvnor.messageconsole.client.console.MessageConsoleService;
 
 public interface TestRunnerReportingView
         extends IsWidget {
 
-
     interface Presenter {
 
-        void onMessageSelected(Failure failure);
-
-        void onAddingFailure(Failure failure);
-
     }
-    void setPresenter(Presenter presenter);
 
-    void bindDataGridToService(TestRuntimeReportingService testRuntimeReportingService);
+    void setPresenter(Presenter presenter);
 
     void showSuccess();
 
     void showFailure();
 
-    void setExplanation(String explanation);
-
-    void setRunStatus(int runCount, long runTime);
-
+    void setRunStatus(int runCount,
+                      long runTime);
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
@@ -1,3 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+a:hover {
+  cursor: pointer;
+}
+
 .kie-dl-horizontal dt {
   text-align: left;
   font-weight: normal;

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
@@ -1,0 +1,69 @@
+.kie-dl-horizontal dt {
+  text-align: left;
+  font-weight: normal;
+  width: auto;
+}
+
+.kie-dl-horizontal dd {
+  margin-bottom: 0.75rem;
+  margin-left: 1rem;
+  float: left;
+}
+
+.kie-dock__heading {
+  font-weight: 600;
+}
+
+.kie-dock-selector > li > a {
+  padding: 1rem 2rem;
+  color: #030303;
+}
+
+.kie-dock-selector > li > a:hover,
+.kie-dock-selector > li > a:focus {
+  background-color: #def3ff;
+  color: #0088ce;
+}
+
+.kie-dock-selector > li.active a {
+  background-color: #def3ff;
+  color: #0088ce;
+}
+
+.kie-dock__heading--section {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.kie-dock__divider {
+  margin-top: 25px;
+  margin-bottom: 15px;
+}
+
+.kie-dock-selector__tab {
+  font-size: 1.16666667;
+  text-align: left;
+  border-left: 3px solid transparent;
+}
+
+.kie-dock-selector__tab.active {
+  border-color: #0088ce;
+}
+
+.kie-tab-content--filters {
+  border-left: 1px solid #bbb;
+  background-color: #fafafa;
+}
+
+.kie-tab-content--filters hr {
+  border-color: #d1d1d1;
+}
+
+.col-xs-3 {
+  width: 25%;
+  float: left;
+  position: relative;
+  min-height: 1px;
+  padding-left: 20px;
+  padding-right: 20px;
+}

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.css
@@ -50,11 +50,6 @@
   border-color: #0088ce;
 }
 
-.kie-tab-content--filters {
-  border-left: 1px solid #bbb;
-  background-color: #fafafa;
-}
-
 .kie-tab-content--filters hr {
   border-color: #d1d1d1;
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
@@ -16,7 +16,8 @@
   ~ limitations under the License.
   -->
 
-<div data-field="resultPanel" class="container-fluid">
+<!--<div data-field="resultPanel" class="container-fluid">
+
     <div class="row">
         <div data-field="resultTitle"></div>
     </div>
@@ -30,4 +31,108 @@
     <div class="row">
         <div data-field="resultDetails"></div>
     </div>
+</div>-->
+
+<div data-field="resultPanel" class="container-fluid">
+    <div class="row">
+        <!-- Content - filters -->
+        <div class="col-xs-9 tab-content kie-tab-content--filters" style="heigth: 100%; height: 100vh">
+            <!-- GENERAL -->
+            <div class="tab-pane kie__dock active" id="kieDockPanel1">
+                <h3 class="kie-dock__heading">
+                    Test Report
+                </h3>
+                <hr class="kie-dock__divider"/>
+
+                <h5 class="kie-dock__heading--section">Overview</h5>
+
+                <dl class="dl-horizontal kie-dl-horizontal clearfix">
+                    <dt>
+                        Test Results:
+                    </dt>
+                    <dd>
+                        <span class="pficon pficon-error-circle-o"></span> TEST FAILED
+                    </dd>
+                    <dt>
+                        Completed at:
+                    </dt>
+                    <dd>
+                        17:11:40.391
+                    </dd>
+                    <dt>
+                        Scenarios run:
+                    </dt>
+                    <dd>
+                        2
+                    </dd>
+                    <dt>
+                        Duration:
+                    </dt>
+                    <dd>
+                        552 seconds
+                    </dd>
+                </dl>
+
+                <a href="">View Details</a>
+
+                <hr class="kie-dock__divider"/>
+                <h5 class="kie-dock__heading--section">Scenario Status</h5>
+
+                <!-- *************** donut graph here *******************-->
+                <div id="kie-test-results1" class="example-donut-chart-bottom-legend"></div>
+                <div id="kie-test-results2" class="example-donut-chart-bottom-legend"></div>
+                <div id="kie-test-results3" class="example-donut-chart-bottom-legend"></div>
+                <!-- *************** END donut graph here *******************-->
+
+                <br/>
+
+            </div>
+
+            <!-- PLACEHOLDER -->
+            <div class="tab-pane" id="kieDockPanel2">
+                <h3 class="kie-dock__heading">
+                    Placeholder
+                </h3>
+                <hr class="kie-dock__divider"/>
+                <br/>
+
+            </div>
+
+            <!-- PLACEHOLDER -->
+            <div class="tab-pane" id="kieDockPanel3">
+                <h3 class="kie-dock__heading">
+                    Placeholder
+                </h3>
+                <hr class="kie-dock__divider"/>
+                <br/>
+            </div>
+
+
+        </div>
+
+        <!-- Tabs for the filter control -->
+        <!-- should be implemented with existing slide-in panel control -->
+        <div class="col-xs-3" style="">
+            <nav class="navbar navbar-static nav-stacked" id="kiePreferences">
+                <ul class="nav kie-dock-selector" role="tablist">
+                    <li class="kie-dock-selector__tab active">
+                        <a href="#kieDockPanel1" data-toggle="tab">
+                            <span class="fa fa-file-text"></span>
+                        </a>
+                    </li>
+                    <li class="kie-dock-selector__tab">
+                        <a href="#kieDockPanel2" data-toggle="tab">
+                            <span class="pficon pficon-info"></span>
+                        </a>
+                    </li>
+                    <li class="kie-dock-selector__tab">
+                        <a href="#kieDockPanel3" data-toggle="tab">
+                            <span class="fa fa-play-circle"></span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
+

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
@@ -16,27 +16,10 @@
   ~ limitations under the License.
   -->
 
-<!--<div data-field="resultPanel" class="container-fluid">
-
-    <div class="row">
-        <div data-field="resultTitle"></div>
-    </div>
-
-    <div class="row" style="text-align: center;">
-        <div class="col-md-12">
-            <div data-field="resultStats"></div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div data-field="resultDetails"></div>
-    </div>
-</div>-->
-
 <div data-field="resultPanel" class="container-fluid">
     <div class="row">
         <!-- Content - filters -->
-        <div class="col-xs-9 tab-content kie-tab-content--filters" style="heigth: 100%; height: 100vh">
+        <div class="col-xs-9 tab-content kie-tab-content--filters" style="width: 100%;">
             <!-- GENERAL -->
             <div class="tab-pane kie__dock active" id="kieDockPanel1">
                 <h3 class="kie-dock__heading">
@@ -51,87 +34,36 @@
                         Test Results:
                     </dt>
                     <dd>
-                        <span class="pficon pficon-error-circle-o"></span> TEST FAILED
+                        <span data-field="testResultIcon"></span> TEST
+                        <span data-field="testResultText" style="display: inline;"></span>
                     </dd>
                     <dt>
                         Completed at:
                     </dt>
                     <dd>
-                        17:11:40.391
+                        <span data-field="completedAt"></span>
                     </dd>
                     <dt>
                         Scenarios run:
                     </dt>
                     <dd>
-                        2
+                        <span data-field="scenariosRun"></span>
                     </dd>
                     <dt>
                         Duration:
                     </dt>
                     <dd>
-                        552 seconds
+                        <span data-field="duration"></span>
                     </dd>
                 </dl>
 
-                <a href="">View Details</a>
+                <a href="" data-field="viewAlerts">View Alerts</a>
 
                 <hr class="kie-dock__divider"/>
                 <h5 class="kie-dock__heading--section">Scenario Status</h5>
 
-                <!-- *************** donut graph here *******************-->
-                <div id="kie-test-results1" class="example-donut-chart-bottom-legend"></div>
-                <div id="kie-test-results2" class="example-donut-chart-bottom-legend"></div>
-                <div id="kie-test-results3" class="example-donut-chart-bottom-legend"></div>
-                <!-- *************** END donut graph here *******************-->
-
-                <br/>
-
-            </div>
-
-            <!-- PLACEHOLDER -->
-            <div class="tab-pane" id="kieDockPanel2">
-                <h3 class="kie-dock__heading">
-                    Placeholder
-                </h3>
-                <hr class="kie-dock__divider"/>
-                <br/>
-
-            </div>
-
-            <!-- PLACEHOLDER -->
-            <div class="tab-pane" id="kieDockPanel3">
-                <h3 class="kie-dock__heading">
-                    Placeholder
-                </h3>
-                <hr class="kie-dock__divider"/>
                 <br/>
             </div>
-
-
-        </div>
-
-        <!-- Tabs for the filter control -->
-        <!-- should be implemented with existing slide-in panel control -->
-        <div class="col-xs-3" style="">
-            <nav class="navbar navbar-static nav-stacked" id="kiePreferences">
-                <ul class="nav kie-dock-selector" role="tablist">
-                    <li class="kie-dock-selector__tab active">
-                        <a href="#kieDockPanel1" data-toggle="tab">
-                            <span class="fa fa-file-text"></span>
-                        </a>
-                    </li>
-                    <li class="kie-dock-selector__tab">
-                        <a href="#kieDockPanel2" data-toggle="tab">
-                            <span class="pficon pficon-info"></span>
-                        </a>
-                    </li>
-                    <li class="kie-dock-selector__tab">
-                        <a href="#kieDockPanel3" data-toggle="tab">
-                            <span class="fa fa-play-circle"></span>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
         </div>
     </div>
 </div>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.html
@@ -57,7 +57,7 @@
                     </dd>
                 </dl>
 
-                <a href="" data-field="viewAlerts">View Alerts</a>
+                <a data-field="viewAlerts">View Alerts</a>
 
                 <hr class="kie-dock__divider"/>
                 <h5 class="kie-dock__heading--section">Scenario Status</h5>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.testscenario.client.reporting;
 
 import java.util.Date;
+
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -24,13 +25,7 @@ import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
-import org.drools.workbench.screens.testscenario.client.service.TestRuntimeReportingService;
-import org.guvnor.common.services.shared.message.Level;
-import org.guvnor.common.services.shared.test.Failure;
-import org.guvnor.messageconsole.client.console.MessageConsoleService;
-import org.guvnor.messageconsole.client.console.widget.MessageTableWidget;
 import org.guvnor.messageconsole.client.console.widget.button.ViewHideAlertsButtonPresenter;
-import org.gwtbootstrap3.client.ui.constants.ColumnSize;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -41,9 +36,6 @@ public class TestRunnerReportingViewImpl
         implements TestRunnerReportingView {
 
     private Presenter presenter;
-
-    @Inject
-    private ViewHideAlertsButtonPresenter alertsPresenter;
 
     @DataField
     private HTMLDivElement resultPanel;
@@ -67,11 +59,7 @@ public class TestRunnerReportingViewImpl
     private HTMLAnchorElement viewAlerts;
 
     @Inject
-    private MessageConsoleService consoleService;
-
-    protected final MessageTableWidget<Failure> dataGrid = new MessageTableWidget<Failure>() {{
-        setToolBarVisible(false);
-    }};
+    private ViewHideAlertsButtonPresenter alertsPresenter;
 
     @Inject
     public TestRunnerReportingViewImpl(HTMLDivElement resultPanel,
@@ -88,11 +76,6 @@ public class TestRunnerReportingViewImpl
         this.completedAt = completedAt;
         this.duration = duration;
         this.viewAlerts = viewAlerts;
-
-        addSuccessColumn();
-        addTextColumn();
-
-        dataGrid.addStyleName(ColumnSize.MD_12.getCssName());
     }
 
     @EventHandler("viewAlerts")
@@ -100,42 +83,9 @@ public class TestRunnerReportingViewImpl
         alertsPresenter.viewAlerts();
     }
 
-    private void addSuccessColumn() {
-        dataGrid.addLevelColumn(10,
-                                new MessageTableWidget.ColumnExtractor<Level>() {
-                                    @Override
-                                    public Level getValue(final Object row) {
-                                        presenter.onAddingFailure((Failure) row);
-                                        return Level.ERROR;
-                                    }
-                                });
-    }
-
-    private void addTextColumn() {
-        dataGrid.addTextColumn(90,
-                               new MessageTableWidget.ColumnExtractor<String>() {
-                                   @Override
-                                   public String getValue(final Object row) {
-
-                                       return makeMessage((Failure) row);
-                                   }
-                               });
-    }
-
-    private String makeMessage(Failure failure) {
-        final String displayName = failure.getDisplayName();
-        final String message = failure.getMessage();
-        return displayName + (!(message == null || message.isEmpty()) ? " : " + message : "");
-    }
-
     @Override
     public void setPresenter(Presenter presenter) {
         this.presenter = presenter;
-    }
-
-    @Override
-    public void bindDataGridToService(TestRuntimeReportingService testRuntimeReportingService) {
-        testRuntimeReportingService.addDataDisplay(dataGrid);
     }
 
     @Override
@@ -148,10 +98,6 @@ public class TestRunnerReportingViewImpl
     public void showFailure() {
         testResultIcon.className = "pficon pficon-error-circle-o";
         testResultText.textContent = "FAILED";
-    }
-
-    @Override
-    public void setExplanation(String explanation) {
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingViewImpl.java
@@ -23,13 +23,11 @@ import javax.inject.Inject;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.ui.Widget;
 import elemental2.dom.HTMLDivElement;
-import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.drools.workbench.screens.testscenario.client.service.TestRuntimeReportingService;
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.common.services.shared.test.Failure;
 import org.guvnor.messageconsole.client.console.widget.MessageTableWidget;
 import org.gwtbootstrap3.client.ui.constants.ColumnSize;
-import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
@@ -43,32 +41,22 @@ public class TestRunnerReportingViewImpl
     @DataField
     private HTMLDivElement resultPanel;
 
-    @DataField
-    private HTMLDivElement resultTitle;
-
-    @DataField
-    private HTMLDivElement resultStats;
-
-    @DataField
-    private HTMLDivElement resultDetails;
+//    @DataField
+//    private HTMLDivElement resultTitle;
+//
+//    @DataField
+//    private HTMLDivElement resultStats;
+//
+//    @DataField
+//    private HTMLDivElement resultDetails;
 
     protected final MessageTableWidget<Failure> dataGrid = new MessageTableWidget<Failure>() {{
         setToolBarVisible(false);
     }};
 
     @Inject
-    public TestRunnerReportingViewImpl(HTMLDivElement resultPanel,
-                                       HTMLDivElement resultTitle,
-                                       HTMLDivElement resultStats,
-                                       HTMLDivElement resultDetails,
-                                       Elemental2DomUtil domUtils) {
+    public TestRunnerReportingViewImpl(HTMLDivElement resultPanel) {
         this.resultPanel = resultPanel;
-        this.resultTitle = resultTitle;
-        this.resultStats = resultStats;
-        this.resultDetails = resultDetails;
-
-        domUtils.appendWidgetToElement(resultDetails,
-                                       dataGrid);
 
         addSuccessColumn();
         addTextColumn();
@@ -116,14 +104,14 @@ public class TestRunnerReportingViewImpl
 
     @Override
     public void showSuccess() {
-        resultTitle.textContent = TestScenarioConstants.INSTANCE.Success();
-        resultTitle.className = "label col-md-12 label-success";
+//        resultTitle.textContent = TestScenarioConstants.INSTANCE.Success();
+//        resultTitle.className = "label col-md-12 label-success";
     }
 
     @Override
     public void showFailure() {
-        resultTitle.textContent = TestScenarioConstants.INSTANCE.ThereWereTestFailures();
-        resultTitle.className = "label col-md-12 label-danger";
+//        resultTitle.textContent = TestScenarioConstants.INSTANCE.ThereWereTestFailures();
+//        resultTitle.className = "label col-md-12 label-danger";
     }
 
     @Override
@@ -137,9 +125,9 @@ public class TestRunnerReportingViewImpl
         DateTimeFormat minutesFormat = DateTimeFormat.getFormat("m");
         DateTimeFormat secondsFormat = DateTimeFormat.getFormat("s");
 
-        resultStats.textContent = TestScenarioConstants.INSTANCE.XTestsRanInYMinutesZSeconds(runCount,
-                                                                                             minutesFormat.format(date),
-                                                                                             secondsFormat.format(date));
+//        resultStats.textContent = TestScenarioConstants.INSTANCE.XTestsRanInYMinutesZSeconds(runCount,
+//                                                                                             minutesFormat.format(date),
+//                                                                                             secondsFormat.format(date));
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreenTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/reporting/TestRunnerReportingScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,91 @@
 
 package org.drools.workbench.screens.testscenario.client.reporting;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.testscenario.client.service.TestRuntimeReportingService;
+import org.guvnor.common.services.shared.test.Failure;
+import org.guvnor.common.services.shared.test.TestResultMessage;
+import org.guvnor.messageconsole.events.SystemMessage;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(GwtMockitoTestRunner.class)
 public class TestRunnerReportingScreenTest {
 
     private TestRunnerReportingView view;
     private TestRunnerReportingScreen screen;
+    private Failure failure;
+
+    @Captor
+    ArgumentCaptor<ArrayList<SystemMessage>> captor;
 
     @Before
     public void setUp() throws Exception {
         view = mock(TestRunnerReportingView.class);
         TestRuntimeReportingService testRuntimeReportingService = mock(TestRuntimeReportingService.class);
         screen = new TestRunnerReportingScreen(view,
-                testRuntimeReportingService);
+                                               testRuntimeReportingService);
+        failure = mock(Failure.class);
     }
 
     @Test
     public void testSetPresenter() throws Exception {
         verify(view).setPresenter(screen);
+    }
+
+    @Test
+    public void testSuccessfulRun() {
+        TestResultMessage testResultMessage = new TestResultMessage("id",
+                                                                    1,
+                                                                    250,
+                                                                    new ArrayList<>());
+        screen.onTestRun(testResultMessage);
+        verify(view).showSuccess();
+        verify(view).setRunStatus(any(),
+                                  eq("1"),
+                                  eq("250 milliseconds"));
+    }
+
+    @Test
+    public void testUnSuccessfulRun() {
+        when(failure.getDisplayName()).thenReturn("Expected true but was false.");
+        when(failure.getMessage()).thenReturn("This is a non-null message");
+        TestResultMessage testResultMessage = new TestResultMessage("id",
+                                                                    1,
+                                                                    2500,
+                                                                    Collections.singletonList(failure));
+        screen.onTestRun(testResultMessage);
+        verify(view).setSystemMessages(captor.capture());
+        assertThat("Expected true but was false. : This is a non-null message").isEqualTo(captor.getValue().get(0).getText());
+        verify(view).showFailure();
+        verify(view).setRunStatus(any(),
+                                  eq("1"),
+                                  eq("2 seconds and 500 milliseconds"));
+    }
+
+    @Test
+    public void testRunTimeInMinutes() {
+        TestResultMessage testResultMessage = new TestResultMessage("id",
+                                                                    150,
+                                                                    125000,
+                                                                    new ArrayList<>());
+        screen.onTestRun(testResultMessage);
+        verify(view).showSuccess();
+        verify(view).setRunStatus(any(),
+                                  eq("150"),
+                                  eq("2 minutes and 5 seconds"));
     }
 }


### PR DESCRIPTION
Updated design of the test result panel. 

1. Applied html and css from https://issues.jboss.org/browse/DROOLS-2707.
2. After talk with Liz and Stetson we decided to rename the "View Details" to "View Alerts" and do not have a separate tab in Alerts for test results.
3. Made the test result message populate the alerts panel.
4. Removed even previously unused logic from the presenter and view.
5. Moved all logic to presenter to keep the view dummy.
6. Created unit tests for onTestRun method (previously called "onSuccess").

The donut graph for visualization the results (scenario status) will be done in other subtask, as well as moving the panel to a location where it can be reused in the new test scenarios, too.

@Rikkola @kkufova can you please review?
@jomarko please also have a look, this is going to influence your Selenium tests.