### PR TITLE
[DROOLS-3073] Retrieving and using actual package name for Data Objects.

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/Scenario.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/Scenario.java
@@ -113,7 +113,9 @@ public class Scenario {
     public String getDescription() {
         return factMappingValues.stream()
                 .filter(e -> e.getExpressionIdentifier().equals(ExpressionIdentifier.DESCRIPTION) &&
-                        e.getFactIdentifier().equals(FactIdentifier.DESCRIPTION)).map(e -> (String) e.getRawValue())
+                        e.getFactIdentifier().equals(FactIdentifier.DESCRIPTION)
+                        && e.getRawValue() != null).
+                        map(e -> (String) e.getRawValue())
                 .findFirst().orElseThrow(() -> new IllegalArgumentException("No description available"));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -372,7 +372,14 @@ public class ScenarioSimulationEditorPresenter
                     simpleProperties.put(modelField.getName(), modelField.getClassName());
                 }
             }
-            FactModelTree toSend = new FactModelTree(factName, packageName, simpleProperties);
+            String factPackageName;
+            String fullFactClassName = oracle.getFQCNByFactName(factName);
+            if (fullFactClassName != null &&  fullFactClassName.contains(".")) {
+                factPackageName = fullFactClassName.substring(0, fullFactClassName.lastIndexOf("."));
+            } else {
+                factPackageName = packageName;
+            }
+            FactModelTree toSend = new FactModelTree(factName, factPackageName, simpleProperties);
             aggregatorCallback.callback(toSend);
         };
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -372,12 +372,10 @@ public class ScenarioSimulationEditorPresenter
                     simpleProperties.put(modelField.getName(), modelField.getClassName());
                 }
             }
-            String factPackageName;
+            String factPackageName = packageName;
             String fullFactClassName = oracle.getFQCNByFactName(factName);
-            if (fullFactClassName != null &&  fullFactClassName.contains(".")) {
+            if (fullFactClassName != null && fullFactClassName.contains(".")) {
                 factPackageName = fullFactClassName.substring(0, fullFactClassName.lastIndexOf("."));
-            } else {
-                factPackageName = packageName;
             }
             FactModelTree toSend = new FactModelTree(factName, factPackageName, simpleProperties);
             aggregatorCallback.callback(toSend);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -92,7 +92,7 @@ public class ScenarioSimulationEditorPresenter
 
     private ScenarioSimulationResourceType type;
 
-    private AsyncPackageDataModelOracle oracle;
+    AsyncPackageDataModelOracle oracle;
 
     private ScenarioSimulationView view;
 
@@ -101,7 +101,7 @@ public class ScenarioSimulationEditorPresenter
     private Command populateRightPanelCommand;
 
     //Package for which this Scenario Simulation relates
-    private String packageName = "";
+    String packageName = "";
 
     RightPanelMenuItem rightPanelMenuItem;
 
@@ -329,6 +329,43 @@ public class ScenarioSimulationEditorPresenter
         return MarshallingWrapper.toJSON(model);
     }
 
+    /**
+     * This <code>Callback</code> will receive <code>ModelField[]</code> from <code>AsyncPackageDataModelOracleFactory.getFieldCompletions(final String,
+     * final Callback&lt;ModelField[]&gt;)</code>; build a <code>FactModelTree</code> from them, and send it to the
+     * given <code>Callback&lt;FactModelTree&gt;</code> aggregatorCallback
+     * @param factName
+     * @param aggregatorCallback
+     * @return
+     */
+    protected Callback<ModelField[]> fieldCompletionsCallback(String factName, Callback<FactModelTree> aggregatorCallback) {
+        return result -> {
+            FactModelTree toSend = getFactModelTree(factName, result);
+            aggregatorCallback.callback(toSend);
+        };
+    }
+
+    /**
+     * Create a <code>FactModelTree</code> for a given <b>factName</b> populating it with the given
+     * <code>ModelField[]</code>
+     * @param factName
+     * @param modelFields
+     * @return
+     */
+    protected FactModelTree getFactModelTree(String factName, ModelField[] modelFields) {
+        Map<String, String> simpleProperties = new HashMap<>();
+        for (ModelField modelField : modelFields) {
+            if (!modelField.getName().equals("this")) {
+                simpleProperties.put(modelField.getName(), modelField.getClassName());
+            }
+        }
+        String factPackageName = packageName;
+        String fullFactClassName = oracle.getFQCNByFactName(factName);
+        if (fullFactClassName != null && fullFactClassName.contains(".")) {
+            factPackageName = fullFactClassName.substring(0, fullFactClassName.lastIndexOf("."));
+        }
+        return new FactModelTree(factName, factPackageName, simpleProperties);
+    }
+
     private RemoteCallback<ScenarioSimulationModelContent> getModelSuccessCallback() {
         return content -> {
             //Path is set to null when the Editor is closed (which can happen before async calls complete).
@@ -354,32 +391,6 @@ public class ScenarioSimulationEditorPresenter
 
     private void addRightPanelMenuItem(final FileMenuBuilder fileMenuBuilder) {
         fileMenuBuilder.addNewTopLevelMenu(rightPanelMenuItem);
-    }
-
-    /**
-     * This <code>Callback</code> will receive <code>ModelField[]</code> from <code>AsyncPackageDataModelOracleFactory.getFieldCompletions(final String,
-     * final Callback&lt;ModelField[]&gt;)</code>; build a <code>FactModelTree</code> from them, and send it to the
-     * given <code>Callback&lt;FactModelTree&gt;</code> aggregatorCallback
-     * @param factName
-     * @param aggregatorCallback
-     * @return
-     */
-    private Callback<ModelField[]> fieldCompletionsCallback(String factName, Callback<FactModelTree> aggregatorCallback) {
-        return result -> {
-            Map<String, String> simpleProperties = new HashMap<>();
-            for (ModelField modelField : result) {
-                if (!modelField.getName().equals("this")) {
-                    simpleProperties.put(modelField.getName(), modelField.getClassName());
-                }
-            }
-            String factPackageName = packageName;
-            String fullFactClassName = oracle.getFQCNByFactName(factName);
-            if (fullFactClassName != null && fullFactClassName.contains(".")) {
-                factPackageName = fullFactClassName.substring(0, fullFactClassName.lastIndexOf("."));
-            }
-            FactModelTree toSend = new FactModelTree(factName, factPackageName, simpleProperties);
-            aggregatorCallback.callback(toSend);
-        };
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.editor;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.commands.CommandExecutor;
+import org.drools.workbench.screens.scenariosimulation.client.models.FactModelTree;
 import org.drools.workbench.screens.scenariosimulation.client.producers.ScenarioSimulationProducer;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.RightPanelPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.RightPanelView;
@@ -33,6 +34,8 @@ import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuIt
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.project.datamodel.oracle.FieldAccessorsAndMutators;
+import org.kie.soup.project.datamodel.oracle.ModelField;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
@@ -56,6 +59,8 @@ import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
@@ -144,6 +149,8 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
     @Mock
     private CommandExecutor mockCommandExecutor;
 
+    private static final String SCENARIO_PACKAGE = "scenario.package";
+
     @Before
     public void setup() {
         super.setup();
@@ -182,6 +189,8 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
                 this.path = mockPath;
                 this.rightPanelMenuItem = mockRightPanelMenuItem;
                 this.scenarioGridPanel = mockScenarioGridPanel;
+                this.oracle = mockOracle;
+                this.packageName = SCENARIO_PACKAGE;
             }
 
             @Override
@@ -311,6 +320,36 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenter.onRunScenario();
 
         verify(scenarioSimulationService).runScenario(any(), eq(model));
+    }
+
+    @Test
+    public void getFactModelTree() {
+        String factPackage = "scenario.test";
+        String factName = "FACT_NAME";
+        String fullFactname = factPackage + "." + factName;
+        ModelField modelField1 = new ModelField("this",
+                                                fullFactname,
+                                                ModelField.FIELD_CLASS_TYPE.REGULAR_CLASS,
+                                                ModelField.FIELD_ORIGIN.SELF,
+                                                FieldAccessorsAndMutators.BOTH,
+                                                fullFactname);
+        ModelField modelField2 = new ModelField("myint",
+                                                int.class.getName(),
+                                                ModelField.FIELD_CLASS_TYPE.REGULAR_CLASS,
+                                                ModelField.FIELD_ORIGIN.SELF,
+                                                FieldAccessorsAndMutators.BOTH,
+                                                int.class.getName());
+        ModelField[] modelFields = {modelField1, modelField2};
+        when(mockOracle.getFQCNByFactName(factName)).thenReturn(fullFactname);
+        FactModelTree retrieved = presenter.getFactModelTree(factName, modelFields);
+        assertNotNull(retrieved);
+        assertEquals(factName, retrieved.getFactName());
+        assertEquals(factPackage, retrieved.getFullPackage());
+        when(mockOracle.getFQCNByFactName(factName)).thenReturn(null);
+        retrieved = presenter.getFactModelTree(factName, modelFields);
+        assertNotNull(retrieved);
+        assertEquals(factName, retrieved.getFactName());
+        assertEquals(SCENARIO_PACKAGE, retrieved.getFullPackage());
     }
 
     private void onClosePlaceStatusOpen() {


### PR DESCRIPTION
@jomarko @Rikkola @danielezonca 
Scope of this PR is to retrieve and store actual package for data objects.
To check:
when using imported Data Objects, running test should not fail with the message " Impossible to load class " followed by a DO with the wrong package name.