### PR TITLE
[DROOLS-3124] Nested GridCell/GridCellValue

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
@@ -305,8 +305,7 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
             final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(scenarioGrid, ap.getY());
             if (uiRowIndex == null) {
                 return false;
-            } else {
-                return manageGridLeftClick(scenarioGrid, uiRowIndex, uiColumnIndex, scenarioGridColumn);
+            } else { return manageGridLeftClick(scenarioGrid, uiRowIndex, uiColumnIndex, scenarioGridColumn);
             }
         } else {
             return true;
@@ -364,7 +363,6 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
     /**
      * This method check if the click happened on an <i>writable</i> column of a <b>grid row</b>. If it is so, start editing the cell,
      * otherwise returns <code>false</code>
-     *
      * @param scenarioGrid
      * @param uiRowIndex
      * @param uiColumnIndex
@@ -379,7 +377,7 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
         if (((ScenarioGridCell) cell).isEditing()) {
             return true;
         }
-        ((ScenarioGridCell) cell).setEditing(scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex));
-        return scenarioGridColumn.isReadOnly() || ((ScenarioGridCell) cell).isEditing();
+        ((ScenarioGridCell) cell).setEditing((!scenarioGridColumn.isReadOnly()) && scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex));
+        return ((ScenarioGridCell) cell).isEditing();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
@@ -44,7 +44,9 @@ import org.drools.workbench.screens.scenariosimulation.client.events.EnableRight
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationGridHeaderUtilities;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridCell;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
@@ -136,8 +138,7 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
                 if (clickReceived.get() == 1) {
                     hideMenus();
                     scenarioGrid.clearSelections();
-                    if (manageLeftClick(canvasX, canvasY, isShiftKeyDown, isControlKeyDown)) {
-                    } else {
+                    if (!manageLeftClick(canvasX, canvasY, isShiftKeyDown, isControlKeyDown)) { // It was not a grid click
                         eventBus.fireEvent(new DisableRightPanelEvent());
                     }
                 }
@@ -301,7 +302,12 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
             return false;
         }
         if (!manageHeaderLeftClick(scenarioGrid, uiColumnIndex, scenarioGridColumn, ap)) {
-            return manageGridLeftClick(scenarioGrid, scenarioGridColumn, ap);
+            final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(scenarioGrid, ap.getY());
+            if (uiRowIndex == null) {
+                return false;
+            } else {
+                return manageGridLeftClick(scenarioGrid, uiRowIndex, uiColumnIndex, scenarioGridColumn);
+            }
         } else {
             return true;
         }
@@ -316,7 +322,7 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
      * @param rp
      * @return
      */
-    private boolean manageHeaderLeftClick(ScenarioGrid scenarioGrid, Integer uiColumnIndex, ScenarioGridColumn scenarioGridColumn, Point2D rp) {
+    protected boolean manageHeaderLeftClick(ScenarioGrid scenarioGrid, Integer uiColumnIndex, ScenarioGridColumn scenarioGridColumn, Point2D rp) {
         double gridY = rp.getY();
         if (!ScenarioSimulationGridHeaderUtilities.hasEditableHeader(scenarioGridColumn)) {
             return false;
@@ -358,16 +364,22 @@ public class ScenarioSimulationGridPanelClickHandler implements ClickHandler,
     /**
      * This method check if the click happened on an <i>writable</i> column of a <b>grid row</b>. If it is so, start editing the cell,
      * otherwise returns <code>false</code>
+     *
      * @param scenarioGrid
+     * @param uiRowIndex
+     * @param uiColumnIndex
      * @param scenarioGridColumn
-     * @param rp
      * @return
      */
-    private boolean manageGridLeftClick(ScenarioGrid scenarioGrid, ScenarioGridColumn scenarioGridColumn, Point2D rp) {
-        final Integer uiRowIndex = CoordinateUtilities.getUiRowIndex(scenarioGrid, rp.getY());
-        if (uiRowIndex == null) {
+    protected boolean manageGridLeftClick(ScenarioGrid scenarioGrid, Integer uiRowIndex, Integer uiColumnIndex, ScenarioGridColumn scenarioGridColumn) {
+        final GridCell<?> cell = scenarioGrid.getModel().getCell(uiRowIndex, uiColumnIndex);
+        if (cell == null) {
             return false;
         }
-        return scenarioGridColumn.isReadOnly() || scenarioGrid.startEditingCell(rp);
+        if (((ScenarioGridCell) cell).isEditing()) {
+            return true;
+        }
+        ((ScenarioGridCell) cell).setEditing(scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex));
+        return scenarioGridColumn.isReadOnly() || ((ScenarioGridCell) cell).isEditing();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridCell.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridCell.java
@@ -20,7 +20,17 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 
 public class ScenarioGridCell extends BaseGridCell<String> {
 
+    private boolean isEditing = false;
+
     public ScenarioGridCell(ScenarioGridCellValue value) {
         super(value);
+    }
+
+    public boolean isEditing() {
+        return isEditing;
+    }
+
+    public void setEditing(boolean editing) {
+        isEditing = editing;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridPanelClickHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridPanelClickHandlerTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
 import java.util.Collections;
 
+import com.ait.lienzo.client.core.types.Point2D;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
@@ -25,6 +26,7 @@ import com.google.gwt.event.dom.client.ContextMenuEvent;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridCell;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
@@ -33,31 +35,39 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractScenarioSimulationGridPanelClickHandlerTest {
 
-    final Double GRID_WIDTH = 100.0;
-    final Double HEADER_HEIGHT = 10.0;
-    final Double HEADER_ROW_HEIGHT = 10.0;
-    final int UI_COLUMN_INDEX = 0;
-    final int CLICK_POINT_X = 5;
-    final int CLICK_POINT_Y = 5;
-    final boolean SHIFT_PRESSED = false;
-    final boolean CTRL_PRESSED = false;
-    final int OFFSET_X = 0;
-    final int NATIVE_EVENT_CLIENT_X = 100;
-    final int NATIVE_EVENT_CLIENT_Y = 100;
-    final int TARGET_ABSOLUTE_LEFT = 50;
-    final int TARGET_SCROLL_LEFT = 20;
-    final int TARGET_ABSOLUTE_TOP = 50;
-    final int TARGET_SCROLL_TOP = 20;
-    final int DOCUMENT_SCROLL_LEFT = 10;
-    final int DOCUMENT_SCROLL_TOP = 10;
+    protected final Double GRID_WIDTH = 100.0;
+    protected final Double HEADER_HEIGHT = 10.0;
+    protected final Double HEADER_ROW_HEIGHT = 10.0;
+    protected final int UI_COLUMN_INDEX = 0;
+    protected final int UI_ROW_INDEX = 1;
+    protected final int CLICK_POINT_X = 5;
+    protected final int CLICK_POINT_Y = 5;
+    protected final boolean SHIFT_PRESSED = false;
+    protected final boolean CTRL_PRESSED = false;
+    protected final int OFFSET_X = 0;
+    protected final int NATIVE_EVENT_CLIENT_X = 100;
+    protected final int NATIVE_EVENT_CLIENT_Y = 100;
+    protected final int TARGET_ABSOLUTE_LEFT = 50;
+    protected final int TARGET_SCROLL_LEFT = 20;
+    protected final int TARGET_ABSOLUTE_TOP = 50;
+    protected final int TARGET_SCROLL_TOP = 20;
+    protected final int DOCUMENT_SCROLL_LEFT = 10;
+    protected final int DOCUMENT_SCROLL_TOP = 10;
+
+    @Mock
+    protected Point2D point2DMock;
 
     @Mock
     protected ScenarioGrid mockScenarioGrid;
+
+    @Mock
+    protected ScenarioGridCell scenarioGridCellMock;
 
     @Mock
     protected ScenarioHeaderMetaData headerMetaData;
@@ -69,7 +79,7 @@ public abstract class AbstractScenarioSimulationGridPanelClickHandlerTest {
     private ScenarioGridPanel mockScenarioGridPanel;
 
     @Mock
-    private ScenarioGridModel scenarioGridModel;
+    private ScenarioGridModel scenarioGridModelMock;
 
     @Mock
     private GridRenderer scenarioGridRenderer;
@@ -90,11 +100,13 @@ public abstract class AbstractScenarioSimulationGridPanelClickHandlerTest {
     private Document mockDocument;
 
 
+
     @Before
     public void setUp() throws Exception {
+        doReturn(scenarioGridCellMock).when(scenarioGridModelMock).getCell(UI_ROW_INDEX, UI_COLUMN_INDEX);
         when(mockScenarioGridPanel.getScenarioGrid()).thenReturn(mockScenarioGrid);
         when(mockScenarioGrid.getWidth()).thenReturn(GRID_WIDTH);
-        when(mockScenarioGrid.getModel()).thenReturn(scenarioGridModel);
+        when(mockScenarioGrid.getModel()).thenReturn(scenarioGridModelMock);
         when(mockScenarioGrid.getRenderer()).thenReturn(scenarioGridRenderer);
         when(mockScenarioGrid.getRendererHelper()).thenReturn(scenarioGridRendererHelper);
         when(scenarioGridRenderer.getHeaderHeight()).thenReturn(HEADER_HEIGHT);
@@ -103,8 +115,8 @@ public abstract class AbstractScenarioSimulationGridPanelClickHandlerTest {
 
         // mock single column in grid
         ScenarioGridColumn column = mock(ScenarioGridColumn.class);
-        when(scenarioGridModel.getColumns()).thenReturn(Collections.singletonList(column));
-        when(scenarioGridModel.getColumnCount()).thenReturn(1);
+        when(scenarioGridModelMock.getColumns()).thenReturn(Collections.singletonList(column));
+        when(scenarioGridModelMock.getColumnCount()).thenReturn(1);
 
         // presence of header metadata is prerequisite to handle header click
         // to simplify test, return just one header metadata
@@ -132,5 +144,4 @@ public abstract class AbstractScenarioSimulationGridPanelClickHandlerTest {
         when(mockContextMenuEvent.getNativeEvent()).thenReturn(mockNativeEvent);
         when(mockContextMenuEvent.getRelativeElement()).thenReturn(mockTarget);
     }
-
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.scenariosimulation.client.editor.menu.Header
 import org.drools.workbench.screens.scenariosimulation.client.editor.menu.OtherContextMenu;
 import org.drools.workbench.screens.scenariosimulation.client.editor.menu.UnmodifiableColumnGridContextMenu;
 import org.drools.workbench.screens.scenariosimulation.client.events.EnableRightPanelEvent;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -71,6 +73,8 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
     private UnmodifiableColumnGridContextMenu mockUnmodifiableColumnGridContextMenu;
     @Mock
     private Set<AbstractHeaderMenuPresenter> mockManagedMenus;
+    @Mock
+    private ScenarioGridColumn gridColumnMock;
 
     @Mock
     private EventBus mockEventBus;
@@ -244,6 +248,20 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
                                                                             CTRL_PRESSED));
         verify(mockScenarioGrid, never()).selectColumn(anyInt());
         verify(mockEventBus, never()).fireEvent(any(EnableRightPanelEvent.class));
+    }
+
+    @Test
+    public void testManageGridLeftClick() {
+        when(headerMetaData.isReadOnly()).thenReturn(false);
+        scenarioSimulationGridPanelClickHandler.setEventBus(mockEventBus);
+        when(scenarioGridCellMock.isEditing()).thenReturn(true);
+        scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        verify(scenarioGridCellMock, never()).setEditing(anyBoolean());
+        verify(gridColumnMock, never()).isReadOnly();
+        when(scenarioGridCellMock.isEditing()).thenReturn(false);
+        scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        verify(scenarioGridCellMock, times(1)).setEditing(anyBoolean());
+        verify(gridColumnMock, times(1)).isReadOnly();
     }
 
     private void commonCheck() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
@@ -251,16 +251,32 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
     }
 
     @Test
-    public void testManageGridLeftClick() {
+    public void testManageGridLeftClickReadOnlyTrue() {
+        when(headerMetaData.isReadOnly()).thenReturn(true);
+        scenarioSimulationGridPanelClickHandler.setEventBus(mockEventBus);
+        when(scenarioGridCellMock.isEditing()).thenReturn(true);
+        boolean retrieved = scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid, UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        verify(scenarioGridCellMock, never()).setEditing(anyBoolean());
+        assertTrue(retrieved);
+        when(scenarioGridCellMock.isEditing()).thenReturn(false);
+        scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        verify(scenarioGridCellMock, times(1)).setEditing(eq(false));
+        verify(gridColumnMock, times(1)).isReadOnly();
+    }
+
+    @Test
+    public void testManageGridLeftClickReadOnlyFalse() {
+        when(mockScenarioGrid.startEditingCell( UI_ROW_INDEX, UI_COLUMN_INDEX)).thenReturn(true);
         when(headerMetaData.isReadOnly()).thenReturn(false);
         scenarioSimulationGridPanelClickHandler.setEventBus(mockEventBus);
         when(scenarioGridCellMock.isEditing()).thenReturn(true);
-        scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        boolean retrieved = scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
+        assertTrue(retrieved);
         verify(scenarioGridCellMock, never()).setEditing(anyBoolean());
         verify(gridColumnMock, never()).isReadOnly();
         when(scenarioGridCellMock.isEditing()).thenReturn(false);
         scenarioSimulationGridPanelClickHandler.manageGridLeftClick(mockScenarioGrid,  UI_ROW_INDEX, UI_COLUMN_INDEX, gridColumnMock);
-        verify(scenarioGridCellMock, times(1)).setEditing(anyBoolean());
+        verify(scenarioGridCellMock, times(1)).setEditing(eq(true));
         verify(gridColumnMock, times(1)).isReadOnly();
     }
 


### PR DESCRIPTION
@kkufova @Rikkola @danielezonca 

Clicking on a Grid cell toggle it to editing mode (insert a ScenarioGrdiCell); but clicking again on the same cell while editing will insert a new ScenarioGridCell inside the previous one.
Scope of this PR is to fix these mis-behavior.
To verify: repeatedly click on same cell should start its editing but no "nested" cell should be created (look at attachment here https://issues.jboss.org/browse/DROOLS-3124 to see how a "nested" cell appear)