### PR TITLE
[DO NOT MERGE] BAQE-650: Remove drools.datetimeformat property

### DIFF
--- a/drools-wb-webapp/src/main/java/org/drools/workbench/backend/server/AppSetup.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/backend/server/AppSetup.java
@@ -120,8 +120,6 @@ public class AppSetup extends BaseAppSetup {
                                                                       "");
         group.addConfigItem(configurationFactory.newConfigItem("drools.dateformat",
                                                                "dd-MMM-yyyy"));
-        group.addConfigItem(configurationFactory.newConfigItem("drools.datetimeformat",
-                                                               "dd-MMM-yyyy hh:mm:ss"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultlanguage",
                                                                "en"));
         group.addConfigItem(configurationFactory.newConfigItem("drools.defaultcountry",


### PR DESCRIPTION
After investigating the codebase it seems that the system property drools.datetimeformat is set, but never used. So this PR removest. The time format pask for dates can be set using drools.dateformat property.

Ensemble with:
- https://github.com/kiegroup/kie-wb-common/pull/2173
- https://github.com/kiegroup/kie-wb-distributions/pull/826
- https://github.com/kiegroup/optaplanner-wb/pull/307