### PR TITLE
[DROOLS-3170] Removing vertical scroll bar from RightPanel

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/RightPanelViewImpl.html
@@ -16,7 +16,7 @@
   -->
 
 <!-- SECOND DOCK TAB - TEST TOOLS -->
-<div id="right-panel" class="tab-pane kie-dock active">
+<div id="right-panel" class="tab-pane kie-dock active" style="overflow-y: auto">
     <hr class="kie-dock__divider"/>
 
     <ul data-field="rightPanelTabs" class="nav nav-tabs nav-tabs-pf" id="kieTestTools" role="tablist">


### PR DESCRIPTION
@kkufova @Rikkola @danielezonca 
Scope of this PR is to remove the vertical scroll bar from RightPanel.

Both scrollbars (horizontal and vertical) should appear only when needed (i.e the content is extending the visible margins) and automatically disappear when not needed.