### PR TITLE
[DROOLS-3322] It is not possible to set a column type by typing in the data object's name manually	

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -18,9 +18,11 @@ package org.drools.workbench.screens.scenariosimulation.client.editor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Supplier;
@@ -441,6 +443,9 @@ public class ScenarioSimulationEditorPresenter
                     });
                 }
                 rightPanelPresenter.setInstanceFieldsMap(instanceFieldsMap);
+                Set<String> dataObjectsInstancesName = new HashSet<>(factTypeFieldsMap.keySet());
+                dataObjectsInstancesName.addAll(instanceFieldsMap.keySet());
+                scenarioGridPanel.getScenarioGrid().getModel().setDataObjectsInstancesName(dataObjectsInstancesName);
             }
         };
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElement.java
@@ -33,7 +33,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 public class ScenarioCellTextAreaDOMElement extends BaseDOMElement<String, TextArea> implements TakesValue<String>,
                                                                                                 Focusable {
 
-    private String originalValue;
+    protected String originalValue;
 
     public ScenarioCellTextAreaDOMElement(final TextArea widget,
                                           final GridLayer gridLayer,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioHeaderTextAreaDOMElement.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.factories;
 
+import java.util.Objects;
+
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.gwtbootstrap3.client.ui.TextArea;
@@ -40,18 +42,21 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
 
     @Override
     public void flush(final String value) {
+        if (scenarioHeaderMetaData != null) {
+            scenarioHeaderMetaData.setEditingMode(false);
+            if (Objects.equals(value, scenarioHeaderMetaData.getTitle())) {
+                return;
+            }
+        }
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
         try {
             ScenarioGridModel model = (ScenarioGridModel) gridWidget.getModel();
-
             if (!model.validateHeaderUpdate(value, rowIndex, columnIndex)) {
                 return;
             }
             model.updateHeader(columnIndex, rowIndex, value);
-            if (scenarioHeaderMetaData != null) {
-                scenarioHeaderMetaData.setEditingMode(false);
-            }
+            originalValue = value;
         } catch (Exception e) {
             throw new IllegalArgumentException(new StringBuilder().append("Impossible to update header (").append(rowIndex)
                                                        .append(") of column ").append(columnIndex).toString(), e);


### PR DESCRIPTION
@kkufova @danielezonca 
Scoope of this pR is to prevent user to manually set an instance header with the name of a Data Object or an already existing instance