### PR TITLE
[DROOLS-3472] Change empty cell behavior, from null to skip it

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperator.java
@@ -72,8 +72,8 @@ public enum BaseExpressionOperator {
         protected Object getValueForGiven(String className, String value, ClassLoader classLoader) {
             String returnValue = removeOperator(value);
 
-            // empty string is equivalent to null only if there is no operator symbol
-            returnValue = "".equals(returnValue) && !match(value).isPresent() ? null : returnValue;
+            // "null" string is converted to null
+            returnValue = "null".equals(returnValue) ? null : returnValue;
 
             return convertValue(className, returnValue, classLoader);
         }
@@ -172,6 +172,9 @@ public enum BaseExpressionOperator {
     }
 
     protected Optional<String> match(String value) {
+        if(value == null) {
+            return Optional.empty();
+        }
         value = value.trim();
         return symbols.stream().filter(value::startsWith).findFirst();
     }
@@ -184,7 +187,7 @@ public enum BaseExpressionOperator {
             int index = value.indexOf(symbolToRemove);
             value = value.substring(index + symbolToRemove.length()).trim();
         }
-        return value.trim();
+        return value == null ? null : value.trim();
     }
 
     private static boolean areComparable(Object a, Object b) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
@@ -133,7 +133,8 @@ public abstract class AbstractRunnerHelper {
         for (FactMappingValue factMappingValue : factMappingValues) {
             FactIdentifier factIdentifier = factMappingValue.getFactIdentifier();
 
-            if (FactIdentifier.EMPTY.equals(factIdentifier)) {
+            // null means skip
+            if (factMappingValue.getRawValue() == null) {
                 continue;
             }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelper.java
@@ -65,7 +65,7 @@ public class RuleScenarioRunnerHelper extends AbstractRunnerHelper {
         }
         RuleScenarioExecutableBuilder ruleScenarioExecutableBuilder = createBuilder(kieContainer);
         scenarioRunnerData.getGivens().stream().map(ScenarioGiven::getValue).forEach(ruleScenarioExecutableBuilder::insert);
-        // all new facts should be verified internally to the working memory because
+        // all new facts should be verified internally to the working memory
         scenarioRunnerData.getExpects().stream()
                 .filter(ScenarioExpect::isNewFact)
                 .flatMap(output -> output.getExpectedResult().stream()

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperatorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperatorTest.java
@@ -43,7 +43,9 @@ public class BaseExpressionOperatorTest {
 
         Assert.assertEquals("Test", BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), "= Test", classLoader));
         Assert.assertEquals("", BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), "= ", classLoader));
-        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), "", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), "null", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), "= null", classLoader));
+        Assert.assertEquals(null, BaseExpressionOperator.EQUALS.getValueForGiven(String.class.getCanonicalName(), null, classLoader));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelperTest.java
@@ -265,7 +265,9 @@ public class RuleScenarioRunnerHelperTest {
     @Test(expected = IllegalArgumentException.class)
     public void groupByFactIdentifierAndFilterFailTest() {
         List<FactMappingValue> fail = new ArrayList<>();
-        fail.add(new FactMappingValue());
+        FactMappingValue factMappingValue = new FactMappingValue();
+        factMappingValue.setRawValue("TEST");
+        fail.add(factMappingValue);
         runnerHelper.groupByFactIdentifierAndFilter(fail, FactMappingType.GIVEN);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElement.java
@@ -113,21 +113,20 @@ public class ScenarioCellTextAreaDOMElement extends BaseDOMElement<String, TextA
     @Override
     @SuppressWarnings("unchecked")
     public void flush(final String value) {
+        String actualValue = value != null && value.isEmpty() ? null : value;
         if (scenarioGridCell != null) {
             scenarioGridCell.setEditingMode(false);
-            String actualValue = value.isEmpty() ? null : value;
             String cellValue = scenarioGridCell.getValue().getValue();
-            String originalValue =  (cellValue == null || cellValue.isEmpty()) ? null : cellValue;
-            if (Objects.equals(actualValue, originalValue)) {
+            if (Objects.equals(actualValue, cellValue)) {
                 return;
             }
         }
-        internalFlush(value);
+        internalFlush(actualValue);
     }
 
     protected void internalFlush(final String value) {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();
-        ((ScenarioGrid)gridWidget).getEventBus().fireEvent(new SetCellValueEvent(rowIndex, columnIndex, value, false));
+        ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetCellValueEvent(rowIndex, columnIndex, value, false));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/ScenarioCellTextAreaDOMElementTest.java
@@ -74,6 +74,23 @@ public class ScenarioCellTextAreaDOMElementTest extends AbstractFactoriesTest {
     }
 
     @Test
+    public void flushNullString() {
+        when(gridCellValueMock.getValue()).thenReturn("");
+        scenarioCellTextAreaDOMElement.flush(null);
+        verify(scenarioGridCellMock, times(1)).setEditingMode(eq(false));
+        verify(scenarioCellTextAreaDOMElement, times(1)).internalFlush(eq(null));
+    }
+
+    @Test
+    public void flushEmptyStringToNullConversion() {
+        when(gridCellValueMock.getValue()).thenReturn("");
+        scenarioCellTextAreaDOMElement.flush("");
+        verify(scenarioGridCellMock, times(1)).setEditingMode(eq(false));
+        // empty strings are converted to null during flush
+        verify(scenarioCellTextAreaDOMElement, times(1)).internalFlush(eq(null));
+    }
+
+    @Test
     public void internalFlush() {
         scenarioCellTextAreaDOMElement.internalFlush(VALUE);
         verify(eventBusMock, times(1)).fireEvent(isA(SetCellValueEvent.class));


### PR DESCRIPTION
Now empty cell means to skip it (both for GIVEN/EXPECT).
Rule scesim file you can use `null` as alternative to express a null condition.
DMN scesim now just skip cell if empty or use FEEL unary expression evaluation if not empty

@Rikkola @gitgabrio @kkufova 