### PR TITLE
[DROOLS-3060] Perform an end to end test for Scenario asset

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/pom.xml
@@ -69,7 +69,12 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValue.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValue.java
@@ -86,14 +86,16 @@ public class FactMappingValue {
         String value = ((String) rawValue).trim();
 
         FactMappingValueOperator operator = FactMappingValueOperator.findOperator(value);
-        Optional<String> first = operator.getSymbols().stream().filter(value::startsWith).findFirst();
-        if (first.isPresent()) {
-            String symbolToRemove = first.get();
+        Optional<String> operatorSymbol = operator.getSymbols().stream().filter(value::startsWith).findFirst();
+        if (operatorSymbol.isPresent()) {
+            String symbolToRemove = operatorSymbol.get();
             int index = value.indexOf(symbolToRemove);
             value = value.substring(index + symbolToRemove.length()).trim();
         }
 
-        return value.trim();
+        String returnValue = value.trim();
+        // empty string is equivalent to null only if there is no operator symbol
+        return "".equals(returnValue) && !operatorSymbol.isPresent() ? null : returnValue;
     }
 
     public static FactMappingValueOperator extractOperator(Object rawValue) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValue.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValue.java
@@ -15,6 +15,7 @@
  */
 package org.drools.workbench.screens.scenariosimulation.model;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -37,8 +38,8 @@ public class FactMappingValue {
     }
 
     public FactMappingValue(FactIdentifier factIdentifier, ExpressionIdentifier expressionIdentifier, Object rawValue) {
-        this.factIdentifier = factIdentifier;
-        this.expressionIdentifier = expressionIdentifier;
+        this.factIdentifier = Objects.requireNonNull(factIdentifier, "FactIdentifier has to be not null");
+        this.expressionIdentifier = Objects.requireNonNull(expressionIdentifier, "ExpressionIdentifier has to be not null");
         this.rawValue = rawValue;
     }
 
@@ -64,7 +65,8 @@ public class FactMappingValue {
     }
 
     public FactMappingValueOperator getOperator() {
-        return operator != null ? operator : extractOperator(rawValue);
+        this.operator = extractOperator(rawValue);
+        return operator;
     }
 
     public Object getCleanValue() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValueTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValueTest.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.scenariosimulation.model;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class FactMappingValueTest {
 
@@ -38,6 +39,18 @@ public class FactMappingValueTest {
 
         rawValue = new Object();
         assertEquals(rawValue, FactMappingValue.cleanValue(rawValue));
+    }
+
+    @Test
+    public void cleanValueEmptyAndNullString() {
+        Object rawValue = "";
+        assertNull(FactMappingValue.cleanValue(rawValue));
+
+        rawValue = null;
+        assertNull(FactMappingValue.cleanValue(rawValue));
+
+        rawValue = " =  ";
+        assertEquals("", FactMappingValue.cleanValue(rawValue));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValueTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/FactMappingValueTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.model;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -69,5 +70,21 @@ public class FactMappingValueTest {
 
         rawValue = new Object();
         assertEquals(FactMappingValueOperator.EQUALS, FactMappingValue.extractOperator(rawValue));
+    }
+
+    @Test
+    public void checkOperator() {
+        FactMappingValue factMappingValue = new FactMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, null);
+        assertEquals(FactMappingValueOperator.EQUALS, factMappingValue.getOperator());
+        factMappingValue = new FactMappingValue(FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION, "!= value");
+        assertEquals(FactMappingValueOperator.NOT_EQUALS, factMappingValue.getOperator());
+
+        assertThatThrownBy(() -> new FactMappingValue(null, ExpressionIdentifier.DESCRIPTION, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("FactIdentifier has to be not null");
+
+        assertThatThrownBy(() -> new FactMappingValue(FactIdentifier.DESCRIPTION, null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("ExpressionIdentifier has to be not null");
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/SimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/SimulationTest.java
@@ -112,7 +112,8 @@ public class SimulationTest {
         assertEquals(1, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
         simulation.removeFactMapping(simulation.getSimulationDescriptor().getFactMappingByIndex(0));
         assertEquals(1, simulation.getUnmodifiableScenarios().get(0).getUnmodifiableFactMappingValues().size());
-        assertEquals(0, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());    }
+        assertEquals(0, simulation.getSimulationDescriptor().getUnmodifiableFactMappings().size());
+    }
 
     private <T extends Throwable> void muteException(Runnable toBeExecuted, Class<T> expected) {
         try {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImpl.java
@@ -35,7 +35,6 @@ import org.jboss.errai.bus.server.annotations.Service;
 import org.junit.runner.Result;
 import org.kie.api.runtime.KieContainer;
 import org.kie.workbench.common.services.backend.builder.service.BuildInfoService;
-import org.kie.workbench.common.services.backend.project.ModuleClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
 import org.uberfire.backend.vfs.Path;
@@ -55,9 +54,6 @@ public class ScenarioRunnerServiceImpl
 
     @Inject
     private BuildInfoService buildInfoService;
-
-    @Inject
-    private ModuleClassLoaderHelper classLoaderHelper;
 
     private BiFunction<KieContainer, Simulation, AbstractScenarioRunner> runnerSupplier = ScenarioRunnerImpl::new;
 
@@ -92,11 +88,11 @@ public class ScenarioRunnerServiceImpl
                         final ScenarioSimulationModel model) {
 
         KieModule kieModule = getKieModule(path);
-        ClassLoader moduleClassLoader = classLoaderHelper.getModuleClassLoader(kieModule);
         KieContainer kieContainer = getKieContainer(kieModule);
+        ClassLoader rootClassLoader = kieContainer.getClassLoader();
         AbstractScenarioRunner scenarioRunner = getRunnerSupplier().apply(kieContainer, model.getSimulation());
 
-        scenarioRunner.setClassLoader(moduleClassLoader);
+        scenarioRunner.setClassLoader(rootClassLoader);
 
         final List<Failure> failures = new ArrayList<>();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
@@ -109,7 +109,8 @@ public class ScenarioRunnerHelper {
 
     public static List<ScenarioResult> verifyConditions(SimulationDescriptor simulationDescriptor,
                                                         List<ScenarioInput> inputData,
-                                                        List<ScenarioOutput> outputData, ClassLoader classLoader) {
+                                                        List<ScenarioOutput> outputData,
+                                                        ClassLoader classLoader) {
         List<ScenarioResult> scenarioResult = new ArrayList<>();
 
         List<FactIdentifier> inputIds = inputData.stream().map(ScenarioInput::getFactIdentifier).collect(Collectors.toList());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
@@ -48,6 +48,7 @@ public class ScenarioRunnerHelper {
 
     private static final Map<String, Class<?>> primitiveMap = new HashMap<>();
     static {
+        primitiveMap.put("boolean", boolean.class);
         primitiveMap.put("int", int.class);
         primitiveMap.put("long", long.class);
         primitiveMap.put("double", double.class);
@@ -230,6 +231,8 @@ public class ScenarioRunnerHelper {
 
             if (clazz.isAssignableFrom(String.class)) {
                 return value;
+            } else if (clazz.isAssignableFrom(Boolean.class) || clazz.isAssignableFrom(boolean.class)) {
+                return Boolean.parseBoolean(value);
             } else if (clazz.isAssignableFrom(Integer.class) || clazz.isAssignableFrom(int.class)) {
                 return Integer.parseInt(value);
             } else if (clazz.isAssignableFrom(Long.class) || clazz.isAssignableFrom(long.class)) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelper.java
@@ -47,6 +47,7 @@ import static org.drools.workbench.screens.scenariosimulation.backend.server.uti
 public class ScenarioRunnerHelper {
 
     private static final Map<String, Class<?>> primitiveMap = new HashMap<>();
+
     static {
         primitiveMap.put("boolean", boolean.class);
         primitiveMap.put("int", int.class);
@@ -54,7 +55,6 @@ public class ScenarioRunnerHelper {
         primitiveMap.put("double", double.class);
         primitiveMap.put("float", float.class);
     }
-
 
     private ScenarioRunnerHelper() {
 
@@ -221,7 +221,7 @@ public class ScenarioRunnerHelper {
                     return cleanValue;
                 }
                 if (!isPrimitive(className) && cleanValue == null) {
-                    return cleanValue;
+                    return null;
                 }
                 throw new IllegalArgumentException(new StringBuilder().append("Object ").append(cleanValue)
                                                            .append(" is not a String or an instance of ").append(className).toString());
@@ -252,7 +252,7 @@ public class ScenarioRunnerHelper {
     }
 
     private static Class<?> loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
-        if(primitiveMap.containsKey(className)) {
+        if (primitiveMap.containsKey(className)) {
             return primitiveMap.get(className);
         }
         return classLoader.loadClass(className);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImpl.java
@@ -83,7 +83,8 @@ public class ScenarioRunnerImpl extends AbstractScenarioRunner {
             executeScenario(kieContainer, scenarioRunnerData.getInputData());
             List<ScenarioResult> scenarioResults = verifyConditions(simulationDescriptor,
                                                                     scenarioRunnerData.getInputData(),
-                                                                    scenarioRunnerData.getOutputData());
+                                                                    scenarioRunnerData.getOutputData(),
+                                                                    getClassLoader());
             validateAssertion(scenarioResults, scenario, singleNotifier);
 
             scenarioResults.forEach(scenarioRunnerData::addResult);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
@@ -59,7 +59,7 @@ public class ScenarioBeanUtil {
 
         Object currentObject = beanToFill;
         if (pathToProperty.size() > 0) {
-            currentObject = navigateToObject(beanToFill, pathToProperty);
+            currentObject = navigateToObject(beanToFill, pathToProperty, true);
         }
 
         Field last = currentObject.getClass().getDeclaredField(lastStep);
@@ -68,6 +68,10 @@ public class ScenarioBeanUtil {
     }
 
     public static Object navigateToObject(Object rootObject, List<String> steps) {
+        return navigateToObject(rootObject, steps, true);
+    }
+
+    public static Object navigateToObject(Object rootObject, List<String> steps, boolean createIfNull) {
         if (steps.size() < 1) {
             throw new ScenarioException(new StringBuilder().append("Invalid path to a property: path='")
                                                 .append(String.join(".", steps)).append("'").toString());
@@ -79,6 +83,11 @@ public class ScenarioBeanUtil {
         for (String step : steps) {
             Field declaredField = null;
             try {
+                if(currentObject == null) {
+                    throw new ScenarioException(new StringBuilder().append("Impossible to reach field ")
+                                                        .append(step).append(" because a step is not instantiated")
+                                                        .toString());
+                }
                 declaredField = currentClass.getDeclaredField(step);
             } catch (NoSuchFieldException e) {
                 throw new ScenarioException(new StringBuilder().append("Impossible to find field with name '")
@@ -88,7 +97,7 @@ public class ScenarioBeanUtil {
             declaredField.setAccessible(true);
             currentClass = declaredField.getType();
             try {
-                currentObject = getOrCreate(declaredField, currentObject);
+                currentObject = getFieldValue(declaredField, currentObject, createIfNull);
             } catch (ReflectiveOperationException e) {
                 throw new ScenarioException(new StringBuilder().append("Impossible to get or create class ")
                                                     .append(currentClass.getCanonicalName()).toString());
@@ -98,9 +107,9 @@ public class ScenarioBeanUtil {
         return currentObject;
     }
 
-    private static Object getOrCreate(Field declaredField, Object currentObject) throws ReflectiveOperationException {
+    private static Object getFieldValue(Field declaredField, Object currentObject, boolean createIfNull) throws ReflectiveOperationException {
         Object value = declaredField.get(currentObject);
-        if (value == null) {
+        if (value == null && createIfNull) {
             value = newInstance(declaredField.getType());
             declaredField.set(currentObject, value);
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
@@ -73,8 +73,7 @@ public class ScenarioBeanUtil {
 
     public static Object navigateToObject(Object rootObject, List<String> steps, boolean createIfNull) {
         if (steps.size() < 1) {
-            throw new ScenarioException(new StringBuilder().append("Invalid path to a property: path='")
-                                                .append(String.join(".", steps)).append("'").toString());
+            throw new ScenarioException(new StringBuilder().append("Invalid path to a property, no steps provided").toString());
         }
 
         Class<?> currentClass = rootObject.getClass();
@@ -83,7 +82,7 @@ public class ScenarioBeanUtil {
         for (String step : steps) {
             Field declaredField = null;
             try {
-                if(currentObject == null) {
+                if (currentObject == null) {
                     throw new ScenarioException(new StringBuilder().append("Impossible to reach field ")
                                                         .append(step).append(" because a step is not instantiated")
                                                         .toString());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtil.java
@@ -33,10 +33,10 @@ public class ScenarioBeanUtil {
         Class<T> clazz = loadClass(className, classLoader);
 
         // if a direct mapping exists (no steps to reach the field) the value itself is the object
-        Optional<Object> noStepMapping = params.entrySet().stream()
+        Optional<Object> directMapping = params.entrySet().stream()
                 .filter(e -> e.getKey().isEmpty()).map(Map.Entry::getValue).findFirst();
-        if (noStepMapping.isPresent()) {
-            return (T) noStepMapping.get();
+        if (directMapping.isPresent()) {
+            return (T) directMapping.get();
         }
 
         T beanToFill = newInstance(clazz);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
@@ -21,6 +21,7 @@ import org.guvnor.common.services.shared.test.TestResultMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.api.runtime.KieContainer;
 import org.kie.workbench.common.services.backend.builder.service.BuildInfo;
 import org.kie.workbench.common.services.backend.builder.service.BuildInfoService;
 import org.kie.workbench.common.services.backend.project.ModuleClassLoaderHelper;
@@ -56,6 +57,9 @@ public class ScenarioRunnerImplServiceImplTest {
     private BuildInfo buildInfo;
 
     @Mock
+    private KieContainer kieContainer;
+
+    @Mock
     private ModuleClassLoaderHelper classLoaderHelper;
 
     @InjectMocks
@@ -76,6 +80,7 @@ public class ScenarioRunnerImplServiceImplTest {
     @Test
     public void runTest() throws Exception {
         when(buildInfoService.getBuildInfo(any())).thenReturn(buildInfo);
+        when(buildInfo.getKieContainer()).thenReturn(kieContainer);
         scenarioRunnerService.runTest("test", mock(Path.class), new ScenarioSimulationModel());
 
         verify(defaultTestResultMessageEvent).fire(any());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelperTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Dispute;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Person;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioInput;
@@ -57,12 +58,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ScenarioRunnerImplHelperTest {
+public class ScenarioRunnerHelperTest {
 
     private static final String NAME = "NAME";
     private static final double AMOUNT = 10;
     private static final String TEST_DESCRIPTION = "Test description";
-    private static final ClassLoader classLoader = ScenarioRunnerImplHelperTest.class.getClassLoader();
+    private static final ClassLoader classLoader = ScenarioRunnerHelperTest.class.getClassLoader();
 
     private Simulation simulation;
     private FactIdentifier personFactIdentifier;
@@ -149,13 +150,18 @@ public class ScenarioRunnerImplHelperTest {
         assertEquals(2, scenario2Results.size());
     }
 
-    @Test(expected = ScenarioException.class)
+    @Test
     public void verifyConditionsFailTest() {
         List<ScenarioInput> scenario1Inputs = extractGivenValues(simulation.getSimulationDescriptor(), scenario1.getUnmodifiableFactMappingValues(), classLoader);
         List<ScenarioOutput> scenario1Outputs = extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
         scenario1Outputs.add(new ScenarioOutput(FactIdentifier.create("NOT_EXISTING", String.class.getCanonicalName()), new ArrayList<>()));
 
-        verifyConditions(simulation.getSimulationDescriptor(), scenario1Inputs, scenario1Outputs, classLoader);
+
+        String expectedMessage = "Some expected conditions are not linked to any given facts: NOT_EXISTING";
+        Assertions.assertThatThrownBy(() -> verifyConditions(simulation.getSimulationDescriptor(),
+                                                             scenario1Inputs,
+                                                             scenario1Outputs,
+                                                             classLoader)).hasMessage(expectedMessage).isInstanceOf(ScenarioException.class);
     }
 
     @Test
@@ -255,7 +261,7 @@ public class ScenarioRunnerImplHelperTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void convertValueFailUnsupportedTest() {
-        convertValue(ScenarioRunnerImplHelperTest.class.getCanonicalName(), "Test", classLoader);
+        convertValue(ScenarioRunnerHelperTest.class.getCanonicalName(), "Test", classLoader);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -265,6 +271,6 @@ public class ScenarioRunnerImplHelperTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void convertValueFailNotStringOrTypeTest() {
-        convertValue(ScenarioRunnerImplHelperTest.class.getCanonicalName(), 1, classLoader);
+        convertValue(ScenarioRunnerHelperTest.class.getCanonicalName(), 1, classLoader);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerHelperTest.java
@@ -156,7 +156,6 @@ public class ScenarioRunnerHelperTest {
         List<ScenarioOutput> scenario1Outputs = extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
         scenario1Outputs.add(new ScenarioOutput(FactIdentifier.create("NOT_EXISTING", String.class.getCanonicalName()), new ArrayList<>()));
 
-
         String expectedMessage = "Some expected conditions are not linked to any given facts: NOT_EXISTING";
         Assertions.assertThatThrownBy(() -> verifyConditions(simulation.getSimulationDescriptor(),
                                                              scenario1Inputs,
@@ -234,7 +233,7 @@ public class ScenarioRunnerHelperTest {
     @Test(expected = IllegalArgumentException.class)
     public void groupByFactIdentifierAndFilterFailTest() {
         List<FactMappingValue> fail = new ArrayList<>();
-        fail.add(new FactMappingValue(personFactIdentifier, null, null));
+        fail.add(new FactMappingValue());
         groupByFactIdentifierAndFilter(fail, FactMappingType.GIVEN);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImplHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImplHelperTest.java
@@ -48,6 +48,7 @@ import static org.drools.workbench.screens.scenariosimulation.backend.server.run
 import static org.drools.workbench.screens.scenariosimulation.backend.server.runner.ScenarioRunnerHelper.validateAssertion;
 import static org.drools.workbench.screens.scenariosimulation.backend.server.runner.ScenarioRunnerHelper.verifyConditions;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -225,6 +226,8 @@ public class ScenarioRunnerImplHelperTest {
     @Test
     public void convertValueTest() {
         assertEquals("Test", convertValue(String.class.getCanonicalName(), "Test", classLoader));
+        assertEquals(false, convertValue(boolean.class.getCanonicalName(), "false", classLoader));
+        assertEquals(true, convertValue(Boolean.class.getCanonicalName(), "true", classLoader));
         assertEquals(1, convertValue(int.class.getCanonicalName(), "1", classLoader));
         assertEquals(1, convertValue(Integer.class.getCanonicalName(), "1", classLoader));
         assertEquals(1L, convertValue(long.class.getCanonicalName(), "1", classLoader));
@@ -233,7 +236,7 @@ public class ScenarioRunnerImplHelperTest {
         assertEquals(1.0D, convertValue(Double.class.getCanonicalName(), "1.0", classLoader));
         assertEquals(1.0F, convertValue(float.class.getCanonicalName(), "1.0", classLoader));
         assertEquals(1.0F, convertValue(Float.class.getCanonicalName(), "1.0", classLoader));
-        assertEquals(null, convertValue(Float.class.getCanonicalName(), null, classLoader));
+        assertNull(convertValue(Float.class.getCanonicalName(), null, classLoader));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImplHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/ScenarioRunnerImplHelperTest.java
@@ -139,14 +139,23 @@ public class ScenarioRunnerImplHelperTest {
         List<ScenarioInput> scenario1Inputs = extractGivenValues(simulation.getSimulationDescriptor(), scenario1.getUnmodifiableFactMappingValues(), classLoader);
         List<ScenarioOutput> scenario1Outputs = extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
 
-        List<ScenarioResult> scenario1Results = verifyConditions(simulation.getSimulationDescriptor(), scenario1Inputs, scenario1Outputs);
+        List<ScenarioResult> scenario1Results = verifyConditions(simulation.getSimulationDescriptor(), scenario1Inputs, scenario1Outputs, classLoader);
         assertEquals(1, scenario1Results.size());
 
         List<ScenarioInput> scenario2Inputs = extractGivenValues(simulation.getSimulationDescriptor(), scenario2.getUnmodifiableFactMappingValues(), classLoader);
         List<ScenarioOutput> scenario2Outputs = extractExpectedValues(scenario2.getUnmodifiableFactMappingValues());
 
-        List<ScenarioResult> scenario2Results = verifyConditions(simulation.getSimulationDescriptor(), scenario2Inputs, scenario2Outputs);
+        List<ScenarioResult> scenario2Results = verifyConditions(simulation.getSimulationDescriptor(), scenario2Inputs, scenario2Outputs, classLoader);
         assertEquals(2, scenario2Results.size());
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void verifyConditionsFailTest() {
+        List<ScenarioInput> scenario1Inputs = extractGivenValues(simulation.getSimulationDescriptor(), scenario1.getUnmodifiableFactMappingValues(), classLoader);
+        List<ScenarioOutput> scenario1Outputs = extractExpectedValues(scenario1.getUnmodifiableFactMappingValues());
+        scenario1Outputs.add(new ScenarioOutput(FactIdentifier.create("NOT_EXISTING", String.class.getCanonicalName()), new ArrayList<>()));
+
+        verifyConditions(simulation.getSimulationDescriptor(), scenario1Inputs, scenario1Outputs, classLoader);
     }
 
     @Test
@@ -159,7 +168,7 @@ public class ScenarioRunnerImplHelperTest {
         ScenarioInput input1 = scenario1Inputs.get(0);
 
         scenario1Outputs = scenario1Outputs.stream().filter(elem -> elem.getFactIdentifier().equals(input1.getFactIdentifier())).collect(toList());
-        List<ScenarioResult> scenario1Results = getScenarioResults(simulation.getSimulationDescriptor(), scenario1Outputs, input1);
+        List<ScenarioResult> scenario1Results = getScenarioResults(simulation.getSimulationDescriptor(), scenario1Outputs, input1, classLoader);
 
         assertEquals(1, scenario1Results.size());
 
@@ -171,7 +180,7 @@ public class ScenarioRunnerImplHelperTest {
         ScenarioInput input2 = scenario2Inputs.get(0);
 
         scenario2Outputs = scenario2Outputs.stream().filter(elem -> elem.getFactIdentifier().equals(input2.getFactIdentifier())).collect(toList());
-        List<ScenarioResult> scenario2Results = getScenarioResults(simulation.getSimulationDescriptor(), scenario2Outputs, input2);
+        List<ScenarioResult> scenario2Results = getScenarioResults(simulation.getSimulationDescriptor(), scenario2Outputs, input2, classLoader);
 
         assertEquals(1, scenario2Results.size());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Dispute;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.NotEmptyConstructor;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Person;
@@ -95,24 +96,33 @@ public class ScenarioBeanUtilTest {
         assertEquals(targetObject, FIRST_NAME);
     }
 
-    @Test(expected = ScenarioException.class)
+    @Test
     public void navigateToObjectNoStepTest() {
-        ScenarioBeanUtil.navigateToObject(new Dispute(), new ArrayList<>(), true);
+        String message = "Invalid path to a property, no steps provided";
+        Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(new Dispute(), new ArrayList<>(), true))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage(message);
     }
 
-    @Test(expected = ScenarioException.class)
+    @Test
     public void navigateToObjectFakeFieldTest() {
         Dispute dispute = new Dispute();
         List<String> pathToProperty = Arrays.asList("fakeField");
 
-        ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true);
+        String message = "Impossible to find field with name 'fakeField' in class " + Dispute.class.getCanonicalName();
+        Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true))
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage(message);
     }
 
-    @Test(expected = ScenarioException.class)
+    @Test
     public void navigateToObjectNoStepCreationTest() {
         Dispute dispute = new Dispute();
         List<String> pathToProperty = Arrays.asList("creator", "firstName");
 
-        ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, false);
+        String message = "Impossible to reach field firstName because a step is not instantiated";
+        Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, false))
+                .isInstanceOf(ScenarioException.class).
+                hasMessage(message);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
@@ -90,14 +90,14 @@ public class ScenarioBeanUtilTest {
         dispute.setCreator(creator);
         List<String> pathToProperty = Arrays.asList("creator", "firstName");
 
-        Object targetObject = ScenarioBeanUtil.navigateToObject(dispute, pathToProperty);
+        Object targetObject = ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true);
 
         assertEquals(targetObject, FIRST_NAME);
     }
 
     @Test(expected = ScenarioException.class)
     public void navigateToObjectNoStepTest() {
-        ScenarioBeanUtil.navigateToObject(new Dispute(), new ArrayList<>());
+        ScenarioBeanUtil.navigateToObject(new Dispute(), new ArrayList<>(), true);
     }
 
     @Test(expected = ScenarioException.class)
@@ -105,6 +105,14 @@ public class ScenarioBeanUtilTest {
         Dispute dispute = new Dispute();
         List<String> pathToProperty = Arrays.asList("fakeField");
 
-        ScenarioBeanUtil.navigateToObject(dispute, pathToProperty);
+        ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, true);
+    }
+
+    @Test(expected = ScenarioException.class)
+    public void navigateToObjectNoStepCreationTest() {
+        Dispute dispute = new Dispute();
+        List<String> pathToProperty = Arrays.asList("creator", "firstName");
+
+        ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, false);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/ScenarioBeanUtilTest.java
@@ -122,7 +122,7 @@ public class ScenarioBeanUtilTest {
 
         String message = "Impossible to reach field firstName because a step is not instantiated";
         Assertions.assertThatThrownBy(() -> ScenarioBeanUtil.navigateToObject(dispute, pathToProperty, false))
-                .isInstanceOf(ScenarioException.class).
-                hasMessage(message);
+                .isInstanceOf(ScenarioException.class)
+                .hasMessage(message);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -204,7 +204,7 @@ public class ScenarioGridModel extends BaseGridData {
             fullPackage += ".";
         }
         String canonicalClassName = fullPackage + elements[0];
-        FactIdentifier factIdentifier = FactIdentifier.create(columnId, canonicalClassName);
+        FactIdentifier factIdentifier = FactIdentifier.create(canonicalClassName, canonicalClassName);
         ExpressionIdentifier ei = ExpressionIdentifier.create(columnId, FactMappingType.valueOf(group));
         commonAddColumn(columnIndex, column, factIdentifier, ei);
         final FactMapping factMappingByIndex = simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
@@ -16,7 +16,7 @@
   -->
 
 <!-- SECOND DOCK TAB - TEST TOOLS -->
-<div id="right-panel" class="tab-pane kie-dock active" >
+<div id="right-panel" class="tab-pane kie-dock active">
     <hr class="kie-dock__divider"/>
 
     <ul data-field="rightPanelTabs" class="nav nav-tabs nav-tabs-pf" id="kieTestTools" role="tablist">
@@ -59,38 +59,41 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <button class="btn btn-default" type="button" data-field="searchButton"><span class="fa fa-search"></span></button>
+                        <button class="btn btn-default" type="button" data-field="searchButton">
+                            <span class="fa fa-search"></span></button>
                     </div>
                 </form>
                 <!-- end search box -->
 
                 <!-- list expansion -->
-                <div id="pf-list-simple-expansion" class="list-group tree-list-view-pf-view kie-tree-list-view-pf-view--compact" data-field="listContainer"> </div>
+                <div id="pf-list-simple-expansion" class="list-group tree-list-view-pf-view kie-tree-list-view-pf-view--compact" data-field="listContainer"></div>
                 <!-- end list expansion -->
             </div><!-- end outlined data object box -->
 
-            <label for="kie-name">Name Field</label>
-            <input id="kie-name" type="text" class="form-control" placeholder="Name" data-field="nameField">
+            <div style="display: none">
+                <label for="kie-name">Name Field</label>
+                <input id="kie-name" type="text" class="form-control" placeholder="Name" data-field="nameField">
 
-            <br/>
+                <br/>
 
-            <label for="kieDropdownConditions">Set Conditions</label>
-            <div class="dropdown">
-                <button class="btn btn-default dropdown-toggle" type="button" id="kieDropdownConditions" data-toggle="dropdown" data-field="conditionsButton">
-                    Condition
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" role="menu" aria-labelledby="kieDropdownConditions" data-field="conditionsDropdown">
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Required</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Preferred</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Other options here</a></li>
-                </ul>
+                <label for="kieDropdownConditions">Set Conditions</label>
+                <div class="dropdown">
+                    <button class="btn btn-default dropdown-toggle" type="button" id="kieDropdownConditions" data-toggle="dropdown" data-field="conditionsButton">
+                        Condition
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu" aria-labelledby="kieDropdownConditions" data-field="conditionsDropdown">
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Required</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Preferred</a></li>
+                        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Other options here</a></li>
+                    </ul>
+                </div>
+
+                <hr/>
+                <button class="btn btn-default" type="button">Add</button>
+                &nbsp;&nbsp;&nbsp;
+                <a href="#0" role="button">Clear</a>
             </div>
-
-            <hr/>
-            <button class="btn btn-default" type="button">Add</button>
-            &nbsp;&nbsp;&nbsp;
-            <a href="#0" role="button">Clear</a>
         </div>
         <br/>
         <!-- content for cheatsheet tab -->

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
@@ -55,7 +55,8 @@
                             <!-- <label for="search1" class="sr-only">Search</label> -->
                             <input id="search1" type="search" class="form-control" data-field="inputSearch" placeholder="Search">
                             <button type="button" class="clear" data-field="clearSearchButton" aria-hidden="true">
-                                <span class="pficon pficon-close"></span></button>
+                                <span class="pficon pficon-close"></span>
+                            </button>
                         </div>
                     </div>
                     <div class="form-group">

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -54,13 +54,14 @@ public class ScenarioSimulationUtils {
         columnBuilder.setColumnTitle(columnGroup);
         columnBuilder.setReadOnly(true);
 
-//        if (isOther(factMappingType)) {
-//            columnBuilder.setColumnTitle(title);
-//            columnBuilder.setColumnGroup(columnGroup);
-//            return columnBuilder;
-//        }
-
         boolean informationHeader = isOther(factMappingType) || isExpected(factMappingType) || isGiven(factMappingType);
+        if (isOther(factMappingType)) {
+            columnBuilder.setColumnTitle(title);
+            columnBuilder.setColumnGroup(columnGroup);
+            columnBuilder.setInformationHeader(informationHeader);
+            return columnBuilder;
+        }
+
         columnBuilder.newLevel()
                 .setColumnTitle(title)
                 .setColumnGroup(columnGroup)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ScenarioSimulationUtilsTest {
@@ -36,6 +37,14 @@ public class ScenarioSimulationUtilsTest {
 
         String alias = "Alias";
         String factName = "FactName";
+
+        ScenarioSimulationUtils.ColumnBuilder columnBuilderOther =
+                ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.OTHER.name(), FactMappingType.OTHER);
+        assertEquals(1, columnBuilderOther.build(factory).size());
+        assertEquals(FactMappingType.OTHER.name(), columnBuilderOther.columnGroup);
+        assertNull(columnBuilderOther.nestedLevel);
+        assertEquals(alias, columnBuilderOther.columnTitle);
+
         ScenarioSimulationUtils.ColumnBuilder columnBuilderGiven =
                 ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.GIVEN.name(), FactMappingType.GIVEN);
         assertEquals(2, columnBuilderGiven.build(factory).size());


### PR DESCRIPTION
Set of minor changes and fixes discovered during a real end to end test of Scenario Simulation

@Rikkola @jomarko @gitgabrio 

Client changes:
- Updated factIdentifier generation for column type binding (no more random columnId generator)
- Hidden "Other" header in the grid
- Hidden right panel mocked component

Backend changes:
- Added support to boolean values into scenario runner
- Better `null` handling in grid values parsing
- Added check on not verifiable "expected" conditions
- Updated runner to use KieContainer classLoader to insert test facts
- Minor improvement in `navigateToBean` method
 