### PR TITLE
[DROOLS-3290] Bump scesim file version to 1.1, added automatic migration support (in memory for now)

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/ScenarioSimulationModel.java
@@ -26,7 +26,7 @@ public class ScenarioSimulationModel
         implements HasImports {
 
     @XStreamAsAttribute()
-    private String version = "1.0";
+    private String version = "1.1";
 
     private Simulation simulation;
 
@@ -78,5 +78,9 @@ public class ScenarioSimulationModel
     @Override
     public void setImports(Imports imports) {
         this.imports = imports;
+    }
+
+    public String getVersion() {
+        return version;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/InMemoryMigrationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/InMemoryMigrationStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.backend.server.util;
+
+import java.util.function.Function;
+
+public class InMemoryMigrationStrategy implements MigrationStrategy {
+
+    @Override
+    public Function<String, String> from1_0to1_1() {
+        return rawXml -> rawXml.replaceAll("EXPECTED", "EXPECT");
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/MigrationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/MigrationStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.backend.server.util;
+
+import java.util.function.Function;
+
+/**
+ * Interface to define the migration strategy for scesim files
+ */
+public interface MigrationStrategy {
+
+    /**
+     * Method to initialize migration strategy composition
+     * @return
+     */
+    default Function<String, String> start() {
+        return Function.identity();
+    }
+
+    /**
+     * Method to obtain the migration function from 1.0 to 1.1
+     * @return
+     */
+    Function<String, String> from1_0to1_1();
+
+    /**
+     * Method to complete the migration. For instance it can be used to store the new value
+     * @return
+     */
+    default Function<String, String> end() {
+        return Function.identity();
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationXMLPersistenceTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationXMLPersistenceTest.java
@@ -15,21 +15,25 @@
  */
 package org.drools.workbench.screens.scenariosimulation.backend.server;
 
+import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModel;
 import org.junit.Test;
 import org.kie.soup.project.datamodel.imports.Import;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ScenarioSimulationXMLPersistenceTest {
 
+    ScenarioSimulationXMLPersistence instance = ScenarioSimulationXMLPersistence.getInstance();
+    
     @Test
     public void noFQCNUsed() throws Exception {
         final ScenarioSimulationModel simulationModel = new ScenarioSimulationModel();
         simulationModel.getImports().addImport(new Import("org.test.Test"));
 
-        final String xml = ScenarioSimulationXMLPersistence.getInstance().marshal(simulationModel);
+        final String xml = instance.marshal(simulationModel);
 
         assertFalse(xml.contains("org.drools.workbench.screens.scenariosimulation.model"));
         assertFalse(xml.contains("org.kie.soup.project.datamodel.imports"));
@@ -37,7 +41,67 @@ public class ScenarioSimulationXMLPersistenceTest {
 
     @Test
     public void versionAttributeExists() throws Exception {
-        final String xml = ScenarioSimulationXMLPersistence.getInstance().marshal(new ScenarioSimulationModel());
-        assertTrue(xml.startsWith("<ScenarioSimulationModel version=\"1.0\">"));
+        final String xml = instance.marshal(new ScenarioSimulationModel());
+        assertTrue(xml.startsWith("<ScenarioSimulationModel version=\""+ ScenarioSimulationXMLPersistence.getCurrentVersion() + "\">"));
+    }
+
+    @Test
+    public void migrateIfNecessary_1_0_to_1_1() {
+        String migrated = instance.migrateIfNecessary("<ScenarioSimulationModel version=\"1.0\">\n" +
+                                                       "  <simulation>\n" +
+                                                       "    <simulationDescriptor>\n" +
+                                                       "      <factMappings>\n" +
+                                                       "        <FactMapping>\n" +
+                                                       "          <expressionElements>\n" +
+                                                       "            <ExpressionElement>\n" +
+                                                       "              <step>lengthYears</step>\n" +
+                                                       "            </ExpressionElement>\n" +
+                                                       "          </expressionElements>\n" +
+                                                       "          <expressionIdentifier>\n" +
+                                                       "            <name>1541680933813</name>\n" +
+                                                       "            <type>EXPECTED</type>\n" +
+                                                       "          </expressionIdentifier>\n" +
+                                                       "          <factIdentifier>\n" +
+                                                       "            <name>1541680933813</name>\n" +
+                                                       "            <className>mortgages.mortgages.LoanApplication</className>\n" +
+                                                       "          </factIdentifier>\n" +
+                                                       "          <className>java.lang.Integer</className>\n" +
+                                                       "          <factAlias>LoanApplication1</factAlias>\n" +
+                                                       "          <expressionAlias>lengthYears</expressionAlias>\n" +
+                                                       "        </FactMapping>\n" +
+                                                       "      </factMappings>\n" +
+                                                       "    </simulationDescriptor>\n" +
+                                                       "    <scenarios>\n" +
+                                                       "      <Scenario>\n" +
+                                                       "        <factMappingValues>\n" +
+                                                       "          <FactMappingValue/>\n" +
+                                                       "        </factMappingValues>\n" +
+                                                       "        <simulationDescriptor reference=\"../../../simulationDescriptor\"/>\n" +
+                                                       "      </Scenario>\n" +
+                                                       "    </scenarios>\n" +
+                                                       "  </simulation>\n" +
+                                                       "  <imports>\n" +
+                                                       "    <imports/>\n" +
+                                                       "  </imports>\n" +
+                                                       "</ScenarioSimulationModel>");
+        assertTrue(migrated.contains("EXPECT"));
+        assertFalse(migrated.contains("EXPECTED"));
+    }
+
+    @Test
+    public void migrateIfNecessary() {
+        Assertions.assertThatThrownBy(() -> instance.migrateIfNecessary("<ScenarioSimulationModel version=\"9999999999.99999999999\">"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Version 9999999999.99999999999 of the file is not supported. Current version is " + ScenarioSimulationXMLPersistence.getCurrentVersion());
+
+        String noMigrationNeeded = "<ScenarioSimulationModel version=\"" + ScenarioSimulationXMLPersistence.getCurrentVersion() + "\">";
+        String afterMigration = instance.migrateIfNecessary(noMigrationNeeded);
+        assertEquals(noMigrationNeeded, afterMigration);
+    }
+
+    @Test
+    public void extractVersion() {
+        String version = instance.extractVersion("<ScenarioSimulationModel version=\"1.0\" version=\"1.1\">");
+        assertEquals("1.0", version);
     }
 }


### PR DESCRIPTION
Define automatic migration mechanism. It is in memory for now to be compatible with both internal WB and external maven runner.

@kkufova @Rikkola @gitgabrio 