### PR TITLE
Drools 3035 - Implement meaningful access to "significant" header metadata

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
@@ -61,7 +62,7 @@ public class InsertColumnCommand implements Command {
 
     @Override
     public void execute() {
-        String columnGroup = model.getColumns().get(columnIndex).getHeaderMetaData().get(1).getColumnGroup();
+        String columnGroup = ((ScenarioGridColumn) model.getColumns().get(columnIndex)).getInformationHeaderMetaData().getColumnGroup();
         int columnPosition = isRight ? columnIndex + 1 : columnIndex;
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
@@ -60,7 +61,7 @@ public class SetColumnValueCommand implements Command {
 
     @Override
     public void execute() {
-        String columnGroup = model.getColumns().get(columnIndex).getHeaderMetaData().get(1).getColumnGroup();
+        String columnGroup = ((ScenarioGridColumn) model.getColumns().get(columnIndex)).getInformationHeaderMetaData().getColumnGroup();
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         model.updateColumnType(columnIndex,
                                getScenarioGridColumn(value,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
@@ -70,7 +70,6 @@ public class SetColumnValueCommand implements Command {
         }
         int columnIndex = model.getColumns().indexOf(selectedColumn);
         String columnGroup = selectedColumn.getInformationHeaderMetaData().getColumnGroup();
-//        String columnGroup = ((ScenarioGridColumn) model.getColumns().get(columnIndex)).getInformationHeaderMetaData().getColumnGroup();
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         model.updateColumnType(columnIndex,
                                getScenarioGridColumn(value,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
@@ -22,7 +22,6 @@ import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGr
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.mvp.Command;
 
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
@@ -65,15 +64,13 @@ public class SetColumnValueCommand implements Command {
 
     @Override
     public void execute() {
-        GridColumn<?> selectedColumn = model.getSelectedColumn();
+        ScenarioGridColumn selectedColumn = (ScenarioGridColumn) model.getSelectedColumn();
         if (selectedColumn == null) {
             return;
         }
         int columnIndex = model.getColumns().indexOf(selectedColumn);
-        String columnGroup = selectedColumn.getHeaderMetaData().get(1).getColumnGroup();
-
-        String columnGroup = ((ScenarioGridColumn) model.getColumns().get(columnIndex)).getInformationHeaderMetaData().getColumnGroup();
-
+        String columnGroup = selectedColumn.getInformationHeaderMetaData().getColumnGroup();
+//        String columnGroup = ((ScenarioGridColumn) model.getColumns().get(columnIndex)).getInformationHeaderMetaData().getColumnGroup();
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         model.updateColumnType(columnIndex,
                                getScenarioGridColumn(value,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
@@ -41,6 +41,7 @@ import org.drools.workbench.screens.scenariosimulation.client.events.DisableRigh
 import org.drools.workbench.screens.scenariosimulation.client.events.EnableRightPanelEvent;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationGridHeaderUtilities.getColumnScenarioHeaderMetaData;
@@ -240,11 +241,11 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
         if (uiRowIndex == null) {
             return false;
         }
-        ScenarioHeaderMetaData columnMetadata = (ScenarioHeaderMetaData) scenarioGrid.getModel().getColumns().get(uiColumnIndex).getHeaderMetaData().get(1);
-        if (columnMetadata == null) {
+        ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) scenarioGrid.getModel().getColumns().get(uiColumnIndex);
+        if (scenarioGridColumn == null) {
             return false;
         }
-        String group = columnMetadata.getColumnGroup();
+        String group = scenarioGridColumn.getInformationHeaderMetaData().getColumnGroup();
         switch (group) {
             case "GIVEN":
             case "EXPECTED":

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaData.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaData.java
@@ -26,16 +26,19 @@ public class ScenarioHeaderMetaData extends BaseHeaderMetaData {
     final SingletonDOMElementFactory<TextBox, ScenarioHeaderTextBoxDOMElement> factory;
     final String columnId;
     final boolean readOnly;
+    // true if this header contains the column' main informations (group, title, id)
+    final boolean informationHeader;
 
-    public ScenarioHeaderMetaData(String columnId, String columnTitle, String columnGroup, final SingletonDOMElementFactory<TextBox, ScenarioHeaderTextBoxDOMElement> factory, boolean readOnly) {
+    public ScenarioHeaderMetaData(String columnId, String columnTitle, String columnGroup, final SingletonDOMElementFactory<TextBox, ScenarioHeaderTextBoxDOMElement> factory, boolean readOnly, boolean informationHeader) {
         super(columnTitle, columnGroup);
         this.columnId = columnId;
         this.factory = factory;
         this.readOnly = readOnly;
+        this.informationHeader = informationHeader;
     }
 
-    public ScenarioHeaderMetaData(String columnId, String columnTitle, String columnGroup, final SingletonDOMElementFactory<TextBox, ScenarioHeaderTextBoxDOMElement> factory) {
-        this(columnId, columnTitle, columnGroup, factory, false);
+    public ScenarioHeaderMetaData(String columnId, String columnTitle, String columnGroup, final SingletonDOMElementFactory<TextBox, ScenarioHeaderTextBoxDOMElement> factory,  boolean informationHeader) {
+        this(columnId, columnTitle, columnGroup, factory, false, informationHeader);
     }
 
     public void edit(final GridBodyCellEditContext context) {
@@ -53,5 +56,9 @@ public class ScenarioHeaderMetaData extends BaseHeaderMetaData {
 
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    public boolean isInformationHeader() {
+        return informationHeader;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -25,9 +25,9 @@ import java.util.stream.IntStream;
 
 import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.screens.scenariosimulation.client.events.ScenarioGridReloadEvent;
-import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridCell;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
@@ -188,9 +188,8 @@ public class ScenarioGridModel extends BaseGridData {
     public void updateColumnType(int columnIndex, final GridColumn<?> column, String fullPackage, String value, String lastLevelClassName) {
         checkSimulation();
         deleteNewColumn(columnIndex);
-        ScenarioHeaderMetaData scenarioHeaderMetaData = (ScenarioHeaderMetaData) column.getHeaderMetaData().get(1);
-        String group = scenarioHeaderMetaData.getColumnGroup();
-        String columnId = scenarioHeaderMetaData.getColumnId();
+        String group = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnGroup();
+        String columnId = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnId();
 
         String[] elements = value.split("\\.");
         if (!fullPackage.endsWith(".")) {
@@ -261,7 +260,7 @@ public class ScenarioGridModel extends BaseGridData {
         // HORRIBLE TRICK BECAUSE gridColumn.getIndex() DOES NOT REFLECT ACTUAL POSITION, BUT ONLY ORDER OF INSERTION
         final Optional<Integer> first = this.getColumns()    // Retrieving the column list
                 .stream()  // streaming
-                .filter(gridColumn -> gridColumn.getHeaderMetaData().get(1).getColumnGroup().equals(groupName))  // filtering by group name
+                .filter(gridColumn -> ((ScenarioGridColumn) gridColumn).getInformationHeaderMetaData().getColumnGroup().equals(groupName))  // filtering by group name
                 .findFirst()
                 .map(gridColumn -> {
                     int indexOfColumn = this.getColumns().indexOf(gridColumn);
@@ -279,7 +278,7 @@ public class ScenarioGridModel extends BaseGridData {
         // HORRIBLE TRICK BECAUSE gridColumn.getIndex() DOES NOT REFLECT ACTUAL POSITION, BUT ONLY ORDER OF INSERTION
         final Optional<Integer> last = this.getColumns()    // Retrieving the column list
                 .stream()  // streaming
-                .filter(gridColumn -> gridColumn.getHeaderMetaData().get(1).getColumnGroup().equals(groupName))  // filtering by group name
+                .filter(gridColumn -> ((ScenarioGridColumn) gridColumn).getInformationHeaderMetaData().getColumnGroup().equals(groupName))  // filtering by group name
                 .reduce((first, second) -> second)  // reducing to have only the last element
                 .map(gridColumn -> {
                     int indexOfColumn = this.getColumns().indexOf(gridColumn);
@@ -296,7 +295,7 @@ public class ScenarioGridModel extends BaseGridData {
     public long getGroupSize(String groupName) {
         return this.getColumns()
                 .stream()
-                .filter(gridColumn -> gridColumn.getHeaderMetaData().get(1).getColumnGroup().equals(groupName))
+                .filter(gridColumn -> ((ScenarioGridColumn) gridColumn).getInformationHeaderMetaData().getColumnGroup().equals(groupName))
                 .count();
     }
 
@@ -365,9 +364,8 @@ public class ScenarioGridModel extends BaseGridData {
      * @param column
      */
     protected void commonAddColumn(final int index, final GridColumn<?> column) {
-        ScenarioHeaderMetaData scenarioHeaderMetaData = (ScenarioHeaderMetaData) column.getHeaderMetaData().get(1);
-        String group = scenarioHeaderMetaData.getColumnGroup();
-        String columnId = scenarioHeaderMetaData.getColumnId();
+        String group = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnGroup();
+        String columnId = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnId();
         FactIdentifier factIdentifier = FactIdentifier.create(columnId, String.class.getCanonicalName());
         ExpressionIdentifier ei = ExpressionIdentifier.create(columnId, FactMappingType.valueOf(group));
         commonAddColumn(index, column, factIdentifier, ei);
@@ -383,8 +381,7 @@ public class ScenarioGridModel extends BaseGridData {
      */
     protected void commonAddColumn(final int index, final GridColumn<?> column, FactIdentifier factIdentifier, ExpressionIdentifier ei) {
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
-        ScenarioHeaderMetaData scenarioHeaderMetaData = (ScenarioHeaderMetaData) column.getHeaderMetaData().get(1);
-        String title = scenarioHeaderMetaData.getTitle();
+        String title = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getTitle();
         final int columnIndex = index == -1 ? getColumnCount() : index;
         try {
             simulationDescriptor.addFactMapping(columnIndex, title, factIdentifier, ei);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -60,9 +60,12 @@ public class ScenarioSimulationUtils {
 //            return columnBuilder;
 //        }
 
+        boolean informationHeader = isOther(factMappingType) || isExpected(factMappingType) || isGiven(factMappingType);
         columnBuilder.newLevel()
                 .setColumnTitle(title)
-                .setColumnGroup(columnGroup).setReadOnly(false);
+                .setColumnGroup(columnGroup)
+                .setReadOnly(false)
+                .setInformationHeader(informationHeader);
 
         return columnBuilder;
     }
@@ -71,12 +74,21 @@ public class ScenarioSimulationUtils {
         return FactMappingType.OTHER.equals(factMappingType);
     }
 
+    private static boolean isExpected(FactMappingType factMappingType) {
+        return FactMappingType.EXPECTED.equals(factMappingType);
+    }
+
+    private static boolean isGiven(FactMappingType factMappingType) {
+        return FactMappingType.GIVEN.equals(factMappingType);
+    }
+
     public static class ColumnBuilder {
 
         String columnId;
         String columnTitle;
         String columnGroup = "";
         boolean readOnly = false;
+        boolean informationHeader = false;
         ColumnBuilder nestedLevel;
 
         public static ColumnBuilder get() {
@@ -103,6 +115,11 @@ public class ScenarioSimulationUtils {
             return this;
         }
 
+        public ColumnBuilder setInformationHeader(boolean informationHeader) {
+            this.informationHeader = informationHeader;
+            return this;
+        }
+
         public ColumnBuilder newLevel() {
             this.nestedLevel = ColumnBuilder.get()
                     .setColumnId(columnId)
@@ -123,7 +140,7 @@ public class ScenarioSimulationUtils {
         }
 
         private GridColumn.HeaderMetaData internalBuild(ScenarioHeaderTextBoxSingletonDOMElementFactory factory) {
-            return new ScenarioHeaderMetaData(columnId, columnTitle, columnGroup, factory, readOnly);
+            return new ScenarioHeaderMetaData(columnId, columnTitle, columnGroup, factory, readOnly, informationHeader);
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
@@ -31,14 +32,18 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
 
     private final ScenarioCellTextBoxSingletonDOMElementFactory factory;
 
+    final ScenarioHeaderMetaData informationHeaderMetaData;
+
     public ScenarioGridColumn(HeaderMetaData headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory) {
         super(headerMetaData, columnRenderer, width);
+        this.informationHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData;
         this.setMovable(isMovable);
         this.factory = factory;
     }
 
     public ScenarioGridColumn(List<HeaderMetaData> headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory) {
         super(headerMetaData, columnRenderer, width);
+        this.informationHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData.stream().filter(hdm -> ((ScenarioHeaderMetaData) hdm).isInformationHeader()).findFirst().orElse(headerMetaData.get(0));
         this.setMovable(isMovable);
         this.factory = factory;
     }
@@ -48,6 +53,10 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
         factory.attachDomElement(context,
                                  e -> e.getWidget().setValue(assertCell(cell).getValue().getValue()),
                                  e -> e.getWidget().setFocus(true));
+    }
+
+    public ScenarioHeaderMetaData getInformationHeaderMetaData() {
+        return informationHeaderMetaData;
     }
 
     private GridCell<String> assertCell(final GridCell<String> cell) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
@@ -19,9 +19,11 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import java.util.List;
 
 import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.RightPanelPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
@@ -30,6 +32,7 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractCommandTest {
@@ -51,15 +54,15 @@ public abstract class AbstractCommandTest {
     protected EventBus mockEventBus;
 
     @Mock
-    protected List<GridColumn<?>> mockColumns;
+    protected List<ScenarioGridColumn> mockColumns;
 
     @Mock
-    protected GridColumn mockGridColumn;
+    protected ScenarioGridColumn mockGridColumn;
 
     @Mock
     protected List<GridColumn.HeaderMetaData> mockHeaderMetaDatas;
     @Mock
-    protected GridColumn.HeaderMetaData mockHeaderMetaData;
+    protected /*GridColumn.HeaderMetaData */ ScenarioHeaderMetaData mockHeaderMetaData;
 
     protected final String COLUMN_ID = "COLUMN ID";
 
@@ -82,8 +85,9 @@ public abstract class AbstractCommandTest {
         when(mockHeaderMetaData.getColumnGroup()).thenReturn(COLUMN_GROUP);
         when(mockHeaderMetaDatas.get(1)).thenReturn(mockHeaderMetaData);
         when(mockGridColumn.getHeaderMetaData()).thenReturn(mockHeaderMetaDatas);
+        when(mockGridColumn.getInformationHeaderMetaData()).thenReturn(mockHeaderMetaData);
         when(mockColumns.get(COLUMN_INDEX)).thenReturn(mockGridColumn);
-        when(mockScenarioGridModel.getColumns()).thenReturn(mockColumns);
+        doReturn(mockColumns).when(mockScenarioGridModel).getColumns();
         when(mockScenarioGrid.getModel()).thenReturn(mockScenarioGridModel);
         when(mockScenarioGridLayer.getScenarioGrid()).thenReturn(mockScenarioGrid);
         when(mockScenarioGridPanel.getScenarioGridLayer()).thenReturn(mockScenarioGridLayer);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractCommandTest {
     @Mock
     protected List<GridColumn.HeaderMetaData> mockHeaderMetaDatas;
     @Mock
-    protected /*GridColumn.HeaderMetaData */ ScenarioHeaderMetaData mockHeaderMetaData;
+    protected ScenarioHeaderMetaData mockHeaderMetaData;
 
     protected final String COLUMN_ID = "COLUMN ID";
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommandTest.java
@@ -28,6 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,7 +46,7 @@ public class SetColumnValueCommandTest extends AbstractCommandTest {
         super.setup();
         when(mockGridColumns.indexOf(mockGridColumn)).thenReturn(COLUMN_INDEX);
         when(mockScenarioGridModel.getColumns()).thenReturn(mockGridColumns);
-        when(mockScenarioGridModel.getSelectedColumn()).thenReturn(mockGridColumn);
+        doReturn(mockGridColumn).when(mockScenarioGridModel).getSelectedColumn();
         setColumnValueCommand = new SetColumnValueCommand(mockScenarioGridModel, COLUMN_ID, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME, mockScenarioGridPanel, mockScenarioGridLayer);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/AbstractScenarioSimulationEditorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/AbstractScenarioSimulationEditorTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractScenarioSimulationEditorTest {
 
     public void setup() {
 
-//        //Mock FileMenuBuilder usage since we cannot use FileMenuBuilderImpl either
+        // Mock FileMenuBuilder usage since we cannot use FileMenuBuilderImpl either
         when(mockFileMenuBuilder.addSave(any(MenuItem.class))).thenReturn(mockFileMenuBuilder);
         when(mockFileMenuBuilder.addCopy(any(ObservablePath.class), any(DefaultFileNameValidator.class))).thenReturn(mockFileMenuBuilder);
         when(mockFileMenuBuilder.addRename(any(Command.class))).thenReturn(mockFileMenuBuilder);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -196,7 +196,6 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
 
             @Override
             void populateRightPanel() {
-                //
             }
 
             @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaDataTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/metadata/ScenarioHeaderMetaDataTest.java
@@ -40,7 +40,7 @@ public class ScenarioHeaderMetaDataTest {
 
     @Test
     public void editTest() {
-        ScenarioHeaderMetaData scenarioHeaderMetaData = new ScenarioHeaderMetaData("", "", "", factory);
+        ScenarioHeaderMetaData scenarioHeaderMetaData = new ScenarioHeaderMetaData("", "", "", factory, false, false);
         scenarioHeaderMetaData.edit(null);
 
         verify(factory, times(1)).attachDomElement(any(), any(), any());
@@ -48,7 +48,7 @@ public class ScenarioHeaderMetaDataTest {
 
     @Test(expected = IllegalStateException.class)
     public void editFailTest() {
-        ScenarioHeaderMetaData scenarioHeaderMetaData = new ScenarioHeaderMetaData("", "", "", factory, true);
+        ScenarioHeaderMetaData scenarioHeaderMetaData = new ScenarioHeaderMetaData("", "", "", factory, true, false);
 
         scenarioHeaderMetaData.edit(null);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -153,7 +153,6 @@ public class ScenarioGridModelTest {
 
             @Override
             public void deleteColumn(GridColumn<?> column) {
-                //
             }
         });
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
@@ -54,7 +55,7 @@ public class ScenarioGridModelTest {
     private ScenarioGridModel scenarioGridModel;
 
     @Mock
-    private GridColumn<String> mockGridStringColumn;
+    private ScenarioGridColumn mockScenarioGridColumn;
 
     @Mock
     private GridColumn<?> mockGridColumn;
@@ -116,11 +117,12 @@ public class ScenarioGridModelTest {
 
     @Before
     public void setup() {
-        when(mockGridStringColumns.get(COLUMN_INDEX)).thenReturn(mockGridStringColumn);
+        when(mockGridStringColumns.get(COLUMN_INDEX)).thenReturn(mockScenarioGridColumn);
         when(mockRows.get(ROW_INDEX)).thenReturn(mockGridRow);
         when(mockSimulationDescriptor.getFactMappingByIndex(COLUMN_INDEX)).thenReturn(mockFactMapping);
         when(mockSimulation.getSimulationDescriptor()).thenReturn(mockSimulationDescriptor);
-        when(mockGridStringColumn.getHeaderMetaData()).thenReturn(mockHeaderMetaDataList);
+        when(mockScenarioGridColumn.getInformationHeaderMetaData()).thenReturn(mockHeaderMetaData);
+        when(mockScenarioGridColumn.getHeaderMetaData()).thenReturn(mockHeaderMetaDataList);
         when(mockHeaderMetaDataList.get(1)).thenReturn(mockHeaderMetaData);
         when(mockHeaderMetaData.getTitle()).thenReturn(GRID_COLUMN_TITLE);
         when(mockHeaderMetaData.getColumnGroup()).thenReturn(GRID_COLUMN_GROUP);
@@ -170,8 +172,8 @@ public class ScenarioGridModelTest {
     @Test
     public void appendNewColumn() {
         reset(scenarioGridModel);
-        scenarioGridModel.appendNewColumn(mockGridStringColumn);
-        verify(scenarioGridModel, times(1)).commonAddColumn(eq(-1), eq(mockGridStringColumn));
+        scenarioGridModel.appendNewColumn(mockScenarioGridColumn);
+        verify(scenarioGridModel, times(1)).commonAddColumn(eq(-1), eq(mockScenarioGridColumn));
     }
 
     @Test
@@ -217,16 +219,16 @@ public class ScenarioGridModelTest {
     @Test
     public void insertColumn() {
         reset(scenarioGridModel);
-        scenarioGridModel.insertColumn(COLUMN_INDEX, mockGridStringColumn);
+        scenarioGridModel.insertColumn(COLUMN_INDEX, mockScenarioGridColumn);
         verify(scenarioGridModel, times(1)).checkSimulation();
     }
 
     @Test
     public void insertNewColumn() {
         reset(scenarioGridModel);
-        scenarioGridModel.insertNewColumn(COLUMN_INDEX, mockGridStringColumn);
+        scenarioGridModel.insertNewColumn(COLUMN_INDEX, mockScenarioGridColumn);
         verify(scenarioGridModel, times(1)).checkSimulation();
-        verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockGridStringColumn));
+        verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockScenarioGridColumn));
     }
 
     @Test
@@ -239,10 +241,10 @@ public class ScenarioGridModelTest {
     @Test
     public void updateColumnType() {
         reset(scenarioGridModel);
-        scenarioGridModel.updateColumnType(COLUMN_INDEX, mockGridColumn, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME);
+        scenarioGridModel.updateColumnType(COLUMN_INDEX, mockScenarioGridColumn, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME);
         verify(scenarioGridModel, times(2)).checkSimulation();
         verify(scenarioGridModel, times(1)).deleteNewColumn(eq(COLUMN_INDEX));
-        verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockGridColumn), isA(FactIdentifier.class), isA(ExpressionIdentifier.class));
+        verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockScenarioGridColumn), isA(FactIdentifier.class), isA(ExpressionIdentifier.class));
         verify(scenarioGridModel, times(1)).selectColumn(eq(COLUMN_INDEX));
 
     }
@@ -262,7 +264,7 @@ public class ScenarioGridModelTest {
     @Test
     public void commonAddColumn() {
         reset(scenarioGridModel);
-        scenarioGridModel.commonAddColumn(COLUMN_INDEX, mockGridStringColumn);
+        scenarioGridModel.commonAddColumn(COLUMN_INDEX, mockScenarioGridColumn);
         verify(scenarioGridModel, times(0)).checkSimulation();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -36,15 +36,6 @@ public class ScenarioSimulationUtilsTest {
 
         String alias = "Alias";
         String factName = "FactName";
-        String expressionName = "ExpressionName";
-
-//        ScenarioSimulationUtils.ColumnBuilder columnBuilderOther =
-//                ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.OTHER.name(), FactMappingType.OTHER);
-//        assertEquals(1, columnBuilderOther.build(factory).size());
-//        assertEquals(FactMappingType.OTHER.name(), columnBuilderOther.columnGroup);
-//        assertNull(columnBuilderOther.nestedLevel);
-//        assertEquals(alias, columnBuilderOther.columnTitle);
-
         ScenarioSimulationUtils.ColumnBuilder columnBuilderGiven =
                 ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.GIVEN.name(), FactMappingType.GIVEN);
         assertEquals(2, columnBuilderGiven.build(factory).size());


### PR DESCRIPTION
@jomarko @Rikkola @danielezonca 
Scope of this PR is to avoid calling "getHeaderMetadata().get(1) to retrieve the column information shown on grid. To realize that, the "InformationHeaderMetaData"  has been introduced inside ScenarioGridColumn.

This modification has impact on all the grid rendering, but it should be absolutely transparent for the final user.