### PR TITLE
[DROOLS-3471] Prevent header editing when adding column in DMN scenario

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommand.java
@@ -50,7 +50,9 @@ public class SetInstanceHeaderCommand extends AbstractScenarioSimulationCommand 
         }
         String className = status.getClassName();
         String canonicalClassName = fullPackage + className;
-        String nameToUseForCreation = context.getModel().getSimulation().get().getSimulationDescriptor().getType().equals(ScenarioSimulationModel.Type.DMN) ? className : selectedColumn.getInformationHeaderMetaData().getColumnId();
+        final ScenarioSimulationModel.Type simulationModelType = context.getModel().getSimulation().get().getSimulationDescriptor().getType();
+        selectedColumn.setEditableHeaders(!simulationModelType.equals(ScenarioSimulationModel.Type.DMN));
+        String nameToUseForCreation = simulationModelType.equals(ScenarioSimulationModel.Type.DMN) ? className : selectedColumn.getInformationHeaderMetaData().getColumnId();
         FactIdentifier factIdentifier = getFactIdentifierByColumnTitle(className, context).orElse(FactIdentifier.create(nameToUseForCreation, canonicalClassName));
         final ScenarioHeaderMetaData informationHeaderMetaData = selectedColumn.getInformationHeaderMetaData();
         informationHeaderMetaData.setTitle(className);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
@@ -53,7 +53,9 @@ public class SetPropertyHeaderCommand extends AbstractScenarioSimulationCommand 
             fullPackage += ".";
         }
         String canonicalClassName = fullPackage + className;
-        String nameToUseForCreation = context.getModel().getSimulation().get().getSimulationDescriptor().getType().equals(ScenarioSimulationModel.Type.DMN) ? className : selectedColumn.getInformationHeaderMetaData().getColumnId();
+        final ScenarioSimulationModel.Type simulationModelType = context.getModel().getSimulation().get().getSimulationDescriptor().getType();
+        selectedColumn.setEditableHeaders(!simulationModelType.equals(ScenarioSimulationModel.Type.DMN));
+        String nameToUseForCreation = simulationModelType.equals(ScenarioSimulationModel.Type.DMN) ? className : selectedColumn.getInformationHeaderMetaData().getColumnId();
         FactIdentifier factIdentifier = getFactIdentifierByColumnTitle(className, context).orElse(FactIdentifier.create(nameToUseForCreation, canonicalClassName));
         final GridData.Range instanceLimits = context.getModel().getInstanceLimits(columnIndex);
         IntStream.range(instanceLimits.getMinRowIndex(), instanceLimits.getMaxRowIndex() + 1)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
@@ -33,7 +33,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -67,13 +67,29 @@ public class SetInstanceHeaderCommandTest extends AbstractScenarioSimulationComm
     }
 
     @Test
-    public void execute() {
+    public void executeDMN() {
         scenarioSimulationContext.getStatus().setFullPackage(FULL_PACKAGE);
         scenarioSimulationContext.getStatus().setClassName(VALUE_CLASS_NAME);
+        when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.DMN);
         command.execute(scenarioSimulationContext);
-        verify(gridColumnMock, atLeast(1)).getInformationHeaderMetaData();
-        verify(informationHeaderMetaDataMock, atLeast(1)).setTitle(eq(VALUE_CLASS_NAME));
-        verify(gridColumnMock, atLeast(1)).setInstanceAssigned(eq(true));
+        verify(gridColumnMock, times(1)).setEditableHeaders(eq(false));
+        verify(gridColumnMock, atLeastOnce()).getInformationHeaderMetaData();
+        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(VALUE_CLASS_NAME));
+        verify(gridColumnMock, times(1)).setInstanceAssigned(eq(true));
+        verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(eq(false));
+        verify(scenarioGridModelMock, times(1)).updateColumnInstance(eq(COLUMN_INDEX), eq(gridColumnMock));
+    }
+
+    @Test
+    public void executeRULE() {
+        scenarioSimulationContext.getStatus().setFullPackage(FULL_PACKAGE);
+        scenarioSimulationContext.getStatus().setClassName(VALUE_CLASS_NAME);
+        when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
+        command.execute(scenarioSimulationContext);
+        verify(gridColumnMock, times(1)).setEditableHeaders(eq(true));
+        verify(gridColumnMock, atLeastOnce()).getInformationHeaderMetaData();
+        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(VALUE_CLASS_NAME));
+        verify(gridColumnMock, times(1)).setInstanceAssigned(eq(true));
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(eq(false));
         verify(scenarioGridModelMock, times(1)).updateColumnInstance(eq(COLUMN_INDEX), eq(gridColumnMock));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -64,9 +64,11 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
     }
 
     @Test
-    public void executeFalse() {
+    public void executeKeepDataFalseDMN() {
         scenarioSimulationContext.getStatus().setKeepData(false);
+        when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.DMN);
         command.execute(scenarioSimulationContext);
+        verify(gridColumnMock, times(1)).setEditableHeaders(eq(false));
         verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
         verify(propertyHeaderMetaDataMock, times(1)).setTitle(VALUE);
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
@@ -74,7 +76,19 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
     }
 
     @Test
-    public void executeTrue() {
+    public void executeKeepDataFalseRule() {
+        scenarioSimulationContext.getStatus().setKeepData(false);
+        when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
+        command.execute(scenarioSimulationContext);
+        verify(gridColumnMock, times(1)).setEditableHeaders(eq(true));
+        verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
+        verify(propertyHeaderMetaDataMock, times(1)).setTitle(VALUE);
+        verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
+        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), isA(ScenarioGridColumn.class), eq(VALUE), eq(VALUE_CLASS_NAME), eq(false));
+    }
+
+    @Test
+    public void executeKeepDataTrue() {
         scenarioSimulationContext.getStatus().setKeepData(true);
         command.execute(scenarioSimulationContext);
         verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());


### PR DESCRIPTION
@kkufova @danielezonca @Rikkola 
Scope of this PR is to prevent header editing when adding column inside a DMN scenario simulation