### PR TITLE
[DROOLS-3417] Avoiding endless loop on ScenarioSimulationGridHeaderUtilitiesTest

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
@@ -63,6 +63,9 @@ public class ScenarioSimulationGridHeaderUtilities {
         int uiHeaderRowIndex = 0;
         double offsetY = cy - headerMinY;
         final int headerRowCount = gridWidget.getModel().getHeaderRowCount();
+        if (headerRowCount < 1) {
+            return null;
+        }
         final double headerRowHeight = renderer.getHeaderRowHeight();
         final double headerRowsHeight = headerRowHeight * headerRowCount;
         final double columnHeaderRowHeight = headerRowsHeight / column.getHeaderMetaData().size();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -43,8 +43,9 @@ import static org.mockito.Mockito.mock;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioSimulationGridHeaderUtilitiesTest {
 
+    private static final int HEADER_ROWS = 2;
     private static final double HEADER_HEIGHT = 50.0;
-    private static final double HEADER_ROW_HEIGHT = HEADER_HEIGHT / 2;
+    private static final double HEADER_ROW_HEIGHT = HEADER_HEIGHT / HEADER_ROWS;
 
     @Mock
     private GridWidget gridWidget;
@@ -64,6 +65,8 @@ public class ScenarioSimulationGridHeaderUtilitiesTest {
     @Mock
     private BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation;
 
+    private ScenarioGridModel scenarioGridModel = new ScenarioGridModel();
+
     private Point2D rp = new Point2D(0, 0);
 
     @Before
@@ -72,15 +75,15 @@ public class ScenarioSimulationGridHeaderUtilitiesTest {
         doReturn(gridRendererHelper).when(gridWidget).getRendererHelper();
         doReturn(ri).when(gridRendererHelper).getRenderingInformation();
         doReturn(HEADER_HEIGHT).when(gridRenderer).getHeaderHeight();
-        doReturn(HEADER_HEIGHT).when(gridRenderer).getHeaderRowHeight();
+        doReturn(HEADER_ROW_HEIGHT).when(gridRenderer).getHeaderRowHeight();
 
         doReturn(floatingBlockInformation).when(ri).getFloatingBlockInformation();
         doReturn(0.0).when(floatingBlockInformation).getX();
         doReturn(0.0).when(floatingBlockInformation).getWidth();
 
         doReturn(mock(Viewport.class)).when(gridWidget).getViewport();
-
-        doReturn(new ScenarioGridModel()).when(gridWidget).getModel();
+        scenarioGridModel.setHeaderRowCount(HEADER_ROWS);
+        doReturn(scenarioGridModel).when(gridWidget).getModel();
     }
 
     @Test
@@ -98,6 +101,16 @@ public class ScenarioSimulationGridHeaderUtilitiesTest {
         final Integer uiHeaderRowIndex = ScenarioSimulationGridHeaderUtilities.getUiHeaderRowIndex(gridWidget,
                                                                                                    uiColumn,
                                                                                                    HEADER_HEIGHT + 5.0);
+        assertNull(uiHeaderRowIndex);
+    }
+
+    @Test
+    public void testGetUiHeaderRowIndexOnNoRowsHeader() {
+        doReturn(new ScenarioGridModel()).when(gridWidget).getModel();
+        final GridColumn<?> uiColumn = mockGridColumn(100.0);
+        final Integer uiHeaderRowIndex = ScenarioSimulationGridHeaderUtilities.getUiHeaderRowIndex(gridWidget,
+                                                                                                   uiColumn,
+                                                                                                   HEADER_ROW_HEIGHT - 5.0);
         assertNull(uiHeaderRowIndex);
     }
 
@@ -314,6 +327,8 @@ public class ScenarioSimulationGridHeaderUtilitiesTest {
 
         doReturn(headerMetaData).when(uiColumn).getHeaderMetaData();
         doReturn(width).when(uiColumn).getWidth();
+
+        scenarioGridModel.appendColumn(uiColumn);
 
         return uiColumn;
     }


### PR DESCRIPTION
@kkufova @jomarko @Rikkola 

That loop was caused by a change inside upper layer.
Before this change, by default ScenariogridModel had 1 header row, even when called by the default constructor. After the change, the default header row number is 0.
Inside ScenarioSimulationGridHeaderUtilities there is a method that uses that row number in a "while" loop for a subtraction, but since now that number is 0, that loop will never end.
The fix has been to check for "0" rows before that loop, eventually returning null.
Tests have been modified as per @jomarko suggestion. A new one has been added.

Please check ASAP to merge it.
 