### PR TITLE
DROOLS-2623: Stabilize xls-dtables tests

### DIFF
--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplCDITest.java
@@ -44,8 +44,7 @@ public class DecisionTableXLSServiceImplCDITest extends CDITestSetup {
 
     @BeforeClass
     public static void setUpDateTimeFormat() {
-        droolsDateFormat = System.getProperty(ApplicationPreferences.DATE_FORMAT);
-        System.setProperty(ApplicationPreferences.DATE_FORMAT, "dd-MM-yyyy");
+        droolsDateFormat = System.setProperty(ApplicationPreferences.DATE_FORMAT, "dd-MM-yyyy");
     }
 
     @AfterClass

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesStripQuotesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesStripQuotesTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 public class DTCellValueUtilitiesStripQuotesTest {
 
-    private static final String DATE_FORMAT = "dd/mm/yyyy";
+    private static final String DATE_FORMAT = "dd-MM-yyyy";
 
     @BeforeClass
     public static void setup() {

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DTCellValueUtilitiesTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class DTCellValueUtilitiesTest {
 
-    private static final String DATE_FORMAT = "dd/mm/yyyy";
+    private static final String DATE_FORMAT = "dd-MM-yyyy";
 
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(DATE_FORMAT);
 
@@ -87,7 +87,7 @@ public class DTCellValueUtilitiesTest {
                 {DataType.TYPE_NUMERIC_LONG, new DTCellValue52("100"), DataType.DataTypes.NUMERIC_LONG, 100l, false},
                 {DataType.TYPE_NUMERIC_SHORT, new DTCellValue52("100"), DataType.DataTypes.NUMERIC_SHORT, new Short("100"), false},
                 {DataType.TYPE_BOOLEAN, new DTCellValue52("true"), DataType.DataTypes.BOOLEAN, true, false},
-                {DataType.TYPE_DATE, new DTCellValue52("31/12/2016"), DataType.DataTypes.DATE, FORMATTER.parse("31/12/2016"), false},
+                {DataType.TYPE_DATE, new DTCellValue52("31-12-2016"), DataType.DataTypes.DATE, FORMATTER.parse("31-12-2016"), false},
                 {DataType.TYPE_STRING, new DTCellValue52("String"), DataType.DataTypes.STRING, "String", false},
 
                 {DataType.TYPE_NUMERIC, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_BIGDECIMAL, new BigDecimal(100), false},
@@ -99,7 +99,7 @@ public class DTCellValueUtilitiesTest {
                 {DataType.TYPE_NUMERIC_INTEGER, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_INTEGER, 100, false},
                 {DataType.TYPE_NUMERIC_LONG, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_LONG, 100l, false},
                 {DataType.TYPE_NUMERIC_SHORT, new DTCellValue52("\"100\""), DataType.DataTypes.NUMERIC_SHORT, new Short("100"), false},
-                {DataType.TYPE_DATE, new DTCellValue52("\"31/12/2016\""), DataType.DataTypes.DATE, FORMATTER.parse("31/12/2016"), false},
+                {DataType.TYPE_DATE, new DTCellValue52("\"31-12-2016\""), DataType.DataTypes.DATE, FORMATTER.parse("31-12-2016"), false},
 
                 {DataType.TYPE_NUMERIC, new DTCellValue52("a"), DataType.DataTypes.NUMERIC_BIGDECIMAL, null, true},
                 {DataType.TYPE_NUMERIC_BIGDECIMAL, new DTCellValue52("a"), DataType.DataTypes.NUMERIC_BIGDECIMAL, null, true},
@@ -120,7 +120,9 @@ public class DTCellValueUtilitiesTest {
         DTCellValueUtilities.assertDTCellValue(type,
                                                provided,
                                                (final String value,
-                                                final DataType.DataTypes dataType) -> assertTrue(hasConversionError));
+                                                final DataType.DataTypes dataType) ->
+                                                       assertTrue("Conversion error callback was called unexpectedly",
+                                                                  hasConversionError));
         assertEquals(expectedDataType,
                      provided.getDataType());
         assertEquals(expectedValue,

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
@@ -128,7 +128,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
     private static void setupPreferences() {
         final Map<String, String> preferences = new HashMap<String, String>() {{
             put(ApplicationPreferences.DATE_FORMAT,
-                "dd/mm/yyyy");
+                "dd-MM-yyyy");
         }};
         ApplicationPreferences.setUp(preferences);
     }

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTableGeneratorListenerTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTableGeneratorListenerTest.java
@@ -93,7 +93,7 @@ public class GuidedDecisionTableGeneratorListenerTest {
     private static void setupPreferences() {
         final Map<String, String> preferences = new HashMap<String, String>() {{
             put(ApplicationPreferences.DATE_FORMAT,
-                "dd/mm/yyyy");
+                "dd-MM-yyyy");
         }};
         ApplicationPreferences.setUp(preferences);
     }


### PR DESCRIPTION
Replacement of #870 

@manstis would you mind to have a look?

I find out the problem is caused by `DecisionTableXLSServiceImplCDITest`. There I set the system property `drools.dateformat`. I debugged hours today, but didn't find out, why the system property from that test is propagated also to other tests, even when I do clean up in `@AfterClass` method.

Due to the time I have spent already with the issue I prefer this alternative, much less appropriate, solution.

Please let me know what do you think.