### PR TITLE
[DROOLS-2981] Fix collapsing cell/label default naming

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
@@ -53,7 +53,7 @@ public class AppendColumnCommand implements Command {
     public void execute() {
         final int index = model.getFirstIndexRightOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
-        String columnTitle = FactMapping.getPlaceHolder(factMappingType, (int) (model.getGroupSize(columnGroup) + 1));
+        String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
         model.insertNewColumn(index, getScenarioGridColumn(columnId, columnTitle, columnGroup, scenarioGridPanel, scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
@@ -64,7 +64,7 @@ public class InsertColumnCommand implements Command {
         String columnGroup = model.getColumns().get(columnIndex).getHeaderMetaData().get(1).getColumnGroup();
         int columnPosition = isRight ? columnIndex + 1 : columnIndex;
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
-        String columnTitle = FactMapping.getPlaceHolder(factMappingType, (int) (model.getGroupSize(columnGroup) + 1));
+        String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
         model.insertNewColumn(columnPosition, getScenarioGridColumn(columnId, columnTitle, columnGroup, scenarioGridPanel, scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
@@ -53,7 +53,7 @@ public class PrependColumnCommand implements Command {
     public void execute() {
         final int index = model.getFirstIndexLeftOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
-        String columnTitle = FactMapping.getPlaceHolder(factMappingType, (int) (model.getGroupSize(columnGroup) + 1));
+        String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
         model.insertNewColumn(index, getScenarioGridColumn(columnId, columnTitle, columnGroup, scenarioGridPanel, scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -46,6 +47,8 @@ public class ScenarioGridModel extends BaseGridData {
 
     EventBus eventBus;
 
+    AtomicInteger columnCounter = new AtomicInteger(0);
+
     public ScenarioGridModel() {
     }
 
@@ -60,10 +63,15 @@ public class ScenarioGridModel extends BaseGridData {
     public void bindContent(Simulation simulation) {
         this.simulation = simulation;
         checkSimulation();
+        columnCounter.set(simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
     }
 
     public void setEventBus(EventBus eventBus) {
         this.eventBus = eventBus;
+    }
+
+    public int nextColumnCount() {
+        return columnCounter.getAndIncrement();
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRenderer.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRenderer.java
@@ -15,8 +15,29 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.renderers;
 
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.ColumnRenderingStrategyFlattened;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.StringColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
 public class ScenarioGridColumnRenderer extends StringColumnRenderer {
 
+    @Override
+    public List<GridRenderer.RendererCommand> renderColumn(final GridColumn<?> column,
+                                                           final GridBodyColumnRenderContext context,
+                                                           final BaseGridRendererHelper rendererHelper,
+                                                           final BaseGridRendererHelper.RenderingInformation renderingInformation,
+                                                           final BiFunction<Boolean, GridColumn<?>, Boolean> columnRenderingConstraint) {
+        return ColumnRenderingStrategyFlattened.render(column,
+                                                       context,
+                                                       rendererHelper,
+                                                       renderingInformation,
+                                                       columnRenderingConstraint);
     }
+
+}


### PR DESCRIPTION
@kkufova @danielezonca 
Scope of this PR is to remove the "collapsing cell" behaviour.
Beside that, the second header level label generation has been modified, so that the number appearing to the right is always incremented, regardless of where the column is actually put.
This PR should be quick to check and has a minimal impact, so if everything is ok it could be merged before 2902