### PR TITLE
Fix enforcer error about commons-logging

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/pom.xml
@@ -84,6 +84,12 @@
       <groupId>org.kie.workbench.services</groupId>
       <artifactId>kie-wb-common-datamodel-backend</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
```
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (ban-blacklisted-dependencies) @ drools-wb-guided-dtable-editor-api ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: commons-logging:commons-logging:jar:1.1.1
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```