### PR TITLE
Drools 3052 Implement read only mechanism for the cells in Scenario grid

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactIdentifier.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactIdentifier.java
@@ -30,6 +30,7 @@ public class FactIdentifier {
 
     public static FactIdentifier INDEX = create("Index", Integer.class.getCanonicalName());
     public static FactIdentifier DESCRIPTION = create("Description", String.class.getCanonicalName());
+    public static FactIdentifier EMPTY = create("Empty", Void.class.getName());
 
     public FactIdentifier() {
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
@@ -48,18 +48,16 @@ public class ScenarioSimulationModel
         // Add GIVEN Facts
         IntStream.range(2, 4).forEach(id -> {
             ExpressionIdentifier givenExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.GIVEN);
-            FactIdentifier givenFact = FactIdentifier.create(FactMappingType.GIVEN + "FACT-" + id, String.class.getCanonicalName());
-            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.GIVEN, id), givenFact, givenExpression);
-            scenario.addMappingValue(givenFact, givenExpression, null);
+            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.GIVEN, id), FactIdentifier.EMPTY, givenExpression);
+            scenario.addMappingValue(FactIdentifier.EMPTY, givenExpression, null);
         });
 
         // Add EXPECTED Facts
         IntStream.range(2, 4).forEach(id -> {
             id += 2; // This is to have consistent labels/names even when adding columns at runtime
             ExpressionIdentifier expectedExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.EXPECTED);
-            FactIdentifier expectFact = FactIdentifier.create(FactMappingType.EXPECTED + "FACT-" + id, String.class.getCanonicalName());
-            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.EXPECTED, id), expectFact, expectedExpression);
-            scenario.addMappingValue(expectFact, expectedExpression, null);
+            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.EXPECTED, id), FactIdentifier.EMPTY, expectedExpression);
+            scenario.addMappingValue(FactIdentifier.EMPTY, expectedExpression, null);
         });
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommand.java
@@ -62,6 +62,7 @@ public abstract class AbstractCommand implements Command {
      * <p>
      * isReadOnly: <code>true</code>;
      * </p>
+     * <p>
      * columnRenderer: new ScenarioGridColumnRenderer()
      * </p>
      * @param title

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommand.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.commands;
+
+import org.drools.workbench.screens.scenariosimulation.client.factories.FactoryProvider;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
+import org.uberfire.mvp.Command;
+
+import static org.drools.workbench.screens.scenariosimulation.client.factories.FactoryProvider.getHeaderTextBoxFactory;
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getHeaderBuilder;
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
+
+/**
+ * <b>Abstract</b> <code>Command</code> class to provide common methods used by actual implementations
+ */
+public abstract class AbstractCommand implements Command {
+
+    protected ScenarioGridPanel scenarioGridPanel;
+    protected ScenarioGridLayer scenarioGridLayer;
+
+    public AbstractCommand() {
+    }
+
+    public AbstractCommand(ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
+        this.scenarioGridPanel = scenarioGridPanel;
+        this.scenarioGridLayer = scenarioGridLayer;
+    }
+
+
+    protected ScenarioHeaderTextBoxSingletonDOMElementFactory getHeaderTextBoxFactoryLocal() {
+        // indirection add for test
+        return getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
+    }
+
+    /**
+     * Returns a <code>ScenarioGridColumn</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param title
+     * @param columnId
+     * @param columnGroup
+     * @param factMappingType
+     * @param scenarioGridPanel
+     * @param gridLayer
+     * @return
+     */
+    protected ScenarioGridColumn getScenarioGridColumnLocal(String title,
+                                                           String columnId,
+                                                           String columnGroup,
+                                                           FactMappingType factMappingType,
+                                                           ScenarioGridPanel scenarioGridPanel,
+                                                           ScenarioGridLayer gridLayer,
+                                                           String placeHolder) {
+        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, gridLayer);
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(title, columnId, columnGroup, factMappingType, factoryHeader);
+        return getScenarioGridColumn(headerBuilder, scenarioGridPanel, gridLayer, true, placeHolder);
+    }
+
+    protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder) {
+        // indirection add for test
+        return getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, false, ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommand.java
@@ -18,35 +18,31 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.mvp.Command;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
 
 /**
  * <code>Command</code> to <b>append</b> (i.e. put in the last position) a column to a given <i>group</i>
  */
 @Dependent
-public class AppendColumnCommand implements Command {
+public class AppendColumnCommand extends AbstractCommand  {
 
     private ScenarioGridModel model;
     private String columnId;
     private String columnGroup;
-    private ScenarioGridPanel scenarioGridPanel;
-    private ScenarioGridLayer scenarioGridLayer;
+
 
     public AppendColumnCommand() {
     }
 
     public AppendColumnCommand(ScenarioGridModel model, String columnId, String columnGroup, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
+        super(scenarioGridPanel, scenarioGridLayer);
         this.model = model;
         this.columnId = columnId;
         this.columnGroup = columnGroup;
-        this.scenarioGridPanel = scenarioGridPanel;
-        this.scenarioGridLayer = scenarioGridLayer;
     }
 
     @Override
@@ -54,11 +50,12 @@ public class AppendColumnCommand implements Command {
         final int index = model.getFirstIndexRightOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertColumn(index, getScenarioGridColumn(columnTitle,
+        model.insertColumn(index, getScenarioGridColumnLocal(columnTitle,
                                                         columnId,
                                                         columnGroup,
                                                         factMappingType,
                                                         scenarioGridPanel,
-                                                        scenarioGridLayer));
+                                                        scenarioGridLayer,
+                                                        ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommand.java
@@ -20,19 +20,17 @@ import java.util.Date;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.mvp.Command;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
 
 /**
  * <code>Command</code> to <b>delete</b> a column. <b>Eventually</b> add a ne column if the deleted one is the last of its group.
  */
 @Dependent
-public class DeleteColumnCommand implements Command {
+public class DeleteColumnCommand extends AbstractCommand {
 
     private ScenarioGridModel model;
     private int columnIndex;
@@ -64,12 +62,13 @@ public class DeleteColumnCommand implements Command {
         if (model.getGroupSize(columnGroup) < 1) {
             FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
             String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-            model.insertColumn(columnIndex, getScenarioGridColumn(columnTitle,
+            model.insertColumn(columnIndex, getScenarioGridColumnLocal(columnTitle,
                                                                   String.valueOf(new Date().getTime()),
                                                                   columnGroup,
                                                                   factMappingType,
                                                                   scenarioGridPanel,
-                                                                  scenarioGridLayer));
+                                                                  scenarioGridLayer,
+                                                                  ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommand.java
@@ -18,27 +18,23 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.mvp.Command;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
 
 /**
  * <code>Command</code> to <b>insert</b> a column.
  */
 @Dependent
-public class InsertColumnCommand implements Command {
+public class InsertColumnCommand extends AbstractCommand {
 
     private ScenarioGridModel model;
     private String columnId;
     private int columnIndex;
-    private boolean isRight;
-    private ScenarioGridPanel scenarioGridPanel;
-    private ScenarioGridLayer scenarioGridLayer;
+    boolean isRight;
 
     public InsertColumnCommand() {
     }
@@ -52,12 +48,11 @@ public class InsertColumnCommand implements Command {
      * @param scenarioGridLayer
      */
     public InsertColumnCommand(ScenarioGridModel model, String columnId, int columnIndex, boolean isRight, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
+        super(scenarioGridPanel, scenarioGridLayer);
         this.model = model;
         this.columnId = columnId;
         this.columnIndex = columnIndex;
         this.isRight = isRight;
-        this.scenarioGridPanel = scenarioGridPanel;
-        this.scenarioGridLayer = scenarioGridLayer;
     }
 
     @Override
@@ -66,11 +61,12 @@ public class InsertColumnCommand implements Command {
         int columnPosition = isRight ? columnIndex + 1 : columnIndex;
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertColumn(columnPosition, getScenarioGridColumn(columnTitle,
-                                                                 columnId,
-                                                                 columnGroup,
-                                                                 factMappingType,
-                                                                 scenarioGridPanel,
-                                                                 scenarioGridLayer));
+        model.insertColumn(columnPosition, getScenarioGridColumnLocal(columnTitle,
+                                                                      columnId,
+                                                                      columnGroup,
+                                                                      factMappingType,
+                                                                      scenarioGridPanel,
+                                                                      scenarioGridLayer,
+                                                                      ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommand.java
@@ -18,35 +18,30 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import javax.enterprise.context.Dependent;
 
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.mvp.Command;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
 
 /**
  * <code>Command</code> to <b>prepend</b> (i.e. put in the first position) a column to a given <i>group</i>
  */
 @Dependent
-public class PrependColumnCommand implements Command {
+public class PrependColumnCommand extends AbstractCommand {
 
     private ScenarioGridModel model;
     private String columnId;
     private String columnGroup;
-    private ScenarioGridPanel scenarioGridPanel;
-    private ScenarioGridLayer scenarioGridLayer;
 
     public PrependColumnCommand() {
     }
 
     public PrependColumnCommand(ScenarioGridModel model, String columnId, String columnGroup, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
+        super(scenarioGridPanel, scenarioGridLayer);
         this.model = model;
         this.columnId = columnId;
         this.columnGroup = columnGroup;
-        this.scenarioGridPanel = scenarioGridPanel;
-        this.scenarioGridLayer = scenarioGridLayer;
     }
 
     @Override
@@ -54,11 +49,12 @@ public class PrependColumnCommand implements Command {
         final int index = model.getFirstIndexLeftOfGroup(columnGroup);
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
         String columnTitle = FactMapping.getPlaceHolder(factMappingType, model.nextColumnCount());
-        model.insertColumn(index, getScenarioGridColumn(columnTitle,
+        model.insertColumn(index, getScenarioGridColumnLocal(columnTitle,
                                                         columnId,
                                                         columnGroup,
                                                         factMappingType,
                                                         scenarioGridPanel,
-                                                        scenarioGridLayer));
+                                                        scenarioGridLayer,
+                                                        ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommand.java
@@ -17,28 +17,27 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import javax.enterprise.context.Dependent;
 
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.mvp.Command;
 
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getHeaderBuilder;
 
 /**
  * <code>Command</code> to <b>enable</b> the <code>RightPanelView</code>
  */
 @Dependent
-public class SetColumnValueCommand implements Command {
+public class SetColumnValueCommand extends AbstractCommand {
 
     private ScenarioGridModel model;
     private String columnId;
     private String fullPackage;
     private String value;
     private String valueClassName;
-    private ScenarioGridPanel scenarioGridPanel;
-    private ScenarioGridLayer scenarioGridLayer;
 
     public SetColumnValueCommand() {
     }
@@ -53,13 +52,12 @@ public class SetColumnValueCommand implements Command {
      * @param scenarioGridLayer
      */
     public SetColumnValueCommand(ScenarioGridModel model, String columnId, String fullPackage, String value, String valueClassName, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
+        super(scenarioGridPanel, scenarioGridLayer);
         this.model = model;
         this.columnId = columnId;
         this.fullPackage = fullPackage;
         this.value = value;
         this.valueClassName = valueClassName;
-        this.scenarioGridPanel = scenarioGridPanel;
-        this.scenarioGridLayer = scenarioGridLayer;
     }
 
     @Override
@@ -71,15 +69,18 @@ public class SetColumnValueCommand implements Command {
         int columnIndex = model.getColumns().indexOf(selectedColumn);
         String columnGroup = selectedColumn.getInformationHeaderMetaData().getColumnGroup();
         FactMappingType factMappingType = FactMappingType.valueOf(columnGroup.toUpperCase());
+        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = getHeaderTextBoxFactoryLocal();
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilderLocal(columnGroup, factMappingType, factoryHeader);
         model.updateColumnType(columnIndex,
-                               getScenarioGridColumn(value,
-                                                     columnId,
-                                                     columnGroup,
-                                                     factMappingType,
-                                                     scenarioGridPanel,
-                                                     scenarioGridLayer),
+                               getScenarioGridColumnLocal(headerBuilder),
                                fullPackage,
                                value,
                                valueClassName);
     }
+
+    protected ScenarioSimulationBuilders.HeaderBuilder getHeaderBuilderLocal(String columnGroup, FactMappingType factMappingType, ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader) {
+        // indirection add for test
+        return getHeaderBuilder(value, columnId, columnGroup, factMappingType, factoryHeader);
+    }
+
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
@@ -295,8 +295,15 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
                                                                            ap.getX());
         if (uiColumnIndex == null) {
             return false;
+        }
+        ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) scenarioGrid.getModel().getColumns().get(uiColumnIndex);
+        if (scenarioGridColumn == null) {
+            return false;
+        }
+        if (!manageHeaderLeftClick(scenarioGrid, uiColumnIndex, scenarioGridColumn, ap)) {
+            return manageGridLeftClick(scenarioGrid, scenarioGridColumn, ap);
         } else {
-            return manageHeaderLeftClick(scenarioGrid, uiColumnIndex, ap);
+            return true;
         }
     }
 
@@ -305,15 +312,12 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
      * otherwise returns <code>false</code>
      * @param scenarioGrid
      * @param uiColumnIndex
+     * @param scenarioGridColumn
      * @param rp
      * @return
      */
-    private boolean manageHeaderLeftClick(ScenarioGrid scenarioGrid, Integer uiColumnIndex, Point2D rp) {
+    private boolean manageHeaderLeftClick(ScenarioGrid scenarioGrid, Integer uiColumnIndex, ScenarioGridColumn scenarioGridColumn, Point2D rp) {
         double gridY = rp.getY();
-        ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) scenarioGrid.getModel().getColumns().get(uiColumnIndex);
-        if (scenarioGridColumn == null) {
-            return false;
-        }
         if (!ScenarioSimulationGridHeaderUtilities.hasEditableHeader(scenarioGridColumn)) {
             return false;
         }
@@ -349,5 +353,21 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
                 return false;
         }
         return true;
+    }
+
+    /**
+     * This method check if the click happened on an <i>writable</i> column of a <b>grid row</b>. If it is so, start editing the cell,
+     * otherwise returns <code>false</code>
+     * @param scenarioGrid
+     * @param scenarioGridColumn
+     * @param rp
+     * @return
+     */
+    private boolean manageGridLeftClick(ScenarioGrid scenarioGrid, ScenarioGridColumn scenarioGridColumn, Point2D rp) {
+        final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(scenarioGrid, rp.getY());
+        if (uiRowIndex == null) {
+            return false;
+        }
+        return scenarioGridColumn.isReadOnly() || scenarioGrid.startEditingCell(rp);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelDoubleClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelDoubleClickHandler.java
@@ -20,6 +20,7 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.Point2D;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationGridHeaderUtilities;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
@@ -115,5 +116,30 @@ public class ScenarioSimulationGridPanelDoubleClickHandler extends BaseGridWidge
                                                                                                         uiHeaderRowIndex);
         headerMetaData.edit(context);
         return true;
+    }
+
+    /**
+     * Check if a MouseDoubleClickEvent happened within a cell and delegate a response
+     * to sub-classes {code}doeEdit(){code} method, passing a context object that can
+     * be used to determine the cell that was double-clicked.
+     * @param event
+     */
+
+    @Override
+    protected boolean handleBodyCellDoubleClick(final NodeMouseDoubleClickEvent event) {
+        //Convert Canvas co-ordinate to Grid co-ordinate
+        final Point2D rp = CoordinateUtilities.convertDOMToGridCoordinate(gridWidget,
+                                                                          new Point2D(event.getX(),
+                                                                                      event.getY()));
+        final Integer uiColumnIndex = CoordinateUtilities.getUiColumnIndex(gridWidget,
+                                                                           rp.getX());
+        if (uiColumnIndex == null) {
+            return false;
+        }
+        ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) gridWidget.getModel().getColumns().get(uiColumnIndex);
+        if (scenarioGridColumn == null) {
+            return false;
+        }
+        return scenarioGridColumn.isReadOnly() || gridWidget.startEditingCell(rp);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelDoubleClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelDoubleClickHandler.java
@@ -20,7 +20,6 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.Point2D;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationGridHeaderUtilities;
-import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
@@ -119,27 +118,12 @@ public class ScenarioSimulationGridPanelDoubleClickHandler extends BaseGridWidge
     }
 
     /**
-     * Check if a MouseDoubleClickEvent happened within a cell and delegate a response
-     * to sub-classes {code}doeEdit(){code} method, passing a context object that can
-     * be used to determine the cell that was double-clicked.
+     * Returns <code>true</code> (block <code>NodeMouseDoubleClickEvent</code> propagation)
      * @param event
      */
-
     @Override
     protected boolean handleBodyCellDoubleClick(final NodeMouseDoubleClickEvent event) {
-        //Convert Canvas co-ordinate to Grid co-ordinate
-        final Point2D rp = CoordinateUtilities.convertDOMToGridCoordinate(gridWidget,
-                                                                          new Point2D(event.getX(),
-                                                                                      event.getY()));
-        final Integer uiColumnIndex = CoordinateUtilities.getUiColumnIndex(gridWidget,
-                                                                           rp.getX());
-        if (uiColumnIndex == null) {
-            return false;
-        }
-        ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) gridWidget.getModel().getColumns().get(uiColumnIndex);
-        if (scenarioGridColumn == null) {
-            return false;
-        }
-        return scenarioGridColumn.isReadOnly() || gridWidget.startEditingCell(rp);
+        // Block event propagation
+        return true;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -103,7 +103,8 @@ public class ScenarioGridModel extends BaseGridData {
             if (value.getRawValue() == null || value.getRawValue() instanceof String) { // Let' put a placeholder
                 String stringValue = (String) value.getRawValue();
                 int columnIndex = simulation.getSimulationDescriptor().getIndexByIdentifier(factIdentifier, expressionIdentifier);
-                setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(stringValue, ScenarioSimulationEditorConstants.INSTANCE.insertValue())));
+                String placeHolder = FactIdentifier.EMPTY.equals(factIdentifier) ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+                setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(stringValue, placeHolder)));
             } else {
                 throw new UnsupportedOperationException("Only string is supported at the moment");
             }
@@ -371,9 +372,8 @@ public class ScenarioGridModel extends BaseGridData {
     protected void commonAddColumn(final int index, final GridColumn<?> column) {
         String group = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnGroup();
         String columnId = ((ScenarioGridColumn) column).getInformationHeaderMetaData().getColumnId();
-        FactIdentifier factIdentifier = FactIdentifier.create(columnId, String.class.getCanonicalName());
         ExpressionIdentifier ei = ExpressionIdentifier.create(columnId, FactMappingType.valueOf(group));
-        commonAddColumn(index, column, factIdentifier, ei);
+        commonAddColumn(index, column, FactIdentifier.EMPTY, ei);
     }
 
     /**
@@ -401,7 +401,10 @@ public class ScenarioGridModel extends BaseGridData {
         }
         final List<Scenario> scenarios = simulation.getUnmodifiableScenarios();
         IntStream.range(0, scenarios.size())
-                .forEach(rowIndex -> setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(null, ScenarioSimulationEditorConstants.INSTANCE.insertValue()))));
+                .forEach(rowIndex -> {
+                    String placeHolder = FactIdentifier.EMPTY.equals(factIdentifier) ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+                    setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(null, placeHolder)));
+                });
     }
 
     protected void commonAddRow(int rowIndex) {
@@ -410,7 +413,8 @@ public class ScenarioGridModel extends BaseGridData {
         IntStream.range(1, getColumnCount()).forEach(columnIndex -> {
             final FactMapping factMappingByIndex = simulationDescriptor.getFactMappingByIndex(columnIndex);
             scenario.addMappingValue(factMappingByIndex.getFactIdentifier(), factMappingByIndex.getExpressionIdentifier(), null);
-            setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(null, ScenarioSimulationEditorConstants.INSTANCE.insertValue())));
+            String placeHolder = FactIdentifier.EMPTY.equals(factMappingByIndex.getFactIdentifier()) ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+            setCell(rowIndex, columnIndex, () -> new ScenarioGridCell(new ScenarioGridCellValue(null, placeHolder)));
         });
         updateIndexColumn();
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -89,4 +89,6 @@ public interface ScenarioSimulationEditorConstants
     String description();
 
     String insertValue();
+
+    String defineValidType();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuilders.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuilders.java
@@ -57,16 +57,17 @@ public class ScenarioSimulationBuilders {
         private boolean isMovable = false;
         private boolean isReadOnly = true;
         private String placeHolder = "";
-        private HeaderBuilder headerBuilder;
+        private final HeaderBuilder headerBuilder;
         private ScenarioGridColumnRenderer scenarioGridColumnRenderer;
         private final ScenarioCellTextBoxSingletonDOMElementFactory factoryCell;
 
-        public static ScenarioGridColumnBuilder get(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell) {
-            return new ScenarioGridColumnBuilder(factoryCell);
+        public static ScenarioGridColumnBuilder get(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell, HeaderBuilder headerBuilder) {
+            return new ScenarioGridColumnBuilder(factoryCell, headerBuilder);
         }
 
-        public ScenarioGridColumnBuilder(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell) {
+        public ScenarioGridColumnBuilder(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell, HeaderBuilder headerBuilder) {
             this.factoryCell = factoryCell;
+            this.headerBuilder = headerBuilder;
         }
 
         public ScenarioGridColumnBuilder setWidth(double width) {
@@ -89,18 +90,13 @@ public class ScenarioSimulationBuilders {
             return this;
         }
 
-        public ScenarioGridColumnBuilder setHeaderBuilder(HeaderBuilder headerBuilder) {
-            this.headerBuilder = headerBuilder;
-            return this;
-        }
-
         public ScenarioGridColumnBuilder setScenarioGridColumnRenderer(ScenarioGridColumnRenderer scenarioGridColumnRenderer) {
             this.scenarioGridColumnRenderer = scenarioGridColumnRenderer;
             return this;
         }
 
         public ScenarioGridColumn build() {
-            List<GridColumn.HeaderMetaData> headerMetaDataList = headerBuilder != null ? headerBuilder.build() : new ArrayList<>();
+            List<GridColumn.HeaderMetaData> headerMetaDataList =  headerBuilder.build();
             ScenarioGridColumnRenderer actualScenarioGridColumnRenderer = scenarioGridColumnRenderer != null ? scenarioGridColumnRenderer : new ScenarioGridColumnRenderer();
             ScenarioGridColumn toReturn = new ScenarioGridColumn(headerMetaDataList,
                                                                  actualScenarioGridColumnRenderer,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuilders.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuilders.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridColumnRenderer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+
+public class ScenarioSimulationBuilders {
+
+    /**
+     * <b>Builder</b> for <code>ScenarioGridColumn</code>.
+     * <p>
+     * If not provided, default values are:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * <p>
+     * placeHolder: "";
+     * </p>
+     * <p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * <p>
+     * headerMetaData: new ArrayList<>
+     * </p>
+     * </p>
+     */
+    public static class ScenarioGridColumnBuilder {
+
+        private double width = 150;
+        private boolean isMovable = false;
+        private boolean isReadOnly = true;
+        private String placeHolder = "";
+        private HeaderBuilder headerBuilder;
+        private ScenarioGridColumnRenderer scenarioGridColumnRenderer;
+        private final ScenarioCellTextBoxSingletonDOMElementFactory factoryCell;
+
+        public static ScenarioGridColumnBuilder get(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell) {
+            return new ScenarioGridColumnBuilder(factoryCell);
+        }
+
+        public ScenarioGridColumnBuilder(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell) {
+            this.factoryCell = factoryCell;
+        }
+
+        public ScenarioGridColumnBuilder setWidth(double width) {
+            this.width = width;
+            return this;
+        }
+
+        public ScenarioGridColumnBuilder setMovable(boolean movable) {
+            isMovable = movable;
+            return this;
+        }
+
+        public ScenarioGridColumnBuilder setReadOnly(boolean readOnly) {
+            isReadOnly = readOnly;
+            return this;
+        }
+
+        public ScenarioGridColumnBuilder setPlaceHolder(String placeHolder) {
+            this.placeHolder = placeHolder;
+            return this;
+        }
+
+        public ScenarioGridColumnBuilder setHeaderBuilder(HeaderBuilder headerBuilder) {
+            this.headerBuilder = headerBuilder;
+            return this;
+        }
+
+        public ScenarioGridColumnBuilder setScenarioGridColumnRenderer(ScenarioGridColumnRenderer scenarioGridColumnRenderer) {
+            this.scenarioGridColumnRenderer = scenarioGridColumnRenderer;
+            return this;
+        }
+
+        public ScenarioGridColumn build() {
+            List<GridColumn.HeaderMetaData> headerMetaDataList = headerBuilder != null ? headerBuilder.build() : new ArrayList<>();
+            ScenarioGridColumnRenderer actualScenarioGridColumnRenderer = scenarioGridColumnRenderer != null ? scenarioGridColumnRenderer : new ScenarioGridColumnRenderer();
+            ScenarioGridColumn toReturn = new ScenarioGridColumn(headerMetaDataList,
+                                                                 actualScenarioGridColumnRenderer,
+                                                                 width,
+                                                                 isMovable,
+                                                                 factoryCell,
+                                                                 placeHolder
+            );
+            toReturn.setReadOnly(isReadOnly);
+            return toReturn;
+        }
+    }
+
+    /**
+     * <b>Builder</b> for <code>List&lt;GridColumn.HeaderMetaData&gt;</code>.
+     * <p>
+     * If not provided, default values are:
+     * <p>
+     * columnId: null
+     * </p>
+     * <p>
+     * columnTitle: null;
+     * </p>
+     * <p>
+     * isReadOnly: <code>false</code>;
+     * </p>
+     * <p>
+     * informationHeader: <code>false</code>;
+     * </p>
+     * </p>
+     */
+    public static class HeaderBuilder {
+
+        String columnId;
+        String columnTitle;
+        String columnGroup = "";
+        boolean readOnly = false;
+        boolean informationHeader = false;
+        HeaderBuilder nestedLevel;
+        final ScenarioHeaderTextBoxSingletonDOMElementFactory factory;
+
+        public static HeaderBuilder get(ScenarioHeaderTextBoxSingletonDOMElementFactory factory) {
+            return new HeaderBuilder(factory);
+        }
+
+        public HeaderBuilder(ScenarioHeaderTextBoxSingletonDOMElementFactory factory) {
+            this.factory = factory;
+        }
+
+        public HeaderBuilder setColumnId(String columnId) {
+            this.columnId = columnId;
+            return this;
+        }
+
+        public HeaderBuilder setColumnTitle(String columnTitle) {
+            this.columnTitle = columnTitle;
+            return this;
+        }
+
+        public HeaderBuilder setColumnGroup(String columnGroup) {
+            this.columnGroup = columnGroup;
+            return this;
+        }
+
+        public HeaderBuilder setReadOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+            return this;
+        }
+
+        public HeaderBuilder setInformationHeader(boolean informationHeader) {
+            this.informationHeader = informationHeader;
+            return this;
+        }
+
+        public HeaderBuilder newLevel() {
+            this.nestedLevel = HeaderBuilder.get(factory)
+                    .setColumnId(columnId)
+                    .setColumnTitle(columnTitle)
+                    .setColumnGroup(columnGroup)
+                    .setReadOnly(readOnly);
+            return this.nestedLevel;
+        }
+
+        public List<GridColumn.HeaderMetaData> build() {
+            List<GridColumn.HeaderMetaData> toReturn = new ArrayList<>();
+            HeaderBuilder current = this;
+            do {
+                toReturn.add(current.internalBuild());
+                current = current.nestedLevel;
+            } while (current != null);
+            return toReturn;
+        }
+
+        private GridColumn.HeaderMetaData internalBuild() {
+            return new ScenarioHeaderMetaData(columnId, columnTitle, columnGroup, factory, readOnly, informationHeader);
+        }
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -39,6 +39,7 @@ public class ScenarioSimulationUtils {
      * </p>
      * <p>
      * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
+     * </p>
      * <p>
      * columnRenderer: new ScenarioGridColumnRenderer()
      * </p>
@@ -72,6 +73,7 @@ public class ScenarioSimulationUtils {
      * <p>
      * isReadOnly: <code>true</code>;
      * </p>
+     * <p>
      * columnRenderer: new ScenarioGridColumnRenderer()
      * </p>
      * @param title
@@ -107,6 +109,7 @@ public class ScenarioSimulationUtils {
      * </p>
      * <p>
      * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
+     * </p>
      * <p>
      * columnRenderer: new ScenarioGridColumnRenderer()
      * </p>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -178,8 +178,7 @@ public class ScenarioSimulationUtils {
     public static ScenarioSimulationBuilders.ScenarioGridColumnBuilder getScenarioGridColumnBuilder(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell,
                                                                                                     ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
                                                                                                     String placeHolder) {
-        ScenarioSimulationBuilders.ScenarioGridColumnBuilder toReturn = ScenarioSimulationBuilders.ScenarioGridColumnBuilder.get(factoryCell);
-        toReturn.setHeaderBuilder(headerBuilder);
+        ScenarioSimulationBuilders.ScenarioGridColumnBuilder toReturn = ScenarioSimulationBuilders.ScenarioGridColumnBuilder.get(factoryCell, headerBuilder);
         toReturn.setPlaceHolder(placeHolder);
         return toReturn;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -15,23 +15,41 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.drools.workbench.screens.scenariosimulation.client.factories.FactoryProvider;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
-import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
-import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridColumnRenderer;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
-import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 public class ScenarioSimulationUtils {
 
+    /**
+     * Returns a <code>ScenarioGridColumn</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * <p>
+     * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
+     * <p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param title
+     * @param columnId
+     * @param columnGroup
+     * @param factMappingType
+     * @param scenarioGridPanel
+     * @param gridLayer
+     * @return
+     */
     public static ScenarioGridColumn getScenarioGridColumn(String title,
                                                            String columnId,
                                                            String columnGroup,
@@ -39,37 +57,177 @@ public class ScenarioSimulationUtils {
                                                            ScenarioGridPanel scenarioGridPanel,
                                                            ScenarioGridLayer gridLayer) {
         ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, gridLayer);
-        ScenarioCellTextBoxSingletonDOMElementFactory factoryCell = FactoryProvider.getCellTextBoxFactory(scenarioGridPanel, gridLayer);
-        return new ScenarioGridColumn(getTwoLevelHeaderBuilder(title, columnId, columnGroup, factMappingType).build(factoryHeader), new ScenarioGridColumnRenderer(), 150, false, factoryCell, ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(title, columnId, columnGroup, factMappingType, factoryHeader);
+        return getScenarioGridColumn(headerBuilder, scenarioGridPanel, gridLayer);
     }
 
-    public static ColumnBuilder getTwoLevelHeaderBuilder(String title,
-                                                         String columnId,
-                                                         String columnGroup,
-                                                         FactMappingType factMappingType) {
+    /**
+     * Returns a <code>ScenarioGridColumn</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param title
+     * @param columnId
+     * @param columnGroup
+     * @param factMappingType
+     * @param scenarioGridPanel
+     * @param gridLayer
+     * @return
+     */
+    public static ScenarioGridColumn getScenarioGridColumn(String title,
+                                                           String columnId,
+                                                           String columnGroup,
+                                                           FactMappingType factMappingType,
+                                                           ScenarioGridPanel scenarioGridPanel,
+                                                           ScenarioGridLayer gridLayer,
+                                                           String placeHolder) {
+        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, gridLayer);
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(title, columnId, columnGroup, factMappingType, factoryHeader);
+        return getScenarioGridColumn(headerBuilder, scenarioGridPanel, gridLayer, true, placeHolder);
+    }
 
-        ColumnBuilder columnBuilder = ColumnBuilder.get();
+    /**
+     * Returns a <code>ScenarioGridColumn</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * <p>
+     * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
+     * <p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param headerBuilder
+     * @param scenarioGridPanel
+     * @param gridLayer
+     * @return
+     */
+    public static ScenarioGridColumn getScenarioGridColumn(ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
+                                                           ScenarioGridPanel scenarioGridPanel,
+                                                           ScenarioGridLayer gridLayer) {
+        ScenarioCellTextBoxSingletonDOMElementFactory factoryCell = FactoryProvider.getCellTextBoxFactory(scenarioGridPanel, gridLayer);
+        ScenarioSimulationBuilders.ScenarioGridColumnBuilder scenarioGridColumnBuilder = getScenarioGridColumnBuilder(factoryCell,
+                                                                                                                      headerBuilder,
+                                                                                                                      ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+        return scenarioGridColumnBuilder.build();
+    }
 
-        columnBuilder.setColumnId(columnId);
+    /**
+     * Returns a <code>ScenarioGridColumn</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param headerBuilder
+     * @param scenarioGridPanel
+     * @param gridLayer
+     * @param readOnly
+     * @param placeHolder
+     * @return
+     */
+    public static ScenarioGridColumn getScenarioGridColumn(ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
+                                                           ScenarioGridPanel scenarioGridPanel,
+                                                           ScenarioGridLayer gridLayer,
+                                                           boolean readOnly,
+                                                           String placeHolder) {
+        ScenarioCellTextBoxSingletonDOMElementFactory factoryCell = FactoryProvider.getCellTextBoxFactory(scenarioGridPanel, gridLayer);
+        ScenarioSimulationBuilders.ScenarioGridColumnBuilder scenarioGridColumnBuilder = getScenarioGridColumnBuilder(factoryCell,
+                                                                                                                      headerBuilder,
+                                                                                                                      placeHolder);
+        scenarioGridColumnBuilder.setReadOnly(readOnly);
+        return scenarioGridColumnBuilder.build();
+    }
 
-        columnBuilder.setColumnTitle(columnGroup);
-        columnBuilder.setReadOnly(true);
+    /**
+     * Returns a <code>ScenarioSimulationBuilders.ScenarioGridColumnBuilder</code> with the following default values:
+     * <p>
+     * width: 150
+     * </p>
+     * <p>
+     * isMovable: <code>false</code>;
+     * </p>
+     * <p>
+     * isReadOnly: <code>true</code>;
+     * </p>
+     * <p>
+     * columnRenderer: new ScenarioGridColumnRenderer()
+     * </p>
+     * @param factoryCell
+     * @param headerBuilder
+     * @param placeHolder
+     * @return
+     */
+    public static ScenarioSimulationBuilders.ScenarioGridColumnBuilder getScenarioGridColumnBuilder(ScenarioCellTextBoxSingletonDOMElementFactory factoryCell,
+                                                                                                    ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
+                                                                                                    String placeHolder) {
+        ScenarioSimulationBuilders.ScenarioGridColumnBuilder toReturn = ScenarioSimulationBuilders.ScenarioGridColumnBuilder.get(factoryCell);
+        toReturn.setHeaderBuilder(headerBuilder);
+        toReturn.setPlaceHolder(placeHolder);
+        return toReturn;
+    }
+
+    /**
+     * Retrieve a <b>single</b> or <b>double</b> level Header metadata, i.e. a <code>List&lt;GridColumn.HeaderMetaData&gt;</code> with one  or two elements,
+     * depending on the column <b>Group</b>:
+     * <p>
+     * OTHER: single level
+     * </p>
+     * <p>
+     * EXPECTED/GIVEN: double level
+     * </p>
+     * @param title
+     * @param columnId
+     * @param columnGroup
+     * @param factMappingType
+     * @param factoryHeader
+     * @return
+     */
+    public static ScenarioSimulationBuilders.HeaderBuilder getHeaderBuilder(String title,
+                                                                            String columnId,
+                                                                            String columnGroup,
+                                                                            FactMappingType factMappingType,
+                                                                            ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader) {
+
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = ScenarioSimulationBuilders.HeaderBuilder.get(factoryHeader);
+
+        headerBuilder.setColumnId(columnId);
+
+        headerBuilder.setColumnTitle(columnGroup);
+        headerBuilder.setReadOnly(true);
 
         boolean informationHeader = isOther(factMappingType) || isExpected(factMappingType) || isGiven(factMappingType);
         if (isOther(factMappingType)) {
-            columnBuilder.setColumnTitle(title);
-            columnBuilder.setColumnGroup(columnGroup);
-            columnBuilder.setInformationHeader(informationHeader);
-            return columnBuilder;
+            headerBuilder.setColumnTitle(title);
+            headerBuilder.setColumnGroup(columnGroup);
+            headerBuilder.setInformationHeader(informationHeader);
+            return headerBuilder;
         }
 
-        columnBuilder.newLevel()
+        headerBuilder.newLevel()
                 .setColumnTitle(title)
                 .setColumnGroup(columnGroup)
                 .setReadOnly(false)
                 .setInformationHeader(informationHeader);
 
-        return columnBuilder;
+        return headerBuilder;
     }
 
     private static boolean isOther(FactMappingType factMappingType) {
@@ -82,67 +240,5 @@ public class ScenarioSimulationUtils {
 
     private static boolean isGiven(FactMappingType factMappingType) {
         return FactMappingType.GIVEN.equals(factMappingType);
-    }
-
-    public static class ColumnBuilder {
-
-        String columnId;
-        String columnTitle;
-        String columnGroup = "";
-        boolean readOnly = false;
-        boolean informationHeader = false;
-        ColumnBuilder nestedLevel;
-
-        public static ColumnBuilder get() {
-            return new ColumnBuilder();
-        }
-
-        public ColumnBuilder setColumnId(String columnId) {
-            this.columnId = columnId;
-            return this;
-        }
-
-        public ColumnBuilder setColumnTitle(String columnTitle) {
-            this.columnTitle = columnTitle;
-            return this;
-        }
-
-        public ColumnBuilder setColumnGroup(String columnGroup) {
-            this.columnGroup = columnGroup;
-            return this;
-        }
-
-        public ColumnBuilder setReadOnly(boolean readOnly) {
-            this.readOnly = readOnly;
-            return this;
-        }
-
-        public ColumnBuilder setInformationHeader(boolean informationHeader) {
-            this.informationHeader = informationHeader;
-            return this;
-        }
-
-        public ColumnBuilder newLevel() {
-            this.nestedLevel = ColumnBuilder.get()
-                    .setColumnId(columnId)
-                    .setColumnTitle(columnTitle)
-                    .setColumnGroup(columnGroup)
-                    .setReadOnly(readOnly);
-            return this.nestedLevel;
-        }
-
-        public List<GridColumn.HeaderMetaData> build(ScenarioHeaderTextBoxSingletonDOMElementFactory factory) {
-            List<GridColumn.HeaderMetaData> toReturn = new ArrayList<>();
-            ColumnBuilder current = this;
-            do {
-                toReturn.add(current.internalBuild(factory));
-                current = current.nestedLevel;
-            } while (current != null);
-            return toReturn;
-        }
-
-        private GridColumn.HeaderMetaData internalBuild(ScenarioHeaderTextBoxSingletonDOMElementFactory factory) {
-            return new ScenarioHeaderMetaData(columnId, columnTitle, columnGroup, factory, readOnly, informationHeader);
-        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -108,7 +108,7 @@ public class ScenarioGrid extends BaseGridWidget {
         String columnGroup = factMapping.getExpressionIdentifier().getType().name();
         ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = getScenarioHeaderTextBoxSingletonDOMElementFactory();
         ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilderLocal(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
-        boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier());
+        boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier()) || FactIdentifier.INDEX.equals(factMapping.getFactIdentifier());
         String placeHolder = readOnly ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
         ScenarioGridColumn scenarioGridColumn = getScenarioGridColumnLocal(headerBuilder, readOnly, placeHolder);
         ((ScenarioGridModel) model).insertColumnGridOnly(columnIndex, scenarioGridColumn);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -20,17 +20,21 @@ import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
 import com.ait.lienzo.shared.core.types.EventPropagationMode;
+import org.drools.workbench.screens.scenariosimulation.client.factories.FactoryProvider;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.ScenarioSimulationGridPanelDoubleClickHandler;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridRenderer;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
+import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.Scenario;
 import org.drools.workbench.screens.scenariosimulation.model.Simulation;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getScenarioGridColumn;
 
 public class ScenarioGrid extends BaseGridWidget {
 
@@ -89,28 +93,42 @@ public class ScenarioGrid extends BaseGridWidget {
                                                                  renderer);
     }
 
-    void setHeaderColumns(Simulation simulation) {
-
+    protected void setHeaderColumns(Simulation simulation) {
         final List<FactMapping> factMappings = simulation.getSimulationDescriptor().getUnmodifiableFactMappings();
         IntStream.range(0, factMappings.size())
-                .forEach(index -> {
-                    FactMapping factMapping = factMappings.get(index);
-                    String columnId = factMapping.getExpressionIdentifier().getName();
-                    String columnTitle = factMapping.getExpressionAlias();
-                    String columnGroup = factMapping.getExpressionIdentifier().getType().name();
-                    ((ScenarioGridModel) model).insertColumnGridOnly(index, getScenarioGridColumn(columnTitle,
-                                                                    columnId,
-                                                                    columnGroup,
-                                                                    factMapping.getExpressionIdentifier().getType(),
-                                                                    scenarioGridPanel,
-                                                                    scenarioGridLayer));
+                .forEach(columnIndex -> {
+                    setHeaderColumn(columnIndex, factMappings.get(columnIndex));
+//                    FactMapping factMapping = factMappings.get(index);
+//                    String columnId = factMapping.getExpressionIdentifier().getName();
+//                    String columnTitle = factMapping.getExpressionAlias();
+//                    String columnGroup = factMapping.getExpressionIdentifier().getType().name();
+//                    ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
+//                    ScenarioSimulationBuilders.HeaderBuilder headerBuilder = ScenarioSimulationUtils.getHeaderBuilder(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
+//                    boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier());
+//                    String placeHolder = readOnly ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+//                    ScenarioGridColumn scenarioGridColumn = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, readOnly, placeHolder);
+//                    ((ScenarioGridModel) model).insertColumnGridOnly(index, scenarioGridColumn);
                 });
     }
 
-    void appendRows(Simulation simulation) {
+    protected void setHeaderColumn(int columnIndex, FactMapping factMapping) {
+        String columnId = factMapping.getExpressionIdentifier().getName();
+        String columnTitle = factMapping.getExpressionAlias();
+        String columnGroup = factMapping.getExpressionIdentifier().getType().name();
+        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = ScenarioSimulationUtils.getHeaderBuilder(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
+        boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier());
+        String placeHolder = readOnly ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+        ScenarioGridColumn scenarioGridColumn = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, readOnly, placeHolder);
+        ((ScenarioGridModel) model).insertColumnGridOnly(columnIndex, scenarioGridColumn);
+    }
+
+    protected void appendRows(Simulation simulation) {
         List<Scenario> scenarios = simulation.getUnmodifiableScenarios();
-        IntStream.range(0, scenarios.size()).forEach(rowIndex -> {
-            ((ScenarioGridModel) model).insertRowGridOnly(rowIndex, new ScenarioGridRow(), scenarios.get(rowIndex));
-        });
+        IntStream.range(0, scenarios.size()).forEach(rowIndex -> appendRow(rowIndex, scenarios.get(rowIndex)));
+    }
+
+    protected void appendRow(int rowIndex, Scenario scenario) {
+        ((ScenarioGridModel) model).insertRowGridOnly(rowIndex, new ScenarioGridRow(),scenario);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimu
 import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.drools.workbench.screens.scenariosimulation.model.Scenario;
 import org.drools.workbench.screens.scenariosimulation.model.Simulation;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
@@ -98,16 +99,6 @@ public class ScenarioGrid extends BaseGridWidget {
         IntStream.range(0, factMappings.size())
                 .forEach(columnIndex -> {
                     setHeaderColumn(columnIndex, factMappings.get(columnIndex));
-//                    FactMapping factMapping = factMappings.get(index);
-//                    String columnId = factMapping.getExpressionIdentifier().getName();
-//                    String columnTitle = factMapping.getExpressionAlias();
-//                    String columnGroup = factMapping.getExpressionIdentifier().getType().name();
-//                    ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
-//                    ScenarioSimulationBuilders.HeaderBuilder headerBuilder = ScenarioSimulationUtils.getHeaderBuilder(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
-//                    boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier());
-//                    String placeHolder = readOnly ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
-//                    ScenarioGridColumn scenarioGridColumn = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, readOnly, placeHolder);
-//                    ((ScenarioGridModel) model).insertColumnGridOnly(index, scenarioGridColumn);
                 });
     }
 
@@ -115,12 +106,24 @@ public class ScenarioGrid extends BaseGridWidget {
         String columnId = factMapping.getExpressionIdentifier().getName();
         String columnTitle = factMapping.getExpressionAlias();
         String columnGroup = factMapping.getExpressionIdentifier().getType().name();
-        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
-        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = ScenarioSimulationUtils.getHeaderBuilder(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
+        ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader = getScenarioHeaderTextBoxSingletonDOMElementFactory();
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilderLocal(columnTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), factoryHeader);
         boolean readOnly = FactIdentifier.EMPTY.equals(factMapping.getFactIdentifier());
         String placeHolder = readOnly ? ScenarioSimulationEditorConstants.INSTANCE.defineValidType() : ScenarioSimulationEditorConstants.INSTANCE.insertValue();
-        ScenarioGridColumn scenarioGridColumn = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, readOnly, placeHolder);
+        ScenarioGridColumn scenarioGridColumn = getScenarioGridColumnLocal(headerBuilder, readOnly, placeHolder);
         ((ScenarioGridModel) model).insertColumnGridOnly(columnIndex, scenarioGridColumn);
+    }
+
+    protected ScenarioHeaderTextBoxSingletonDOMElementFactory getScenarioHeaderTextBoxSingletonDOMElementFactory() {
+        return FactoryProvider.getHeaderTextBoxFactory(scenarioGridPanel, scenarioGridLayer);
+    }
+
+    protected ScenarioSimulationBuilders.HeaderBuilder getHeaderBuilderLocal(String columnTitle, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader) {
+        return ScenarioSimulationUtils.getHeaderBuilder(columnTitle, columnId, columnGroup, factMappingType, factoryHeader);
+    }
+
+    protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, boolean readOnly, String placeHolder) {
+        return ScenarioSimulationUtils.getScenarioGridColumn(headerBuilder, scenarioGridPanel, scenarioGridLayer, readOnly, placeHolder);
     }
 
     protected void appendRows(Simulation simulation) {
@@ -129,6 +132,6 @@ public class ScenarioGrid extends BaseGridWidget {
     }
 
     protected void appendRow(int rowIndex, Scenario scenario) {
-        ((ScenarioGridModel) model).insertRowGridOnly(rowIndex, new ScenarioGridRow(),scenario);
+        ((ScenarioGridModel) model).insertRowGridOnly(rowIndex, new ScenarioGridRow(), scenario);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
@@ -33,6 +33,8 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
 
     final ScenarioHeaderMetaData informationHeaderMetaData;
 
+    boolean readOnly = false;
+
     final String placeHolder;
 
     public ScenarioGridColumn(HeaderMetaData headerMetaData, GridColumnRenderer<String> columnRenderer, double width, boolean isMovable, ScenarioCellTextBoxSingletonDOMElementFactory factory, String placeHolder) {
@@ -56,6 +58,14 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
         factory.attachDomElement(context,
                                  e -> e.getWidget().setValue(assertCell(cell).getValue().getValue()),
                                  e -> e.getWidget().setFocus(true));
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+        this.readOnly = readOnly;
     }
 
     public ScenarioHeaderMetaData getInformationHeaderMetaData() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -29,6 +29,7 @@ testEditor=Test Editor
 scenarioCheatSheet=Scenario Cheatsheet
 runScenarioSimulation=Run Test
 insertValue=Insert value
+defineValidType=Define valid type
 # Menus
 expected=Expected
 given=Given

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AbstractCommandTest.java
@@ -19,9 +19,11 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import java.util.List;
 
 import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.RightPanelPresenter;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
@@ -63,6 +65,11 @@ public abstract class AbstractCommandTest {
     protected List<GridColumn.HeaderMetaData> mockHeaderMetaDatas;
     @Mock
     protected ScenarioHeaderMetaData mockHeaderMetaData;
+    @Mock
+    protected ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
+    @Mock
+    protected ScenarioSimulationBuilders.HeaderBuilder headerBuilderMock;
+
 
     protected final String COLUMN_ID = "COLUMN ID";
 
@@ -79,6 +86,7 @@ public abstract class AbstractCommandTest {
 
     protected final int FIRST_INDEX_LEFT = 2;
     protected final int FIRST_INDEX_RIGHT = 4;
+    protected final FactMappingType factMappingType = FactMappingType.valueOf(COLUMN_GROUP);
 
     @Before
     public void setup() {
@@ -93,5 +101,6 @@ public abstract class AbstractCommandTest {
         when(mockScenarioGridPanel.getScenarioGridLayer()).thenReturn(mockScenarioGridLayer);
         when(mockScenarioGridModel.getFirstIndexLeftOfGroup(eq(COLUMN_GROUP))).thenReturn(FIRST_INDEX_LEFT);
         when(mockScenarioGridModel.getFirstIndexRightOfGroup(eq(COLUMN_GROUP))).thenReturn(FIRST_INDEX_RIGHT);
+        doReturn(mockGridColumn).when(mockScenarioGridModel).getSelectedColumn();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/AppendColumnCommandTest.java
@@ -17,33 +17,42 @@
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class AppendColumnCommandTest extends AbstractCommandTest {
 
-
-
     private AppendColumnCommand appendColumnCommand;
 
     @Before
     public void setup() {
         super.setup();
-        appendColumnCommand = new AppendColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer);
+        appendColumnCommand = spy(new AppendColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer) {
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(String title, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer gridLayer, String placeHolder) {
+                return mockGridColumn;
+            }
+        });
     }
 
     @Test
     public void execute() {
         appendColumnCommand.execute();
+        verify(appendColumnCommand, times(1)).getScenarioGridColumnLocal(anyString(), eq(COLUMN_ID), eq(COLUMN_GROUP), eq(factMappingType), eq(mockScenarioGridPanel), eq(mockScenarioGridLayer), eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
         verify(mockScenarioGridModel, times(1)).getFirstIndexRightOfGroup(eq(COLUMN_GROUP));
-        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_RIGHT), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_RIGHT), eq(mockGridColumn));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/CommandExecutorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/CommandExecutorTest.java
@@ -43,7 +43,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -155,9 +158,15 @@ public class CommandExecutorTest extends AbstractCommandTest {
     @Test
     public void onDeleteColumnEvent() {
         DeleteColumnEvent event = new DeleteColumnEvent(COLUMN_INDEX, COLUMN_GROUP);
+        when(mockScenarioGridModel.getSelectedColumn()).thenReturn(null);
         commandExecutor.onEvent(event);
         verify(commandExecutor, times(1)).commonExecute(isA(DeleteColumnCommand.class));
         verify(commandExecutor, times(1)).commonExecute(isA(DisableRightPanelCommand.class));
+        reset(commandExecutor);
+        doReturn(mockGridColumn).when(mockScenarioGridModel).getSelectedColumn();
+        commandExecutor.onEvent(event);
+        verify(commandExecutor, times(1)).commonExecute(isA(DeleteColumnCommand.class));
+        verify(commandExecutor, never()).commonExecute(isA(DisableRightPanelCommand.class));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/DeleteColumnCommandTest.java
@@ -17,17 +17,22 @@
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,14 +40,17 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class DeleteColumnCommandTest extends AbstractCommandTest {
 
-
-
     private DeleteColumnCommand deleteColumnCommand;
 
     @Before
     public void setup() {
         super.setup();
-        deleteColumnCommand = new DeleteColumnCommand(mockScenarioGridModel, COLUMN_INDEX,  COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer);
+        deleteColumnCommand = spy(new DeleteColumnCommand(mockScenarioGridModel, COLUMN_INDEX, COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer) {
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(String title, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer gridLayer, String placeHolder) {
+                return mockGridColumn;
+            }
+        });
     }
 
     @Test
@@ -50,11 +58,12 @@ public class DeleteColumnCommandTest extends AbstractCommandTest {
         when(mockScenarioGridModel.getGroupSize(COLUMN_GROUP)).thenReturn(4L);
         deleteColumnCommand.execute();
         verify(mockScenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
-        verify(mockScenarioGridModel,never()).insertColumn(anyInt(), anyObject());
+        verify(mockScenarioGridModel, never()).insertColumn(anyInt(), anyObject());
         reset(mockScenarioGridModel);
         when(mockScenarioGridModel.getGroupSize(COLUMN_GROUP)).thenReturn(0L);
         deleteColumnCommand.execute();
+        verify(deleteColumnCommand, times(1)).getScenarioGridColumnLocal(anyString(), anyString(), eq(COLUMN_GROUP), eq(factMappingType), eq(mockScenarioGridPanel), eq(mockScenarioGridLayer), eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
         verify(mockScenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
-        verify(mockScenarioGridModel,times(1)).insertColumn(eq(COLUMN_INDEX), isA(GridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX), eq(mockGridColumn));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/InsertColumnCommandTest.java
@@ -17,13 +17,19 @@
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -35,15 +41,24 @@ public class InsertColumnCommandTest extends AbstractCommandTest {
     @Before
     public void setup() {
         super.setup();
+        insertColumnCommand = spy(new InsertColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_INDEX, true, mockScenarioGridPanel, mockScenarioGridLayer) {
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(String title, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer gridLayer, String placeHolder) {
+                return mockGridColumn;
+            }
+        });
     }
 
     @Test
     public void execute() {
-        insertColumnCommand = new InsertColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_INDEX, false, mockScenarioGridPanel, mockScenarioGridLayer);
+        insertColumnCommand.isRight = false;
         insertColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX), isA(ScenarioGridColumn.class));
-        insertColumnCommand = new InsertColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_INDEX, true, mockScenarioGridPanel, mockScenarioGridLayer);
+        verify(insertColumnCommand, times(1)).getScenarioGridColumnLocal(anyString(), anyString(), eq(COLUMN_GROUP), eq(factMappingType), eq(mockScenarioGridPanel), eq(mockScenarioGridLayer), eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX), eq(mockGridColumn));
+        reset(insertColumnCommand);
+        insertColumnCommand.isRight = true;
         insertColumnCommand.execute();
-        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX + 1), isA(ScenarioGridColumn.class));
+        verify(insertColumnCommand, times(1)).getScenarioGridColumnLocal(anyString(), anyString(), eq(COLUMN_GROUP), eq(factMappingType), eq(mockScenarioGridPanel), eq(mockScenarioGridLayer), eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(COLUMN_INDEX + 1), eq(mockGridColumn));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/PrependColumnCommandTest.java
@@ -17,33 +17,42 @@
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class PrependColumnCommandTest extends AbstractCommandTest {
 
-
-
     private PrependColumnCommand prependColumnCommand;
 
     @Before
     public void setup() {
         super.setup();
-        prependColumnCommand = new PrependColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer);
+        prependColumnCommand = spy(new PrependColumnCommand(mockScenarioGridModel, COLUMN_ID, COLUMN_GROUP, mockScenarioGridPanel, mockScenarioGridLayer) {
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(String title, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer gridLayer, String placeHolder) {
+                return mockGridColumn;
+            }
+        });
     }
 
     @Test
     public void execute() {
         prependColumnCommand.execute();
+        verify(prependColumnCommand, times(1)).getScenarioGridColumnLocal(anyString(), anyString(), eq(COLUMN_GROUP), eq(factMappingType), eq(mockScenarioGridPanel), eq(mockScenarioGridLayer), eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
         verify(mockScenarioGridModel, times(1)).getFirstIndexLeftOfGroup(eq(COLUMN_GROUP));
-        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_LEFT), isA(ScenarioGridColumn.class));
+        verify(mockScenarioGridModel, times(1)).insertColumn(eq(FIRST_INDEX_LEFT), eq(mockGridColumn));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/SetColumnValueCommandTest.java
@@ -19,7 +19,10 @@ package org.drools.workbench.screens.scenariosimulation.client.commands;
 import java.util.List;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,8 +30,7 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,13 +48,32 @@ public class SetColumnValueCommandTest extends AbstractCommandTest {
         super.setup();
         when(mockGridColumns.indexOf(mockGridColumn)).thenReturn(COLUMN_INDEX);
         when(mockScenarioGridModel.getColumns()).thenReturn(mockGridColumns);
-        doReturn(mockGridColumn).when(mockScenarioGridModel).getSelectedColumn();
-        setColumnValueCommand = new SetColumnValueCommand(mockScenarioGridModel, COLUMN_ID, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME, mockScenarioGridPanel, mockScenarioGridLayer);
+        setColumnValueCommand = spy(new SetColumnValueCommand(mockScenarioGridModel, COLUMN_ID, FULL_PACKAGE, VALUE, VALUE_CLASS_NAME, mockScenarioGridPanel, mockScenarioGridLayer) {
+
+            @Override
+            protected ScenarioHeaderTextBoxSingletonDOMElementFactory getHeaderTextBoxFactoryLocal() {
+                return scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
+            }
+
+            @Override
+            protected ScenarioSimulationBuilders.HeaderBuilder getHeaderBuilderLocal(String columnGroup, FactMappingType factMappingType, ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader) {
+                return headerBuilderMock;
+            }
+
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder) {
+                return mockGridColumn;
+            }
+        });
+
     }
 
     @Test
     public void execute() {
         setColumnValueCommand.execute();
-        verify(mockScenarioGridModel, times(1)).updateColumnType(eq(COLUMN_INDEX), isA(ScenarioGridColumn.class), eq(FULL_PACKAGE), eq(VALUE), eq(VALUE_CLASS_NAME));
+        verify(setColumnValueCommand, times(1)).getHeaderTextBoxFactoryLocal();
+        verify(setColumnValueCommand, times(1)).getHeaderBuilderLocal(eq(COLUMN_GROUP), eq(factMappingType), eq(scenarioHeaderTextBoxSingletonDOMElementFactoryMock));
+        verify(setColumnValueCommand, times(1)).getScenarioGridColumnLocal(eq(headerBuilderMock));
+        verify(mockScenarioGridModel, times(1)).updateColumnType(eq(COLUMN_INDEX), eq(mockGridColumn), eq(FULL_PACKAGE), eq(VALUE), eq(VALUE_CLASS_NAME));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.client.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
+import org.junit.Before;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.doReturn;
+
+public abstract class AbstractUtilsTest {
+
+    @Mock
+    protected ScenarioCellTextBoxSingletonDOMElementFactory scenarioCellTextBoxSingletonDOMElementFactoryMock;
+
+    @Mock
+    protected ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
+
+    @Mock
+    protected ScenarioGridLayer mockScenarioGridLayer;
+
+    @Mock
+    protected ScenarioGridPanel mockScenarioGridPanel;
+
+    @Mock
+    protected ScenarioSimulationBuilders.HeaderBuilder headerBuilderMock;
+
+    @Mock
+    protected ScenarioHeaderMetaData scenarioHeaderMetaDataMock;
+
+    protected List<ScenarioHeaderMetaData> scenarioHeaderMetaDataList = new ArrayList<>();
+
+    protected final static String PLACEHOLDER = "PLACEHOLDER";
+    protected final static String COLUMN_ID = "COLUMN_ID";
+    protected final static String COLUMN_TITLE_FIRST = "COLUMN_TITLE_FIRST";
+    protected final static String COLUMN_GROUP_FIRST = "OTHER";
+    protected final FactMappingType factMappingType = FactMappingType.valueOf(COLUMN_GROUP_FIRST);
+
+    @Before
+    public void setup() {
+        scenarioHeaderMetaDataList = Collections.singletonList(scenarioHeaderMetaDataMock);
+        doReturn(scenarioHeaderMetaDataList).when(headerBuilderMock).build();
+    }
+
+
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuildersTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuildersTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.client.utils;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ScenarioSimulationBuildersTest extends AbstractUtilsTest {
+
+
+    @Before
+    public void setup() {
+        super.setup();
+    }
+
+    @Test
+    public void testScenarioGridColumnBuilder() {
+        ScenarioSimulationBuilders.ScenarioGridColumnBuilder builder = ScenarioSimulationBuilders.ScenarioGridColumnBuilder.get(scenarioCellTextBoxSingletonDOMElementFactoryMock, headerBuilderMock);
+        builder.setReadOnly(false);
+        builder.setPlaceHolder(PLACEHOLDER);
+        ScenarioGridColumn retrieved = builder.build();
+        assertNotNull(retrieved);
+        assertEquals(PLACEHOLDER, retrieved.getPlaceHolder());
+        assertFalse(retrieved.isReadOnly());
+        assertFalse(retrieved.isMovable());
+        assertNotNull(retrieved.getHeaderMetaData());
+        assertFalse(retrieved.getHeaderMetaData().isEmpty());
+    }
+
+    @Test
+    public void testHeaderBuilder() {
+        ScenarioSimulationBuilders.HeaderBuilder builder = ScenarioSimulationBuilders.HeaderBuilder.get(scenarioHeaderTextBoxSingletonDOMElementFactoryMock);
+        builder.setColumnTitle(COLUMN_TITLE_FIRST);
+        builder.setColumnGroup(COLUMN_GROUP_FIRST);
+        builder.setInformationHeader(true);
+        List<GridColumn.HeaderMetaData> retrieved = builder.build();
+        assertNotNull(retrieved);
+        assertEquals(1, retrieved.size());
+        ScenarioHeaderMetaData headerMetaData = (ScenarioHeaderMetaData)retrieved.get(0);
+        assertNotNull(headerMetaData);
+        assertEquals(COLUMN_TITLE_FIRST, headerMetaData.getTitle());
+        assertEquals(COLUMN_GROUP_FIRST, headerMetaData.getColumnGroup());
+        assertTrue(headerMetaData.isInformationHeader());
+        assertFalse(headerMetaData.isReadOnly());
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -16,41 +16,50 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
-import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
-import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ScenarioSimulationUtilsTest {
-
-    @Mock
-    private ScenarioHeaderTextBoxSingletonDOMElementFactory factory;
+@RunWith(GwtMockitoTestRunner.class)
+public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
 
     @Test
-    public void getColumnBuilder() {
-
-        String alias = "Alias";
-        String factName = "FactName";
-
-        ScenarioSimulationBuilders.HeaderBuilder headerBuilderOther =
-                ScenarioSimulationUtils.getHeaderBuilder(alias, factName, FactMappingType.OTHER.name(), FactMappingType.OTHER, factory);
-        assertEquals(1, headerBuilderOther.build().size());
-        assertEquals(FactMappingType.OTHER.name(), headerBuilderOther.columnGroup);
-        assertNull(headerBuilderOther.nestedLevel);
-        assertEquals(alias, headerBuilderOther.columnTitle);
-
-        ScenarioSimulationBuilders.HeaderBuilder headerBuilderGiven =
-                ScenarioSimulationUtils.getHeaderBuilder(alias, factName, FactMappingType.GIVEN.name(), FactMappingType.GIVEN, factory);
-        assertEquals(2, headerBuilderGiven.build().size());
-        assertEquals("", headerBuilderGiven.columnGroup);
-        assertEquals(FactMappingType.GIVEN.name(), headerBuilderGiven.columnTitle);
-        assertEquals(alias, headerBuilderGiven.nestedLevel.columnTitle);
-        assertEquals(FactMappingType.GIVEN.name(), headerBuilderGiven.nestedLevel.columnGroup);
+    public void getScenarioGridColumn1() {
+        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, mockScenarioGridPanel, mockScenarioGridLayer);
+        assertNotNull(retrieved);
     }
+
+    @Test
+    public void getScenarioGridColumn2() {
+        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, mockScenarioGridPanel, mockScenarioGridLayer, PLACEHOLDER);
+        assertNotNull(retrieved);
+    }
+
+    @Test
+    public void getScenarioGridColumn3() {
+        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilderMock, mockScenarioGridPanel, mockScenarioGridLayer);
+        assertNotNull(retrieved);
+    }
+
+    @Test
+    public void getScenarioGridColumn4() {
+        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilderMock, mockScenarioGridPanel, mockScenarioGridLayer, false, PLACEHOLDER);
+        assertNotNull(retrieved);
+    }
+
+    @Test
+    public void getScenarioGridColumnBuilder() {
+        final ScenarioSimulationBuilders.ScenarioGridColumnBuilder retrieved = ScenarioSimulationUtils.getScenarioGridColumnBuilder(scenarioCellTextBoxSingletonDOMElementFactoryMock, headerBuilderMock, PLACEHOLDER);
+        assertNotNull(retrieved);
+    }
+
+    @Test
+    public void getHeaderBuilder() {
+        final ScenarioSimulationBuilders.HeaderBuilder retrieved = ScenarioSimulationUtils.getHeaderBuilder(COLUMN_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, scenarioHeaderTextBoxSingletonDOMElementFactoryMock);
+        assertNotNull(retrieved);
+    }
+
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -38,19 +38,19 @@ public class ScenarioSimulationUtilsTest {
         String alias = "Alias";
         String factName = "FactName";
 
-        ScenarioSimulationUtils.ColumnBuilder columnBuilderOther =
-                ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.OTHER.name(), FactMappingType.OTHER);
-        assertEquals(1, columnBuilderOther.build(factory).size());
-        assertEquals(FactMappingType.OTHER.name(), columnBuilderOther.columnGroup);
-        assertNull(columnBuilderOther.nestedLevel);
-        assertEquals(alias, columnBuilderOther.columnTitle);
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilderOther =
+                ScenarioSimulationUtils.getHeaderBuilder(alias, factName, FactMappingType.OTHER.name(), FactMappingType.OTHER, factory);
+        assertEquals(1, headerBuilderOther.build().size());
+        assertEquals(FactMappingType.OTHER.name(), headerBuilderOther.columnGroup);
+        assertNull(headerBuilderOther.nestedLevel);
+        assertEquals(alias, headerBuilderOther.columnTitle);
 
-        ScenarioSimulationUtils.ColumnBuilder columnBuilderGiven =
-                ScenarioSimulationUtils.getTwoLevelHeaderBuilder(alias, factName, FactMappingType.GIVEN.name(), FactMappingType.GIVEN);
-        assertEquals(2, columnBuilderGiven.build(factory).size());
-        assertEquals("", columnBuilderGiven.columnGroup);
-        assertEquals(FactMappingType.GIVEN.name(), columnBuilderGiven.columnTitle);
-        assertEquals(alias, columnBuilderGiven.nestedLevel.columnTitle);
-        assertEquals(FactMappingType.GIVEN.name(), columnBuilderGiven.nestedLevel.columnGroup);
+        ScenarioSimulationBuilders.HeaderBuilder headerBuilderGiven =
+                ScenarioSimulationUtils.getHeaderBuilder(alias, factName, FactMappingType.GIVEN.name(), FactMappingType.GIVEN, factory);
+        assertEquals(2, headerBuilderGiven.build().size());
+        assertEquals("", headerBuilderGiven.columnGroup);
+        assertEquals(FactMappingType.GIVEN.name(), headerBuilderGiven.columnTitle);
+        assertEquals(alias, headerBuilderGiven.nestedLevel.columnTitle);
+        assertEquals(FactMappingType.GIVEN.name(), headerBuilderGiven.nestedLevel.columnGroup);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -15,13 +15,17 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.widgets;
 
-import java.util.List;
+import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridRenderer;
+import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
+import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
+import org.drools.workbench.screens.scenariosimulation.model.Scenario;
 import org.drools.workbench.screens.scenariosimulation.model.Simulation;
 import org.drools.workbench.screens.scenariosimulation.model.SimulationDescriptor;
 import org.junit.Before;
@@ -32,12 +36,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManage
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioGridTest {
@@ -51,20 +56,26 @@ public class ScenarioGridTest {
     @Mock
     private ScenarioGridPanel mockScenarioGridPanel;
 
-    @Mock
-    private List<FactMapping> mockFactMappings;
-    @Mock
-    private SimulationDescriptor mockSimulationDescriptor;
-    @Mock
-    private Simulation mockSimulation;
+    private Simulation simulation = new Simulation();
+
+    private final int COLUMNS = 6;
 
     private ScenarioGrid scenarioGrid;
 
     @Before
     public void setup() {
-        when(mockSimulationDescriptor.getUnmodifiableFactMappings()).thenReturn(mockFactMappings);
-        when(mockSimulation.getSimulationDescriptor()).thenReturn(mockSimulationDescriptor);
-        scenarioGrid = spy(new ScenarioGrid(mockScenarioGridModel, mockScenarioGridLayer, mockScenarioGridRenderer, mockScenarioGridPanel));
+        simulation = getSimulation();
+        scenarioGrid = spy(new ScenarioGrid(mockScenarioGridModel, mockScenarioGridLayer, mockScenarioGridRenderer, mockScenarioGridPanel) {
+            @Override
+            protected void setHeaderColumn(int index, FactMapping factMapping) {
+                // do nothing
+            }
+
+            @Override
+            protected void appendRow(int rowIndex, Scenario scenario) {
+                // do nothing
+            }
+        });
     }
 
     @Test
@@ -75,10 +86,50 @@ public class ScenarioGridTest {
 
     @Test
     public void setContent() {
-        scenarioGrid.setContent(mockSimulation);
+        scenarioGrid.setContent(simulation);
         verify(mockScenarioGridModel, times(1)).clear();
-        verify(mockScenarioGridModel, times(1)).bindContent(eq(mockSimulation));
-        verify(scenarioGrid, times(1)).setHeaderColumns(eq(mockSimulation));
-        verify(scenarioGrid, times(1)).appendRows(eq(mockSimulation));
+        verify(mockScenarioGridModel, times(1)).bindContent(eq(simulation));
+        verify(scenarioGrid, times(1)).setHeaderColumns(eq(simulation));
+        verify(scenarioGrid, times(1)).appendRows(eq(simulation));
+    }
+
+    @Test
+    public void setHeaderColumns() {
+        scenarioGrid.setHeaderColumns(simulation);
+        verify(scenarioGrid, times(COLUMNS)).setHeaderColumn(anyInt(), isA(FactMapping.class));
+    }
+
+    @Test
+    public void appendRows() {
+        scenarioGrid.appendRows(simulation);
+        verify(scenarioGrid, times(1)).appendRow(anyInt(), isA(Scenario.class));
+    }
+
+    private Simulation getSimulation() {
+        Simulation toReturn = new Simulation();
+        SimulationDescriptor simulationDescriptor = toReturn.getSimulationDescriptor();
+
+        simulationDescriptor.addFactMapping(FactIdentifier.INDEX.getName(), FactIdentifier.INDEX, ExpressionIdentifier.INDEX);
+        simulationDescriptor.addFactMapping(FactIdentifier.DESCRIPTION.getName(), FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION);
+
+        Scenario scenario = toReturn.addScenario();
+        int row = toReturn.getUnmodifiableScenarios().indexOf(scenario);
+        scenario.setDescription(null);
+
+        // Add GIVEN Facts
+        IntStream.range(2, 4).forEach(id -> {
+            ExpressionIdentifier givenExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.GIVEN);
+            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.GIVEN, id), FactIdentifier.EMPTY, givenExpression);
+            scenario.addMappingValue(FactIdentifier.EMPTY, givenExpression, null);
+        });
+
+        // Add EXPECTED Facts
+        IntStream.range(2, 4).forEach(id -> {
+            id += 2; // This is to have consistent labels/names even when adding columns at runtime
+            ExpressionIdentifier expectedExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.EXPECTED);
+            simulationDescriptor.addFactMapping(FactMapping.getPlaceHolder(FactMappingType.EXPECTED, id), FactIdentifier.EMPTY, expectedExpression);
+            scenario.addMappingValue(FactIdentifier.EMPTY, expectedExpression, null);
+        });
+        return toReturn;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -19,8 +19,11 @@ import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.event.NodeMouseDoubleClickHandler;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.renderers.ScenarioGridRenderer;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
@@ -55,6 +58,17 @@ public class ScenarioGridTest {
     private ScenarioGridRenderer mockScenarioGridRenderer;
     @Mock
     private ScenarioGridPanel mockScenarioGridPanel;
+    @Mock
+    private ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
+    @Mock
+    private ScenarioSimulationBuilders.HeaderBuilder headerBuilderMock;
+    @Mock
+    private ScenarioGridColumn scenarioGridColumnMock;
+
+    private final FactMappingType factMappingType = FactMappingType.valueOf("OTHER");
+    private final String EXPRESSION_ALIAS = "EXPRESSION_ALIAS";
+
+    private FactMapping factMapping;
 
     private Simulation simulation = new Simulation();
 
@@ -64,16 +78,28 @@ public class ScenarioGridTest {
 
     @Before
     public void setup() {
+        factMapping = new FactMapping(EXPRESSION_ALIAS, FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION);
         simulation = getSimulation();
         scenarioGrid = spy(new ScenarioGrid(mockScenarioGridModel, mockScenarioGridLayer, mockScenarioGridRenderer, mockScenarioGridPanel) {
-            @Override
-            protected void setHeaderColumn(int index, FactMapping factMapping) {
-                // do nothing
-            }
 
             @Override
             protected void appendRow(int rowIndex, Scenario scenario) {
                 // do nothing
+            }
+
+            @Override
+            protected ScenarioHeaderTextBoxSingletonDOMElementFactory getScenarioHeaderTextBoxSingletonDOMElementFactory() {
+                return scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
+            }
+
+            @Override
+            protected ScenarioSimulationBuilders.HeaderBuilder getHeaderBuilderLocal(String columnTitle, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader) {
+                return headerBuilderMock;
+            }
+
+            @Override
+            protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, boolean readOnly, String placeHolder) {
+                return scenarioGridColumnMock;
             }
         });
     }
@@ -97,6 +123,20 @@ public class ScenarioGridTest {
     public void setHeaderColumns() {
         scenarioGrid.setHeaderColumns(simulation);
         verify(scenarioGrid, times(COLUMNS)).setHeaderColumn(anyInt(), isA(FactMapping.class));
+    }
+
+    @Test
+    public void setHeaderColumn() {
+        scenarioGrid.setHeaderColumn(1, factMapping);
+        verify(scenarioGrid, times(1)).getScenarioHeaderTextBoxSingletonDOMElementFactory();
+        verify(scenarioGrid, times(1)).getHeaderBuilderLocal(eq(factMapping.getExpressionAlias()),
+                                                             eq(factMapping.getExpressionIdentifier().getName()),
+                                                             eq(factMapping.getExpressionIdentifier().getType().name()),
+                                                             eq(factMapping.getExpressionIdentifier().getType()),
+                                                             eq(scenarioHeaderTextBoxSingletonDOMElementFactoryMock));
+        verify(scenarioGrid, times(1)).getScenarioGridColumnLocal(eq(headerBuilderMock),
+                                                             eq(false),
+                                                             eq(ScenarioSimulationEditorConstants.INSTANCE.insertValue()));
     }
 
     @Test


### PR DESCRIPTION
@kkufova @Rikkola @danielezonca 
Scope of this PR is to implement read only mechanism for the cells in Scenario grid.
More specifically:
1) Index column should never be editable
2) description column should always be editable
3) GIVEN/EXPECTED columns should not be editable if not mapped to a real property
Different placeholder messages should appear in the different condition (empty editable cell vs not editable one)
Cell editing should start with single click