### PR TITLE
[DROOLS-3401] Moved Fluent API to kie-internal

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ScenarioExecutableBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/ScenarioExecutableBuilder.java
@@ -31,9 +31,9 @@ import org.kie.api.builder.model.KieSessionModel;
 import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.RequestContext;
-import org.kie.api.runtime.builder.ExecutableBuilder;
-import org.kie.api.runtime.builder.KieSessionFluent;
 import org.kie.api.runtime.conf.ClockTypeOption;
+import org.kie.internal.builder.fluent.ExecutableBuilder;
+import org.kie.internal.builder.fluent.KieSessionFluent;
 
 public class ScenarioExecutableBuilder {
 


### PR DESCRIPTION
As discussed, this PR move to kie-internal the fluent API because it is still experimental

@mariofusco @mdproctor @kkufova 

PRs list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/349
https://github.com/kiegroup/drools/pull/2177
https://github.com/kiegroup/drools-wb/pull/1016
https://github.com/kiegroup/droolsjbpm-integration/pull/1661