### PR TITLE
Drools 3051 - Implement placeholder for ScenarioGridModel

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMapping.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactMapping.java
@@ -103,4 +103,5 @@ public class FactMapping {
     public static String getPlaceHolder(FactMappingType factMappingType, int index) {
         return getPlaceHolder(factMappingType) + " " + index;
     }
+
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
@@ -43,14 +43,14 @@ public class ScenarioSimulationModel
 
         Scenario scenario = simulation.addScenario();
         int row = simulation.getUnmodifiableScenarios().indexOf(scenario);
-        scenario.setDescription(FactMappingValue.getPlaceHolder(0, 1));
+        scenario.setDescription(null);
 
         // Add GIVEN Facts
         IntStream.range(2, 4).forEach(id -> {
             ExpressionIdentifier givenExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.GIVEN);
             FactIdentifier givenFact = FactIdentifier.create(FactMappingType.GIVEN + "FACT-" + id, String.class.getCanonicalName());
             simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.GIVEN, id), givenFact, givenExpression);
-            scenario.addMappingValue(givenFact, givenExpression, FactMappingValue.getPlaceHolder(row, id));
+            scenario.addMappingValue(givenFact, givenExpression, null);
         });
 
         // Add EXPECTED Facts
@@ -59,7 +59,7 @@ public class ScenarioSimulationModel
             ExpressionIdentifier expectedExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.EXPECTED);
             FactIdentifier expectFact = FactIdentifier.create(FactMappingType.EXPECTED + "FACT-" + id, String.class.getCanonicalName());
             simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.EXPECTED, id), expectFact, expectedExpression);
-            scenario.addMappingValue(expectFact, expectedExpression, FactMappingValue.getPlaceHolder(row, id));
+            scenario.addMappingValue(expectFact, expectedExpression, null);
         });
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
@@ -76,8 +76,9 @@ public class ScenarioRunnerImplServiceImplTest {
     @Test
     public void runTest() throws Exception {
         when(buildInfoService.getBuildInfo(any())).thenReturn(buildInfo);
-        scenarioRunnerService.runTest("test", mock(Path.class), new ScenarioSimulationModel());
-
+        final ScenarioSimulationModel scenarioSimulationModel = new ScenarioSimulationModel();
+        scenarioSimulationModel.getSimulation().getScenarioByIndex(0).setDescription("testDescription"); // fix the getScenarioByIndex(1)
+        scenarioRunnerService.runTest("test", mock(Path.class), scenarioSimulationModel);
         verify(defaultTestResultMessageEvent).fire(any());
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextBoxDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextBoxDOMElement.java
@@ -17,8 +17,8 @@
 package org.drools.workbench.screens.scenariosimulation.client.factories;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.TextBoxDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
@@ -33,13 +33,9 @@ public class ScenarioCellTextBoxDOMElement extends TextBoxDOMElement {
     public void flush(final String value) {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
-        if (value == null || value.trim().isEmpty()) {
-            ((ScenarioGridModel) gridWidget.getModel()).deleteNewCell(rowIndex,
-                                                                      columnIndex);
-        } else {
-            ((ScenarioGridModel) gridWidget.getModel()).setNewCellValue(rowIndex,
-                                                                        columnIndex,
-                                                                        new BaseGridCellValue<String>(value));
-        }
+        String actualValue = (value == null || value.trim().isEmpty()) ? null : value;
+        ((ScenarioGridModel) gridWidget.getModel()).setNewCellValue(rowIndex,
+                                                                    columnIndex,
+                                                                    new ScenarioGridCellValue(actualValue));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -245,7 +245,7 @@ public class ScenarioGridModel extends BaseGridData {
 
     @Override
     public Range setCellValue(int rowIndex, int columnIndex, GridCellValue<?> value) {
-        return setCell(rowIndex, columnIndex, () -> new ScenarioGridCell((GridCellValue<String>) value));
+        return setCell(rowIndex, columnIndex, () -> new ScenarioGridCell((GridCellValue<String>) value, ((ScenarioGridColumn) getColumns().get(columnIndex)).getPlaceHolder()));
     }
 
     @Override
@@ -307,10 +307,6 @@ public class ScenarioGridModel extends BaseGridData {
     public void updateHeader(int columnIndex, int rowIndex, String value) {
         getColumns().get(columnIndex).getHeaderMetaData().get(rowIndex).setTitle(value);
         simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex).setExpressionAlias(value);
-    }
-
-    public Range setNewCellValue(int rowIndex, int columnIndex, GridCellValue<?> value) {
-        return setNewCell(rowIndex, columnIndex, () -> new ScenarioGridCell((GridCellValue<String>) value, ((ScenarioGridColumn) getColumns().get(columnIndex)).getPlaceHolder()));
     }
 
     public void clear() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/BaseExpressionGridTheme.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/BaseExpressionGridTheme.java
@@ -25,9 +25,8 @@ import com.ait.lienzo.shared.core.types.TextAlign;
 import com.ait.lienzo.shared.core.types.TextBaseLine;
 import com.ait.lienzo.shared.core.types.TextUnit;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
 
-public class BaseExpressionGridTheme implements GridRendererTheme {
+public class BaseExpressionGridTheme implements ScenarioGridRendererTheme {
 
     public static final String BACKGROUND_FILL_COLOUR = "#c7ffca";
 
@@ -58,6 +57,8 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
     public static final String FONT_FAMILY_LABEL = "Open Sans, Helvetica, Arial, sans-serif";
 
     public static final String FONT_FAMILY_EXPRESSION = "Courier New";
+
+    public static final String FONT_STYLE_ITALIC = "italic";
 
     public static final double SELECTOR_STROKE_WIDTH = 2.0;
 
@@ -140,6 +141,19 @@ public class BaseExpressionGridTheme implements GridRendererTheme {
                 .setFillColor(ColorName.BLACK)
                 .setFontSize(FONT_SIZE)
                 .setFontFamily(FONT_FAMILY_LABEL)
+                .setTextUnit(TextUnit.PT)
+                .setListening(false)
+                .setTextBaseLine(TextBaseLine.MIDDLE)
+                .setTextAlign(TextAlign.CENTER);
+    }
+
+    @Override
+    public Text getPlaceholderText() {
+        return new Text("")
+                .setFillColor(ColorName.GRAY)
+                .setFontSize(FONT_SIZE)
+                .setFontFamily(FONT_FAMILY_LABEL)
+                .setFontStyle(FONT_STYLE_ITALIC)
                 .setTextUnit(TextUnit.PT)
                 .setListening(false)
                 .setTextBaseLine(TextBaseLine.MIDDLE)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRenderer.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRenderer.java
@@ -15,8 +15,35 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.renderers;
 
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Text;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridCell;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.StringColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 
 public class ScenarioGridColumnRenderer extends StringColumnRenderer {
 
+    @Override
+    public Group renderCell(final GridCell<String> cell,
+                            final GridBodyCellRenderContext context) {
+        if (cell == null) { // nothing to render
+            return null;
+        }
+        if (!(cell instanceof ScenarioGridCell) || (cell.getValue() != null && cell.getValue().getValue() != null)) { // not a ScenarioGridCell or placeholder is null
+            return super.renderCell(cell, context);
+        }
+        // Render as placeholder
+        final GridRenderer renderer = context.getRenderer();
+        final ScenarioGridRendererTheme theme = (ScenarioGridRendererTheme) renderer.getTheme();
+        final Group g = new Group();
+        final Text t = theme.getPlaceholderText();
+        t.setText(((ScenarioGridCell) cell).getPlaceHolder());
+        t.setListening(false);
+        t.setX(context.getCellWidth() / 2);
+        t.setY(context.getCellHeight() / 2);
+        g.add(t);
+        return g;
+    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridRendererTheme.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridRendererTheme.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.renderers;
+
+import com.ait.lienzo.client.core.shape.Text;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
+
+public interface ScenarioGridRendererTheme extends GridRendererTheme {
+
+    Text getPlaceholderText();
+
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -87,4 +87,6 @@ public interface ScenarioSimulationEditorConstants
     String insertRightmostColumn();
 
     String description();
+
+    String insertValue();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -23,6 +23,7 @@ import org.drools.workbench.screens.scenariosimulation.client.factories.Scenario
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridColumnRenderer;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
@@ -39,7 +40,7 @@ public class ScenarioSimulationUtils {
                                                            ScenarioGridLayer gridLayer) {
         ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, gridLayer);
         ScenarioCellTextBoxSingletonDOMElementFactory factoryCell = FactoryProvider.getCellTextBoxFactory(scenarioGridPanel, gridLayer);
-        return new ScenarioGridColumn(getTwoLevelHeaderBuilder(title, columnId, columnGroup, factMappingType).build(factoryHeader), new ScenarioGridColumnRenderer(), 150, false, factoryCell);
+        return new ScenarioGridColumn(getTwoLevelHeaderBuilder(title, columnId, columnGroup, factMappingType).build(factoryHeader), new ScenarioGridColumnRenderer(), 150, false, factoryCell, ScenarioSimulationEditorConstants.INSTANCE.insertValue());
     }
 
     public static ColumnBuilder getTwoLevelHeaderBuilder(String title,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridCell.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridCell.java
@@ -15,12 +15,24 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.widgets;
 
+import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 
 public class ScenarioGridCell extends BaseGridCell<String> {
 
-    public ScenarioGridCell(GridCellValue<String> value) {
+    final private String placeHolder;
+
+    public ScenarioGridCell(GridCellValue<String> value, String placeHolder) {
         super(value);
+        this.placeHolder = placeHolder;
+    }
+
+    public ScenarioGridCell(String placeHolder) {
+        this(new ScenarioGridCellValue(null), placeHolder);
+    }
+
+    public String getPlaceHolder() {
+        return placeHolder;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
@@ -20,10 +20,9 @@ import java.util.function.Consumer;
 
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
-import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
-import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
@@ -34,18 +33,22 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
 
     final ScenarioHeaderMetaData informationHeaderMetaData;
 
-    public ScenarioGridColumn(HeaderMetaData headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory) {
+    final String placeHolder;
+
+    public ScenarioGridColumn(HeaderMetaData headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory, String placeHolder) {
         super(headerMetaData, columnRenderer, width);
         this.informationHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData;
         this.setMovable(isMovable);
         this.factory = factory;
+        this.placeHolder = placeHolder;
     }
 
-    public ScenarioGridColumn(List<HeaderMetaData> headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory) {
+    public ScenarioGridColumn(List<HeaderMetaData> headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory, String placeHolder) {
         super(headerMetaData, columnRenderer, width);
         this.informationHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData.stream().filter(hdm -> ((ScenarioHeaderMetaData) hdm).isInformationHeader()).findFirst().orElse(headerMetaData.get(0));
         this.setMovable(isMovable);
         this.factory = factory;
+        this.placeHolder = placeHolder;
     }
 
     @Override
@@ -59,10 +62,14 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
         return informationHeaderMetaData;
     }
 
+    public String getPlaceHolder() {
+        return placeHolder;
+    }
+
     private GridCell<String> assertCell(final GridCell<String> cell) {
         if (cell != null) {
             return cell;
         }
-        return new BaseGridCell<>(new BaseGridCellValue<>(""));
+        return new ScenarioGridCell(new ScenarioGridCellValue(""), placeHolder);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -28,6 +28,7 @@ testTools=Test Tools
 testEditor=Test Editor
 scenarioCheatSheet=Scenario Cheatsheet
 runScenarioSimulation=Run Test
+insertValue=(Insert value)
 # Menus
 expected=Expected
 given=Given
@@ -44,4 +45,5 @@ insertRowBelow=Insert row below
 deleteRow=Delete row
 duplicateRow=Duplicate row
 description=Description
+
 


### PR DESCRIPTION
@jomarko @Rikkola @danielezonca 
Scope of this PR is to Implement a HTML-like placeholder mechanism for ScenarioGridModel. More specifically, empty cells should show a "placeholder-like" string  (Insert value).
After deleting the value of a cell, the "placeholder" should be shown.
Cell of new rows/columns, or soon after asset creation, should also show the placeholder.
Verify also inserted values (if not empty) are correctly saved.