### PR TITLE
[DROOLS-3044] Update ScenarioGridModel inherited methods to align Simulation model

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
@@ -54,11 +54,11 @@ public class AppendColumnCommand implements Command {
         final int index = model.getFirstIndexRightOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertNewColumn(index, getScenarioGridColumn(columnTitle,
-                                                           columnId,
-                                                           columnGroup,
-                                                           factMappingType,
-                                                           scenarioGridPanel,
-                                                           scenarioGridLayer));
+        model.insertColumn(index, getScenarioGridColumn(columnTitle,
+                                                        columnId,
+                                                        columnGroup,
+                                                        factMappingType,
+                                                        scenarioGridPanel,
+                                                        scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendRowCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendRowCommand.java
@@ -35,6 +35,6 @@ public class AppendRowCommand implements Command {
 
     @Override
     public void execute() {
-        model.appendNewRow(new ScenarioGridRow());
+        model.appendRow(new ScenarioGridRow());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommand.java
@@ -60,16 +60,16 @@ public class DeleteColumnCommand implements Command {
 
     @Override
     public void execute() {
-        model.deleteNewColumn(columnIndex);
+        model.deleteColumn(columnIndex);
         if (model.getGroupSize(columnGroup) < 1) {
             FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
             String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-            model.insertNewColumn(columnIndex, getScenarioGridColumn(columnTitle,
-                                                                     String.valueOf(new Date().getTime()),
-                                                                     columnGroup,
-                                                                     factMappingType,
-                                                                     scenarioGridPanel,
-                                                                     scenarioGridLayer));
+            model.insertColumn(columnIndex, getScenarioGridColumn(columnTitle,
+                                                                  String.valueOf(new Date().getTime()),
+                                                                  columnGroup,
+                                                                  factMappingType,
+                                                                  scenarioGridPanel,
+                                                                  scenarioGridLayer));
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteRowCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteRowCommand.java
@@ -43,6 +43,6 @@ public class DeleteRowCommand implements Command {
 
     @Override
     public void execute() {
-        model.deleteNewRow(rowIndex);
+        model.deleteRow(rowIndex);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DuplicateRowCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DuplicateRowCommand.java
@@ -44,6 +44,6 @@ public class DuplicateRowCommand implements Command {
 
     @Override
     public void execute() {
-        model.duplicateNewRow(rowIndex, new ScenarioGridRow());
+        model.duplicateRow(rowIndex, new ScenarioGridRow());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
@@ -65,11 +65,11 @@ public class InsertColumnCommand implements Command {
         int columnPosition = isRight ? columnIndex + 1 : columnIndex;
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertNewColumn(columnPosition, getScenarioGridColumn(columnTitle,
-                                                                    columnId,
-                                                                    columnGroup,
-                                                                    factMappingType,
-                                                                    scenarioGridPanel,
-                                                                    scenarioGridLayer));
+        model.insertColumn(columnPosition, getScenarioGridColumn(columnTitle,
+                                                                 columnId,
+                                                                 columnGroup,
+                                                                 factMappingType,
+                                                                 scenarioGridPanel,
+                                                                 scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertRowCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertRowCommand.java
@@ -37,6 +37,6 @@ public class InsertRowCommand implements Command {
 
     @Override
     public void execute() {
-        model.insertNewRow(rowIndex, new ScenarioGridRow());
+        model.insertRow(rowIndex, new ScenarioGridRow());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
@@ -54,11 +54,11 @@ public class PrependColumnCommand implements Command {
         final int index = model.getFirstIndexLeftOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertNewColumn(index, getScenarioGridColumn(columnTitle,
-                                                           columnId,
-                                                           columnGroup,
-                                                           factMappingType,
-                                                           scenarioGridPanel,
-                                                           scenarioGridLayer));
+        model.insertColumn(index, getScenarioGridColumn(columnTitle,
+                                                        columnId,
+                                                        columnGroup,
+                                                        factMappingType,
+                                                        scenarioGridPanel,
+                                                        scenarioGridLayer));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependRowCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependRowCommand.java
@@ -35,6 +35,6 @@ public class PrependRowCommand implements Command {
 
     @Override
     public void execute() {
-        model.insertNewRow(0, new ScenarioGridRow());
+        model.insertRow(0, new ScenarioGridRow());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextBoxDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextBoxDOMElement.java
@@ -34,12 +34,12 @@ public class ScenarioCellTextBoxDOMElement extends TextBoxDOMElement {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
         if (value == null || value.trim().isEmpty()) {
-            ((ScenarioGridModel) gridWidget.getModel()).deleteNewCell(rowIndex,
-                                                                      columnIndex);
+            ((ScenarioGridModel) gridWidget.getModel()).deleteCell(rowIndex,
+                                                                   columnIndex);
         } else {
-            ((ScenarioGridModel) gridWidget.getModel()).setNewCellValue(rowIndex,
-                                                                        columnIndex,
-                                                                        new BaseGridCellValue<String>(value));
+            ((ScenarioGridModel) gridWidget.getModel()).setCellValue(rowIndex,
+                                                                     columnIndex,
+                                                                     new BaseGridCellValue<String>(value));
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -423,7 +423,6 @@ public class ScenarioGridModel extends BaseGridData {
     }
 
     protected void commonAddRow(int rowIndex) {
-        GWT.log("commonAddRow " + rowIndex);
         Scenario scenario = simulation.addScenario(rowIndex);
         final SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
         IntStream.range(1, getColumnCount()).forEach(columnIndex -> {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -156,7 +156,6 @@ public class ScenarioGridModel extends BaseGridData {
      * @param index
      * @param column
      */
-    //@Override
     public void insertColumnGridOnly(final int index, final GridColumn<?> column) {
         checkSimulation();
         super.insertColumn(index, column);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -98,7 +98,7 @@ public class ScenarioGrid extends BaseGridWidget {
                     String columnId = factMapping.getExpressionIdentifier().getName();
                     String columnTitle = factMapping.getExpressionAlias();
                     String columnGroup = factMapping.getExpressionIdentifier().getType().name();
-                    model.insertColumn(index, getScenarioGridColumn(columnTitle,
+                    ((ScenarioGridModel) model).insertColumnGridOnly(index, getScenarioGridColumn(columnTitle,
                                                                     columnId,
                                                                     columnGroup,
                                                                     factMapping.getExpressionIdentifier().getType(),
@@ -110,7 +110,7 @@ public class ScenarioGrid extends BaseGridWidget {
     void appendRows(Simulation simulation) {
         List<Scenario> scenarios = simulation.getUnmodifiableScenarios();
         IntStream.range(0, scenarios.size()).forEach(rowIndex -> {
-            ((ScenarioGridModel) model).insertRow(rowIndex, new ScenarioGridRow(), scenarios.get(rowIndex));
+            ((ScenarioGridModel) model).insertRowGridOnly(rowIndex, new ScenarioGridRow(), scenarios.get(rowIndex));
         });
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommandTest.java
@@ -44,6 +44,6 @@ public class AppendColumnCommandTest extends AbstractCommandTest {
     public void execute() {
         appendColumnCommand.execute();
         verify(mockScenarioGridModel, times(1)).getFirstIndexRightOfGroup(eq(COLUMN_GROUP));
-        verify(mockScenarioGridModel, times(1)).insertNewColumn(eq(FIRST_INDEX_RIGHT), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_RIGHT), isA(ScenarioGridColumn.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendRowCommandTest.java
@@ -42,6 +42,6 @@ public class AppendRowCommandTest extends AbstractCommandTest {
     @Test
     public void execute() {
         appendRowCommand.execute();
-        verify(mockScenarioGridModel, times(1)).appendNewRow(isA(ScenarioGridRow.class));
+        verify(mockScenarioGridModel, times(1)).appendRow(isA(ScenarioGridRow.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommandTest.java
@@ -49,12 +49,12 @@ public class DeleteColumnCommandTest extends AbstractCommandTest {
     public void execute() {
         when(mockScenarioGridModel.getGroupSize(COLUMN_GROUP)).thenReturn(4L);
         deleteColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).deleteNewColumn(eq(COLUMN_INDEX));
-        verify(mockScenarioGridModel,never()).insertNewColumn(anyInt(),anyObject());
+        verify(mockScenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
+        verify(mockScenarioGridModel,never()).insertColumn(anyInt(), anyObject());
         reset(mockScenarioGridModel);
         when(mockScenarioGridModel.getGroupSize(COLUMN_GROUP)).thenReturn(0L);
         deleteColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).deleteNewColumn(eq(COLUMN_INDEX));
-        verify(mockScenarioGridModel,times(1)).insertNewColumn(eq(COLUMN_INDEX),isA(GridColumn.class));
+        verify(mockScenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
+        verify(mockScenarioGridModel,times(1)).insertColumn(eq(COLUMN_INDEX), isA(GridColumn.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteRowCommandTest.java
@@ -41,6 +41,6 @@ public class DeleteRowCommandTest extends AbstractCommandTest {
     @Test
     public void execute() {
         deleteRowCommand.execute();
-        verify(mockScenarioGridModel, times(1)).deleteNewRow(eq(ROW_INDEX));
+        verify(mockScenarioGridModel, times(1)).deleteRow(eq(ROW_INDEX));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DuplicateRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DuplicateRowCommandTest.java
@@ -43,6 +43,6 @@ public class DuplicateRowCommandTest extends AbstractCommandTest {
     @Test
     public void execute() {
         duplicateRowCommand.execute();
-        verify(mockScenarioGridModel, times(1)).duplicateNewRow(eq(ROW_INDEX), isA(ScenarioGridRow.class));
+        verify(mockScenarioGridModel, times(1)).duplicateRow(eq(ROW_INDEX), isA(ScenarioGridRow.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommandTest.java
@@ -41,9 +41,9 @@ public class InsertColumnCommandTest extends AbstractCommandTest {
     public void execute() {
         insertColumnCommand = new InsertColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_INDEX, false, mockScenarioGridPanel, mockScenarioGridLayer);
         insertColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertNewColumn(eq(COLUMN_INDEX), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX), isA(ScenarioGridColumn.class));
         insertColumnCommand = new InsertColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_INDEX, true, mockScenarioGridPanel, mockScenarioGridLayer);
         insertColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertNewColumn(eq(COLUMN_INDEX + 1), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX + 1), isA(ScenarioGridColumn.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertRowCommandTest.java
@@ -40,6 +40,6 @@ public class InsertRowCommandTest extends AbstractCommandTest  {
     @Test
     public void execute() {
         insertRowCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertNewRow(eq(ROW_INDEX), isA(ScenarioGridRow.class));
+        verify(mockScenarioGridModel, times(1)).insertRow(eq(ROW_INDEX), isA(ScenarioGridRow.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommandTest.java
@@ -44,6 +44,6 @@ public class PrependColumnCommandTest extends AbstractCommandTest {
     public void execute() {
         prependColumnCommand.execute();
         verify(mockScenarioGridModel, times(1)).getFirstIndexLeftOfGroup(eq(COLUMN_GROUP));
-        verify(mockScenarioGridModel, times(1)).insertNewColumn(eq(FIRST_INDEX_LEFT), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_LEFT), isA(ScenarioGridColumn.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependRowCommandTest.java
@@ -43,6 +43,6 @@ public class PrependRowCommandTest extends AbstractCommandTest {
     @Test
     public void execute() {
         prependRowCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertNewRow(eq(0), isA(ScenarioGridRow.class));
+        verify(mockScenarioGridModel, times(1)).insertRow(eq(0), isA(ScenarioGridRow.class));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -168,50 +168,50 @@ public class ScenarioGridModelTest {
     }
 
     @Test
-    public void appendNewColumn() {
+    public void appendRow() {
         reset(scenarioGridModel);
-        scenarioGridModel.appendNewColumn(mockGridStringColumn);
-        verify(scenarioGridModel, times(1)).commonAddColumn(eq(-1), eq(mockGridStringColumn));
-    }
-
-    @Test
-    public void appendNewRow() {
-        reset(scenarioGridModel);
-        scenarioGridModel.appendNewRow(mockGridRow);
+        scenarioGridModel.appendRow(mockGridRow);
         verify(scenarioGridModel, times(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).commonAddRow(eq(ROW_COUNT - 1));
     }
 
     @Test
-    public void insertRow() {
+    public void insertRowGridOnly() {
         reset(scenarioGridModel);
-        scenarioGridModel.insertRow(ROW_INDEX, mockGridRow, mockScenario);
+        scenarioGridModel.insertRowGridOnly(ROW_INDEX, mockGridRow, mockScenario);
         verify(scenarioGridModel, times(1)).insertRow(eq(ROW_INDEX), eq(mockGridRow));
     }
 
     @Test
-    public void insertNewRow() {
+    public void insertRow() {
         reset(scenarioGridModel);
-        scenarioGridModel.insertNewRow(ROW_INDEX, mockGridRow);
+        scenarioGridModel.insertRow(ROW_INDEX, mockGridRow);
         verify(scenarioGridModel, times(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).commonAddRow(eq(ROW_INDEX));
     }
 
     @Test
-    public void deleteNewRow() {
+    public void deleteRow() {
         reset(scenarioGridModel);
-        scenarioGridModel.deleteNewRow(ROW_INDEX);
+        scenarioGridModel.deleteRow(ROW_INDEX);
         verify(scenarioGridModel, times(1)).checkSimulation();
         verify(mockSimulation, times(1)).removeScenarioByIndex(eq(ROW_INDEX));
     }
 
     @Test
-    public void duplicateNewRow() {
+    public void duplicateRow() {
         reset(scenarioGridModel);
-        scenarioGridModel.duplicateNewRow(ROW_INDEX, mockGridRow);
-        verify(scenarioGridModel, times(2)).checkSimulation();
+        scenarioGridModel.duplicateRow(ROW_INDEX, mockGridRow);
+        verify(scenarioGridModel, times(3)).checkSimulation();
         verify(mockSimulation, times(1)).cloneScenario(eq(ROW_INDEX), eq(ROW_INDEX + 1));
-        verify(scenarioGridModel, times(1)).insertRow(eq(ROW_INDEX + 1), eq(mockGridRow), isA(Scenario.class));
+        verify(scenarioGridModel, times(1)).insertRowGridOnly(eq(ROW_INDEX + 1), eq(mockGridRow), isA(Scenario.class));
+    }
+
+    @Test
+    public void insertColumnGridOnly() {
+        reset(scenarioGridModel);
+        scenarioGridModel.insertColumnGridOnly(COLUMN_INDEX, mockGridStringColumn);
+        verify(scenarioGridModel, times(1)).checkSimulation();
     }
 
     @Test
@@ -219,19 +219,12 @@ public class ScenarioGridModelTest {
         reset(scenarioGridModel);
         scenarioGridModel.insertColumn(COLUMN_INDEX, mockGridStringColumn);
         verify(scenarioGridModel, times(1)).checkSimulation();
-    }
-
-    @Test
-    public void insertNewColumn() {
-        reset(scenarioGridModel);
-        scenarioGridModel.insertNewColumn(COLUMN_INDEX, mockGridStringColumn);
-        verify(scenarioGridModel, times(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockGridStringColumn));
     }
 
     @Test
-    public void deleteNewColumn() {
-        scenarioGridModel.deleteNewColumn(COLUMN_INDEX);
+    public void deleteColumn() {
+        scenarioGridModel.deleteColumn(COLUMN_INDEX);
         verify(scenarioGridModel, times(1)).checkSimulation();
         verify(mockSimulation, times(1)).removeFactMappingByIndex(eq(COLUMN_INDEX));
     }
@@ -241,21 +234,21 @@ public class ScenarioGridModelTest {
         reset(scenarioGridModel);
         scenarioGridModel.updateColumnType(COLUMN_INDEX, mockGridColumn, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME);
         verify(scenarioGridModel, times(2)).checkSimulation();
-        verify(scenarioGridModel, times(1)).deleteNewColumn(eq(COLUMN_INDEX));
+        verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(mockGridColumn), isA(FactIdentifier.class), isA(ExpressionIdentifier.class));
         verify(scenarioGridModel, times(1)).selectColumn(eq(COLUMN_INDEX));
 
     }
 
     @Test
-    public void setCell() {
-        scenarioGridModel.setCell(ROW_INDEX, COLUMN_INDEX, gridCellSupplier);
+    public void setCellGridOnly() {
+        scenarioGridModel.setCellGridOnly(ROW_INDEX, COLUMN_INDEX, gridCellSupplier);
         verify(scenarioGridModel, times(1)).checkSimulation();
     }
 
     @Test
-    public void setNewCell() {
-        scenarioGridModel.setNewCell(ROW_INDEX, COLUMN_INDEX, gridCellSupplier);
+    public void setCell() {
+        scenarioGridModel.setCell(ROW_INDEX, COLUMN_INDEX, gridCellSupplier);
         verify(scenarioGridModel, times(1)).setCell(eq(ROW_INDEX), eq(COLUMN_INDEX), eq(gridCellSupplier));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -172,7 +173,7 @@ public class ScenarioGridModelTest {
     public void appendRow() {
         reset(scenarioGridModel);
         scenarioGridModel.appendRow(mockGridRow);
-        verify(scenarioGridModel, times(1)).checkSimulation();
+        verify(scenarioGridModel, atLeast(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).commonAddRow(eq(ROW_COUNT - 1));
     }
 
@@ -180,7 +181,7 @@ public class ScenarioGridModelTest {
     public void insertRowGridOnly() {
         reset(scenarioGridModel);
         scenarioGridModel.insertRowGridOnly(ROW_INDEX, mockGridRow, mockScenario);
-        verify(scenarioGridModel, times(1)).checkSimulation();
+        verify(scenarioGridModel, atLeast(1)).checkSimulation();
         verify(scenarioGridModel, never()).insertRow(eq(ROW_INDEX), eq(mockGridRow));
         verify(scenarioGridModel, times(1)).updateIndexColumn();
     }
@@ -189,7 +190,7 @@ public class ScenarioGridModelTest {
     public void insertRow() {
         reset(scenarioGridModel);
         scenarioGridModel.insertRow(ROW_INDEX, mockGridRow);
-        verify(scenarioGridModel, times(1)).checkSimulation();
+        verify(scenarioGridModel, atLeast(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).commonAddRow(eq(ROW_INDEX));
         verify(scenarioGridModel, times(1)).updateIndexColumn();
     }
@@ -198,7 +199,7 @@ public class ScenarioGridModelTest {
     public void deleteRow() {
         reset(scenarioGridModel);
         scenarioGridModel.deleteRow(ROW_INDEX);
-        verify(scenarioGridModel, times(1)).checkSimulation();
+        verify(scenarioGridModel, atLeast(1)).checkSimulation();
         verify(mockSimulation, times(1)).removeScenarioByIndex(eq(ROW_INDEX));
         verify(scenarioGridModel, times(1)).updateIndexColumn();
     }
@@ -207,7 +208,7 @@ public class ScenarioGridModelTest {
     public void duplicateRow() {
         reset(scenarioGridModel);
         scenarioGridModel.duplicateRow(ROW_INDEX, mockGridRow);
-        verify(scenarioGridModel, times(2)).checkSimulation();
+        verify(scenarioGridModel, atLeast(1)).checkSimulation();
         verify(mockSimulation, times(1)).cloneScenario(eq(ROW_INDEX), eq(ROW_INDEX + 1));
         verify(scenarioGridModel, times(1)).insertRowGridOnly(eq(ROW_INDEX + 1), eq(mockGridRow), isA(Scenario.class));
         verify(scenarioGridModel, never()).insertRow(eq(ROW_INDEX), eq(mockGridRow));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -179,7 +180,8 @@ public class ScenarioGridModelTest {
     public void insertRowGridOnly() {
         reset(scenarioGridModel);
         scenarioGridModel.insertRowGridOnly(ROW_INDEX, mockGridRow, mockScenario);
-        verify(scenarioGridModel, times(1)).insertRow(eq(ROW_INDEX), eq(mockGridRow));
+        verify(scenarioGridModel, times(1)).checkSimulation();
+        verify(scenarioGridModel, never()).insertRow(eq(ROW_INDEX), eq(mockGridRow));
     }
 
     @Test
@@ -202,9 +204,10 @@ public class ScenarioGridModelTest {
     public void duplicateRow() {
         reset(scenarioGridModel);
         scenarioGridModel.duplicateRow(ROW_INDEX, mockGridRow);
-        verify(scenarioGridModel, times(3)).checkSimulation();
+        verify(scenarioGridModel, times(2)).checkSimulation();
         verify(mockSimulation, times(1)).cloneScenario(eq(ROW_INDEX), eq(ROW_INDEX + 1));
         verify(scenarioGridModel, times(1)).insertRowGridOnly(eq(ROW_INDEX + 1), eq(mockGridRow), isA(Scenario.class));
+        verify(scenarioGridModel, never()).insertRow(eq(ROW_INDEX), eq(mockGridRow));
     }
 
     @Test


### PR DESCRIPTION
@jomarko @Rikkola @danielezonca 

Scope of this pr is to refactor ScenarioGridModel methods names to reflect following contract: "overrided" methods works on both basegrid and scenariosimulation models, "GridOnly" ones works only on basegrid model.

This modification has impact on all the grid rendering, but it should be absolutely transparent for the final user.