### PR TITLE
[DROOLS-3085] Added index information to scenario runner failures

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/IndexedScenarioException.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/IndexedScenarioException.java
@@ -16,17 +16,22 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.runner;
 
-public class ScenarioException extends IllegalArgumentException {
+public class IndexedScenarioException extends ScenarioException {
 
-    public ScenarioException(String message) {
+    private final int index;
+
+    public IndexedScenarioException(int index, String message) {
         super(message);
+        this.index = index;
     }
 
-    public ScenarioException(String message, Throwable cause) {
+    public IndexedScenarioException(int index, String message, Throwable cause) {
         super(message, cause);
+        this.index = index;
     }
 
-    public ScenarioException(Throwable cause) {
-        super(cause.getMessage(), cause);
+    public IndexedScenarioException(int index, Throwable cause) {
+        super(cause);
+        this.index = index;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerImplServiceImplTest.java
@@ -15,11 +15,20 @@
  */
 package org.drools.workbench.screens.scenariosimulation.backend.server;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.drools.workbench.screens.scenariosimulation.backend.server.runner.IndexedScenarioException;
+import org.drools.workbench.screens.scenariosimulation.backend.server.runner.ScenarioRunnerImpl;
+import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioResult;
+import org.drools.workbench.screens.scenariosimulation.model.Scenario;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModel;
 import org.drools.workbench.screens.scenariosimulation.model.Simulation;
+import org.guvnor.common.services.shared.test.Failure;
 import org.guvnor.common.services.shared.test.TestResultMessage;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.internal.runners.model.EachTestNotifier;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
 import org.kie.api.runtime.KieContainer;
@@ -27,15 +36,20 @@ import org.kie.workbench.common.services.backend.builder.service.BuildInfo;
 import org.kie.workbench.common.services.backend.builder.service.BuildInfoService;
 import org.kie.workbench.common.services.backend.project.ModuleClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.mocks.EventSourceMock;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +76,9 @@ public class ScenarioRunnerImplServiceImplTest {
 
     @Mock
     private ModuleClassLoaderHelper classLoaderHelper;
+
+    @Captor
+    private ArgumentCaptor<TestResultMessage> testResultMessage;
 
     @InjectMocks
     private ScenarioRunnerServiceImpl scenarioRunnerService = new ScenarioRunnerServiceImpl();
@@ -99,5 +116,39 @@ public class ScenarioRunnerImplServiceImplTest {
 
         verify(defaultTestResultMessageEvent, never()).fire(any());
         verify(customTestResultEvent).fire(any());
+    }
+
+    @Test
+    public void runFailed() throws Exception {
+        when(buildInfoService.getBuildInfo(any())).thenReturn(buildInfo);
+        when(buildInfo.getKieContainer()).thenReturn(kieContainer);
+        ScenarioSimulationModel scenarioSimulationModel = new ScenarioSimulationModel();
+        Scenario scenario = scenarioSimulationModel.getSimulation().getScenarioByIndex(0);
+        scenario.setDescription("Test Scenario");
+        String errorMessage = "Test Error";
+
+        scenarioRunnerService.setRunnerSupplier((kieContainer, simulation) -> new ScenarioRunnerImpl(kieContainer, simulation) {
+
+            @Override
+            protected List<ScenarioResult> internalRunScenario(int index, Scenario scenario, EachTestNotifier singleNotifier) {
+
+                singleNotifier.fireTestStarted();
+
+                singleNotifier.addFailure(new IndexedScenarioException(index, errorMessage));
+                singleNotifier.fireTestFinished();
+
+                return Collections.emptyList();
+            }
+        });
+        scenarioRunnerService.runTest("test", mock(Path.class), scenarioSimulationModel);
+        verify(defaultTestResultMessageEvent, times(1)).fire(testResultMessage.capture());
+        TestResultMessage value = testResultMessage.getValue();
+        List<Failure> failures = value.getFailures();
+        assertEquals(1, failures.size());
+
+        String testDescription = String.format("#%d: %s", 1, scenario.getDescription());
+        Failure failure = failures.get(0);
+        assertEquals(errorMessage, failure.getMessage());
+        assertTrue(failure.getDisplayName().startsWith(testDescription));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImplTest.java
@@ -134,7 +134,7 @@ public class ScenarioSimulationServiceImplTest {
     private Path path = PathFactory.newPath("contextpath", "file:///contextpath");
 
     @Before
-    public void setuo() {
+    public void setup() {
         Set<Package> packages = new HashSet<>();
         packages.add(new Package(path, path, path, path, path, "Test", "", ""));
         when(kieModuleService.resolveModule(any())).thenReturn(module);


### PR DESCRIPTION
This PR add index information to scenario failures to be able to understand which test failed reading the alerts or as output of junit runner (`mvn test`)

@Rikkola @gitgabrio @kkufova 