### PR TITLE
JBPM-8026: Remove unnecessary dependency to stunner standalone backend module

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -902,10 +902,6 @@
     </dependency>
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-backend</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-client-common</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Hey @ederign @hasys @manstis 

See https://issues.jboss.org/browse/JBPM-8026

The `kie-wb-common-stunner-backend` is only necessary when the backend does not support guvnor and some other kie modules, which is not the case of this webapp. So this dependency can be removed. Also by removing it, the `stunner.git` repository will be never created. I've tested the webapp and it works.

Thanks!