### PR TITLE
[DROOLS-3313] Avoid double invocation of ScenarioGridPanelProduce.newScenarioGrid()

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioGridPanelProducer.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioGridPanelProducer.java
@@ -15,6 +15,7 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.producers;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -31,23 +32,24 @@ import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGr
 public class ScenarioGridPanelProducer {
 
     @Inject
-    ScenarioGridLayer scenarioGridLayer;
+    protected ScenarioGridLayer scenarioGridLayer;
 
     @Inject
-    ScenarioGridPanel scenarioGridPanel;
+    protected ScenarioGridPanel scenarioGridPanel;
+
+    @PostConstruct
+    public void init() {
+        final ScenarioGrid scenarioGrid = new ScenarioGrid(new ScenarioGridModel(false),
+                                                           scenarioGridLayer,
+                                                           new ScenarioGridRenderer(false),
+                                                           scenarioGridPanel);
+        scenarioGridLayer.addScenarioGrid(scenarioGrid);
+        scenarioGridPanel.add(scenarioGridLayer);
+
+    }
 
     public ScenarioGridPanel getScenarioGridPanel() {
-        scenarioGridLayer.addScenarioGrid(newScenarioGrid(scenarioGridPanel,
-                                                          scenarioGridLayer));
-        scenarioGridPanel.add(scenarioGridLayer);
         return scenarioGridPanel;
     }
 
-    ScenarioGrid newScenarioGrid(final ScenarioGridPanel scenarioGridPanel,
-                                         final ScenarioGridLayer scenarioGridLayer) {
-        return new ScenarioGrid(new ScenarioGridModel(false),
-                                scenarioGridLayer,
-                                new ScenarioGridRenderer(false),
-                                scenarioGridPanel);
-    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioGridPanelProducerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioGridPanelProducerTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,21 +48,20 @@ public class ScenarioGridPanelProducerTest extends AbstractProducerTest {
                 this.scenarioGridLayer = scenarioGridLayerMock;
                 this.scenarioGridPanel = scenarioGridPanelMock;
             }
-
-            @Override
-            ScenarioGrid newScenarioGrid(ScenarioGridPanel scenarioGridPanel, ScenarioGridLayer scenarioGridLayer) {
-                return scenarioGridMock;
-            }
         });
+    }
+
+    @Test
+    public void init() {
+        scenarioGridPanelProducer.init();
+        verify(scenarioGridLayerMock, times(1)).addScenarioGrid(isA(ScenarioGrid.class));
+        verify(scenarioGridPanelMock, times(1)).add(eq(scenarioGridLayerMock));
     }
 
     @Test
     public void getScenarioGridPanel() {
         final ScenarioGridPanel retrieved = scenarioGridPanelProducer.getScenarioGridPanel();
         assertEquals(scenarioGridPanelMock, retrieved);
-        verify(scenarioGridPanelProducer, times(1)).newScenarioGrid(eq(scenarioGridPanelMock), eq(scenarioGridLayerMock));
-        verify(scenarioGridLayerMock, times(1)).addScenarioGrid(eq(scenarioGridMock));
-        verify(scenarioGridPanelMock, times(1)).add(eq(scenarioGridLayerMock));
     }
 
 }


### PR DESCRIPTION
@kkufova @Rikkola @danielezonca 

Scope of this PR is to avoid double invocation/Creation of ScenarioGrid/ScenarioGridModel.

The modification should be transparent for the user. Please check for regressions.