### PR TITLE
[DROOLS-3033] Fixing dependency declaration of drools-verifier-api

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -1311,7 +1311,7 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-wb-verifier-api</artifactId>
+      <artifactId>drools-verifier-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
@Rikkola @manstis @porcelli @danielezonca 
Scope of this PR is to fix the dependency declaration of drool verifier api inside drools-wb-webapp

drools-wb-verifier-api -> drools-verifier-api

Currently, enforcer find "drools-verifier-api" as transitive dependency, while in the pom the drools-wb-verifier-api one is declared.