### PR TITLE
[DROOLS-3177] Move RegistryContext to kie-internal

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
@@ -112,13 +112,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.kie.workbench.services</groupId>
-      <artifactId>kie-wb-common-services-api</artifactId>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-internal</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-core</artifactId>
+      <groupId>org.kie.workbench.services</groupId>
+      <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ValidateFactCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ValidateFactCommand.java
@@ -19,10 +19,10 @@ package org.drools.workbench.screens.scenariosimulation.backend.server.fluent;
 import java.util.Collection;
 import java.util.List;
 
-import org.drools.core.command.impl.RegistryContext;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
+import org.kie.internal.command.RegistryContext;
 
 public class ValidateFactCommand implements ExecutableCommand<Void> {
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ValidateFactCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ValidateFactCommandTest.java
@@ -19,8 +19,6 @@ package org.drools.workbench.screens.scenariosimulation.backend.server.fluent;
 import java.util.Collections;
 import java.util.function.Function;
 
-import org.drools.core.command.RequestContextImpl;
-import org.drools.core.command.impl.RegistryContext;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioResult;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.SingleFactValueResult;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingValue;
@@ -28,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.ObjectFilter;
+import org.kie.internal.command.RegistryContext;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -51,14 +50,15 @@ public class ValidateFactCommandTest {
     @Mock
     private FactMappingValue factMappingValue;
 
+    @Mock
+    private RegistryContext registryContext;
+
     @Test
     public void executeTest() {
+        when(registryContext.lookup(KieSession.class)).thenReturn(kieSession);
         Function<Object, SingleFactValueResult> alwaysMatchFunction = SingleFactValueResult::createResult;
 
         ValidateFactCommand validateFactCommand = new ValidateFactCommand(asList(new FactCheckerHandle(String.class, alwaysMatchFunction, scenarioResult)));
-
-        RegistryContext registryContext = new RequestContextImpl();
-        registryContext.register(KieSession.class, kieSession);
 
         when(kieSession.getObjects(any(ObjectFilter.class))).thenReturn(Collections.singleton(null));
         validateFactCommand.execute(registryContext);


### PR DESCRIPTION
As discussed I moved RegistryContext to kie-internal end updated usages.

@mariofusco @kkufova

PR list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/348
https://github.com/kiegroup/drools/pull/2174
https://github.com/kiegroup/drools-wb/pull/1012
https://github.com/kiegroup/jbpm/pull/1387
https://github.com/kiegroup/droolsjbpm-integration/pull/1657