### PR TITLE
[DROOLS-3496][DROOLS-3473][DROOLS-3487] Fix external JUnit runner support for DMN scenarios

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/utils/ScenarioSimulationSharedUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/utils/ScenarioSimulationSharedUtils.java
@@ -26,7 +26,7 @@ public class ScenarioSimulationSharedUtils {
      * @return
      */
     public static boolean isCollection(String className) {
-        return List.class.getName().equals(className) || Map.class.getName().equals(className);
+        return isList(className) || isMap(className);
     }
 
     /**
@@ -36,5 +36,15 @@ public class ScenarioSimulationSharedUtils {
      */
     public static boolean isList(String className) {
         return List.class.getName().equals(className);
+    }
+
+
+    /**
+     * Returns true if given string equals <code>List.class.getName()</code>
+     * @param className
+     * @return
+     */
+    public static boolean isMap(String className) {
+        return Map.class.getName().equals(className);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractKieContainerService.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractKieContainerService.java
@@ -33,6 +33,11 @@ public abstract class AbstractKieContainerService {
 
     protected KieContainer getKieContainer(Path path) {
         KieModule kieModule = moduleService.resolveModule(path);
-        return buildInfoService.getBuildInfo(kieModule).getKieContainer();
+        KieContainer kieContainer = buildInfoService.getBuildInfo(kieModule).getKieContainer();
+        if (kieContainer == null) {
+            throw new IllegalArgumentException("Impossible to retrieve KieContainer, please fix compilation errors of " +
+                                                       "the project and then build it again.");
+        }
+        return kieContainer;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractKieContainerService.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractKieContainerService.java
@@ -35,8 +35,8 @@ public abstract class AbstractKieContainerService {
         KieModule kieModule = moduleService.resolveModule(path);
         KieContainer kieContainer = buildInfoService.getBuildInfo(kieModule).getKieContainer();
         if (kieContainer == null) {
-            throw new IllegalArgumentException("Impossible to retrieve KieContainer, please fix compilation errors of " +
-                                                       "the project and then build it again.");
+            throw new IllegalArgumentException("Retrieving KieContainer has failed. Fix all compilation errors within the " +
+                                                       "project and build the project again.");
         }
         return kieContainer;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
@@ -341,18 +341,25 @@ public class ScenarioSimulationServiceImpl
 
         String kieVersion = props.getProperty(KIE_VERSION);
 
-        getDependecies(kieVersion).forEach(gav -> {
-            editPomIfNecessary(module.getPomXMLPath(), projectPom, dependencies, gav);
-        });
+        boolean toSave = false;
+        Path modulePomXMLPath = module.getPomXMLPath();
+        for (GAV gav : getDependencies(kieVersion)) {
+            toSave |= editPomIfNecessary(dependencies, gav);
+        }
+
+        if (toSave) {
+            pomService.save(modulePomXMLPath, projectPom, null, "");
+        }
     }
 
-    void editPomIfNecessary(Path pomPath, POM projectPom, Dependencies dependencies, GAV gav) {
+    boolean editPomIfNecessary(Dependencies dependencies, GAV gav) {
         Dependency scenarioDependency = new Dependency(gav);
         scenarioDependency.setScope("test");
         if (!dependencies.containsDependency(gav)) {
             dependencies.add(scenarioDependency);
-            pomService.save(pomPath, projectPom, null, "");
+            return true;
         }
+        return false;
     }
 
     org.uberfire.java.nio.file.Path getActivatorPath(Package rootModulePackage) {
@@ -360,9 +367,12 @@ public class ScenarioSimulationServiceImpl
         return packagePath.resolve(ScenarioJunitActivator.ACTIVATOR_CLASS_NAME + ".java");
     }
 
-    List<GAV> getDependecies(String kieVersion) {
+    List<GAV> getDependencies(String kieVersion) {
         return Arrays.asList(new GAV("org.drools", "drools-wb-scenario-simulation-editor-api", kieVersion),
                              new GAV("org.drools", "drools-wb-scenario-simulation-editor-backend", kieVersion),
-                             new GAV("org.drools", "drools-compiler", kieVersion));
+                             new GAV("org.drools", "drools-compiler", kieVersion),
+                             new GAV("org.kie", "kie-dmn-feel", kieVersion),
+                             new GAV("org.kie", "kie-dmn-api", kieVersion),
+                             new GAV("org.kie", "kie-dmn-core", kieVersion));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/AbstractExpressionEvaluator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/AbstractExpressionEvaluator.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.drools.workbench.screens.scenariosimulation.utils.ScenarioSimulationSharedUtils;
+
+public abstract class AbstractExpressionEvaluator implements ExpressionEvaluator {
+
+    protected boolean internalEvaluate(Object rawExpression, Object resultValue, Class<?> resultClass) {
+        if (resultClass != null && ScenarioSimulationSharedUtils.isCollection(resultClass.getCanonicalName())) {
+            return verifyResult(rawExpression, resultValue, resultClass);
+        } else {
+            return internalUnaryEvaluation((String) rawExpression, resultValue, resultClass, false);
+        }
+    }
+
+    protected Object internalGetValueForGiven(String className, List<String> genericClasses, String raw) {
+        if (ScenarioSimulationSharedUtils.isCollection(className)) {
+            return convertResult(raw, className, genericClasses);
+        } else {
+            return internalLiteralEvaluate(raw, className);
+        }
+    }
+
+    protected Object convertResult(String rawString, String className, List<String> genericClasses) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode jsonNode = objectMapper.readTree(rawString);
+            if (jsonNode.isArray()) {
+                return createAndFillList((ArrayNode) jsonNode, new ArrayList<>(), className, genericClasses);
+            } else if (jsonNode.isObject()) {
+                return createAndFillObject((ObjectNode) jsonNode,
+                                           createObject(className, genericClasses),
+                                           className,
+                                           genericClasses);
+            }
+            throw new IllegalArgumentException("Malformed raw data");
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed raw data", e);
+        }
+    }
+
+    protected List<Object> createAndFillList(ArrayNode json, List<Object> toReturn, String className, List<String> genericClasses) {
+        for (JsonNode node : json) {
+            String genericClassName = ScenarioSimulationSharedUtils.isMap(className) ? className : genericClasses.get(genericClasses.size() - 1);
+            Object listElement = createObject(genericClassName, genericClasses);
+            Object returnedObject = createAndFillObject((ObjectNode) node, listElement, genericClassName, genericClasses);
+            toReturn.add(returnedObject);
+        }
+        return toReturn;
+    }
+
+    protected Object createAndFillObject(ObjectNode json, Object toReturn, String className, List<String> genericClasses) {
+        Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
+        int numberOfFields = json.size();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> element = fields.next();
+            String key = element.getKey();
+            JsonNode jsonNode = element.getValue();
+            // if is a simple value just return the parsed result
+            if (numberOfFields == 1 && "value".equals(key)) {
+                return internalLiteralEvaluate(jsonNode.textValue(), genericClasses.get(0));
+            }
+
+            if (jsonNode.isArray()) {
+                List<Object> nestedList = new ArrayList<>();
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                List<Object> returnedList = createAndFillList((ArrayNode) jsonNode, nestedList, fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                setField(toReturn, key, returnedList);
+            } else if (jsonNode.isObject()) {
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                Object nestedObject = createObject(fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                Object returnedObject = createAndFillObject((ObjectNode) jsonNode, nestedObject, fieldDescriptor.getKey(), fieldDescriptor.getValue());
+                setField(toReturn, key, returnedObject);
+            } else if (jsonNode.textValue() != null && !jsonNode.textValue().isEmpty()) {
+                Map.Entry<String, List<String>> fieldDescriptor = getFieldClassNameAndGenerics(toReturn, key, className, genericClasses);
+                setField(toReturn, key, internalLiteralEvaluate(jsonNode.textValue(), fieldDescriptor.getKey()));
+            } else {
+                // empty strings are skipped
+            }
+        }
+        return toReturn;
+    }
+
+    protected boolean verifyResult(Object rawValue, Object resultRaw, Class<?> resultClass) {
+        if (!(resultRaw instanceof List) && !(resultRaw instanceof Map)) {
+            throw new IllegalArgumentException("A list was expected");
+        }
+        if (!(rawValue instanceof String)) {
+            throw new IllegalArgumentException("Malformed raw data");
+        }
+        String raw = (String) rawValue;
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(raw);
+            if (jsonNode.isArray()) {
+                return verifyList((ArrayNode) jsonNode, (List) resultRaw, resultClass);
+            } else if (jsonNode.isObject()) {
+                return verifyObject((ObjectNode) jsonNode, resultRaw, resultClass);
+            }
+            throw new IllegalArgumentException("Malformed raw data");
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed raw data", e);
+        }
+    }
+
+    protected boolean verifyList(ArrayNode json, List resultRaw, Class<?> resultClass) {
+
+        for (JsonNode node : json) {
+            boolean success = false;
+            for (Object result : resultRaw) {
+                if (verifyObject((ObjectNode) node, result, resultClass)) {
+                    success = true;
+                }
+            }
+            if (!success) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean verifyObject(ObjectNode json, Object result, Class<?> resultClass) {
+        Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
+        int numberOfFields = json.size();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> element = fields.next();
+            String key = element.getKey();
+            JsonNode jsonNode = element.getValue();
+            // if is a simple value just return the parsed result
+            if (numberOfFields == 1 && "value".equals(key)) {
+                return internalUnaryEvaluation(jsonNode.textValue(), result, result.getClass(), true);
+            }
+
+            Object fieldValue = extractFieldValue(result, key);
+            if (jsonNode.isArray()) {
+                if (!verifyList((ArrayNode) jsonNode, (List) fieldValue, fieldValue.getClass())) {
+                    return false;
+                }
+            } else if (jsonNode.isObject()) {
+                if (!verifyObject((ObjectNode) jsonNode, fieldValue, fieldValue.getClass())) {
+                    return false;
+                }
+            } else {
+                if (!internalUnaryEvaluation(jsonNode.textValue(), fieldValue, fieldValue.getClass(), true)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    abstract protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString);
+
+    abstract protected Object internalLiteralEvaluate(String raw, String className);
+
+    abstract protected Object extractFieldValue(Object result, String fieldName);
+
+    abstract protected Object createObject(String className, List<String> genericClasses);
+
+    abstract protected void setField(Object toReturn, String fieldName, Object fieldValue);
+
+    abstract protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses);
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionEvaluator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionEvaluator.java
@@ -15,7 +15,19 @@
  */
 package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
 
-public class BaseExpressionEvaluator implements ExpressionEvaluator {
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.workbench.screens.scenariosimulation.utils.ScenarioSimulationSharedUtils;
+
+public class BaseExpressionEvaluator extends AbstractExpressionEvaluator {
 
     private final ClassLoader classLoader;
 
@@ -30,16 +42,91 @@ public class BaseExpressionEvaluator implements ExpressionEvaluator {
             return BaseExpressionOperator.EQUALS.eval(raw, resultValue, resultClass, classLoader);
         }
 
-        String rawValue = (String) raw;
-        return BaseExpressionOperator.findOperator(rawValue).eval(rawValue, resultValue, resultClass, classLoader);
+        return internalEvaluate(raw, resultValue, resultClass);
     }
 
     @Override
-    public Object getValueForGiven(String className, Object raw) {
+    public Object getValueForGiven(String className, List<String> genericClasses, Object raw) {
         if (!(raw instanceof String)) {
             return raw;
         }
-        String rawValue = (String) raw;
+
+        return internalGetValueForGiven(className, genericClasses, (String) raw);
+    }
+
+    @Override
+    protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+        if (rawExpression != null && skipEmptyString && rawExpression.isEmpty()) {
+            return true;
+        }
+        return BaseExpressionOperator.findOperator(rawExpression).eval(rawExpression, resultValue, resultClass, classLoader);
+    }
+
+    @Override
+    protected Object internalLiteralEvaluate(String rawValue, String className) {
         return BaseExpressionOperator.findOperator(rawValue).getValueForGiven(className, rawValue, classLoader);
+    }
+
+    @Override
+    protected Object extractFieldValue(Object result, String fieldName) {
+        try {
+            return result.getClass().getDeclaredField(fieldName).get(result);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Impossible to find field: " + fieldName, e);
+        }
+    }
+
+    @Override
+    protected Object createObject(String className, List<String> genericClasses) {
+        if (ScenarioSimulationSharedUtils.isMap(className)) {
+            return new HashMap();
+        } else {
+            try {
+                return classLoader.loadClass(className).newInstance();
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Impossible to instantiate " + className, e);
+            }
+        }
+    }
+
+    @Override
+    protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+        if (toReturn instanceof Map) {
+            Map returnMap = (Map) toReturn;
+            returnMap.put(fieldName, fieldValue);
+        } else {
+            try {
+                Field declaredField = toReturn.getClass().getDeclaredField(fieldName);
+                declaredField.setAccessible(true);
+                declaredField.set(toReturn, fieldValue);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Impossible to set the field " + fieldName, e);
+            }
+        }
+    }
+
+    @Override
+    protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+        try {
+            if (ScenarioSimulationSharedUtils.isMap(className)) {
+                return new AbstractMap.SimpleEntry<>(genericClasses.get(genericClasses.size() - 1), Collections.emptyList());
+            }
+            Field declaredField = element.getClass().getDeclaredField(fieldName);
+            Class<?> fieldType = declaredField.getType();
+            List<String> genericsString = new ArrayList<>();
+            if (declaredField.getGenericType() instanceof ParameterizedType) {
+                ParameterizedType generics = (ParameterizedType) declaredField.getGenericType();
+                for (Type typeArgument : generics.getActualTypeArguments()) {
+                    if (typeArgument instanceof ParameterizedType) {
+                        genericsString.add(((ParameterizedType) typeArgument).getRawType().getTypeName());
+                    } else {
+                        genericsString.add(typeArgument.getTypeName());
+                    }
+                }
+            }
+            return new AbstractMap.SimpleEntry<>(fieldType.getCanonicalName(), genericsString);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Impossible to get the field " + fieldName, e);
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionOperator.java
@@ -172,7 +172,7 @@ public enum BaseExpressionOperator {
     }
 
     protected Optional<String> match(String value) {
-        if(value == null) {
+        if (value == null) {
             return Optional.empty();
         }
         value = value.trim();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/DMNFeelExpressionEvaluator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/DMNFeelExpressionEvaluator.java
@@ -16,7 +16,11 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
 
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.kie.dmn.feel.FEEL;
 import org.kie.dmn.feel.lang.EvaluationContext;
@@ -24,7 +28,7 @@ import org.kie.dmn.feel.lang.impl.EvaluationContextImpl;
 import org.kie.dmn.feel.lang.impl.FEELEventListenersManager;
 import org.kie.dmn.feel.runtime.UnaryTest;
 
-public class DMNFeelExpressionEvaluator implements ExpressionEvaluator {
+public class DMNFeelExpressionEvaluator extends AbstractExpressionEvaluator {
 
     private final FEEL feel = FEEL.newInstance();
     private final ClassLoader classLoader;
@@ -38,24 +42,68 @@ public class DMNFeelExpressionEvaluator implements ExpressionEvaluator {
         if (rawExpression != null && !(rawExpression instanceof String)) {
             throw new IllegalArgumentException("Raw expression should be a string");
         }
+
+        return internalEvaluate(rawExpression, resultValue, resultClass);
+    }
+
+    @Override
+    public Object getValueForGiven(String className, List<String> genericClasses, Object raw) {
+        if (!(raw instanceof String)) {
+            return raw;
+        }
+
+        return internalGetValueForGiven(className, genericClasses, (String) raw);
+    }
+
+    private EvaluationContext newEvaluationContext() {
+        return new EvaluationContextImpl(classLoader, new FEELEventListenersManager());
+    }
+
+    @Override
+    protected Object internalLiteralEvaluate(String raw, String className) {
         EvaluationContext evaluationContext = newEvaluationContext();
-        List<UnaryTest> unaryTests = feel.evaluateUnaryTests((String) rawExpression);
-        if(unaryTests.size() < 1) {
+        return feel.evaluate(raw, evaluationContext);
+    }
+
+    @Override
+    protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+        if (rawExpression != null && skipEmptyString && rawExpression.isEmpty()) {
+            return true;
+        }
+        EvaluationContext evaluationContext = newEvaluationContext();
+        List<UnaryTest> unaryTests = feel.evaluateUnaryTests(rawExpression);
+        if (unaryTests.size() < 1) {
             throw new IllegalArgumentException("Impossible to parse the expression '" + rawExpression + "'");
         }
         return unaryTests.stream().allMatch(unaryTest -> unaryTest.apply(evaluationContext, resultValue));
     }
 
     @Override
-    public Object getValueForGiven(String className, Object raw) {
-        if (!(raw instanceof String)) {
-            return raw;
-        }
-        EvaluationContext evaluationContext = newEvaluationContext();
-        return feel.evaluate((String) raw, evaluationContext);
+    protected Object extractFieldValue(Object result, String fieldName) {
+        return ((Map<String, Object>) result).get(fieldName);
     }
 
-    private EvaluationContext newEvaluationContext() {
-        return new EvaluationContextImpl(classLoader, new FEELEventListenersManager());
+    @Override
+    protected Object createObject(String className, List<String> genericClasses) {
+        return new HashMap<String, Object>();
+    }
+
+    @Override
+    protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+        Map<String, Object> returnMap = (Map<String, Object>) toReturn;
+        returnMap.put(fieldName, fieldValue);
+    }
+
+    /**
+     * This is not used for DMN
+     * @param element
+     * @param fieldName
+     * @param className
+     * @param genericClasses
+     * @return
+     */
+    @Override
+    protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+        return new AbstractMap.SimpleEntry<>("", Collections.singletonList(""));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/ExpressionEvaluator.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/ExpressionEvaluator.java
@@ -16,9 +16,11 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
 
+import java.util.List;
+
 public interface ExpressionEvaluator {
 
     boolean evaluate(Object rawExpression, Object resultValue, Class<?> resultClass);
 
-    Object getValueForGiven(String className, Object raw);
+    Object getValueForGiven(String className, List<String> genericClasses, Object raw);
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
@@ -169,6 +169,7 @@ public abstract class AbstractRunnerHelper {
 
             try {
                 Object value = expressionEvaluator.getValueForGiven(factMapping.getClassName(),
+                                                                    factMapping.getGenericTypes(),
                                                                     factMappingValue.getRawValue());
                 paramsForBean.put(pathToField, value);
             } catch (IllegalArgumentException e) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
@@ -93,7 +93,7 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
 
                 FactMapping factMapping = factMappingExtractor.getFactMapping(factModelTree, factName, previousSteps, factType);
 
-                if(ScenarioSimulationSharedUtils.isList(factType)) {
+                if (ScenarioSimulationSharedUtils.isList(factType)) {
                     factMapping.setGenericTypes(factModelTree.getGenericTypeInfo(factName));
                 }
                 factMapping.addExpressionElement(factName, factType);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtils.java
@@ -16,23 +16,49 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.kie.api.runtime.KieContainer;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNRuntime;
 
 public class DMNSimulationUtils {
 
+    private static String delimiter = "/";
+
     private DMNSimulationUtils() {
     }
 
     public static DMNModel extractDMNModel(DMNRuntime dmnRuntime, String path) {
-        return dmnRuntime.getModels().stream()
-                .filter(model -> path.endsWith(model.getResource().getSourcePath()))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Cannot find a DMN model with resource=" + path));
+        List<String> pathSplit = Arrays.asList(new StringBuilder(path).reverse().toString().split(delimiter));
+        List<DMNModel> dmnModels = dmnRuntime.getModels();
+
+        return findDMNModel(dmnModels, pathSplit, 1);
     }
 
     public static DMNRuntime extractDMNRuntime(KieContainer kieContainer) {
         return kieContainer.newKieSession().getKieRuntime(DMNRuntime.class);
+    }
+
+    public static DMNModel findDMNModel(List<DMNModel> dmnModels, List<String> pathToFind, int step) {
+        List<DMNModel> result = new ArrayList<>();
+        String pathToCompare = String.join(delimiter, pathToFind.subList(0, step));
+        for (DMNModel dmnModel : dmnModels) {
+            String modelPath = new StringBuilder(dmnModel.getResource().getSourcePath()).reverse().toString();
+            if (modelPath.startsWith(pathToCompare)) {
+                result.add(dmnModel);
+            }
+        }
+        if (result.size() == 0) {
+            throw new IllegalArgumentException("Impossible to retrieve DMNModel. Please verify if your model has any " +
+                                                       "compilation errors or if there are multiple DMN files in the project " +
+                                                       "with the same namespace and name. After that, please build again the project");
+        } else if (result.size() == 1) {
+            return result.get(0);
+        } else {
+            return findDMNModel(dmnModels, pathToFind, step + 1);
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtils.java
@@ -52,9 +52,10 @@ public class DMNSimulationUtils {
             }
         }
         if (result.size() == 0) {
-            throw new IllegalArgumentException("Impossible to retrieve DMNModel. Please verify if your model has any " +
-                                                       "compilation errors or if there are multiple DMN files in the project " +
-                                                       "with the same namespace and name. After that, please build again the project");
+            throw new IllegalArgumentException("Retrieving the DMNModel has failed. Make sure the used DMN asset does not " +
+                                                       "produce any compilation errors and that the project does not " +
+                                                       "contain multiple DMN assets with the same name and namespace. " +
+                                                       "After addressing the issues, build the project again.");
         } else if (result.size() == 1) {
             return result.get(0);
         } else {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -78,7 +78,6 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertTrue(simpleStringFactModelTree.getSimpleProperties().containsKey("value"));
         assertEquals("string", simpleStringFactModelTree.getSimpleProperties().get("value"));
 
-
         // Single property collection retrieve
         DMNType simpleCollectionString = new SimpleTypeImpl(null, "string", null);
         ((SimpleTypeImpl) simpleCollectionString).setCollection(true);
@@ -89,7 +88,6 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertEquals(1, simpleCollectionStringFactModelTree.getSimpleProperties().size());
         assertTrue(simpleCollectionStringFactModelTree.getSimpleProperties().containsKey("value"));
         assertEquals("string", simpleCollectionStringFactModelTree.getSimpleProperties().get("value"));
-
 
         // Complex object retrieve
         DMNType person = new CompositeTypeImpl();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImplTest.java
@@ -157,7 +157,7 @@ public class ScenarioRunnerServiceImplTest {
         when(buildInfoMock.getKieContainer()).thenReturn(null);
         Assertions.assertThatThrownBy(() -> scenarioRunnerService.getKieContainer(mock(Path.class)))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Impossible to retrieve KieContainer, please fix compilation errors of " +
-                                    "the project and then build it again.");
+                .hasMessage("Retrieving KieContainer has failed. Fix all compilation errors within the " +
+                                    "project and build the project again.");
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioRunnerServiceImplTest.java
@@ -17,6 +17,7 @@ package org.drools.workbench.screens.scenariosimulation.backend.server;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.AbstractScenarioRunner;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.RuleScenarioRunner;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.ScenarioException;
@@ -148,5 +149,15 @@ public class ScenarioRunnerServiceImplTest {
         assertEquals(errorMessageFormatted, failure.getMessage());
         assertEquals(1, value.getRunCount());
         assertTrue(failure.getDisplayName().startsWith(testDescription));
+    }
+
+    @Test
+    public void kieContainerTest() {
+        when(buildInfoServiceMock.getBuildInfo(any())).thenReturn(buildInfoMock);
+        when(buildInfoMock.getKieContainer()).thenReturn(null);
+        Assertions.assertThatThrownBy(() -> scenarioRunnerService.getKieContainer(mock(Path.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Impossible to retrieve KieContainer, please fix compilation errors of " +
+                                    "the project and then build it again.");
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/AbstractExpressionEvaluatorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/AbstractExpressionEvaluatorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractExpressionEvaluatorTest {
+
+    JsonNodeFactory factory = JsonNodeFactory.instance;
+
+    @Test
+    public void convertList() {
+        // Test simple list
+        ArrayNode jsonNodes = new ArrayNode(factory);
+        ObjectNode objectNode = new ObjectNode(factory);
+        objectNode.put("value", "data");
+        jsonNodes.add(objectNode);
+
+        List<Object> objects = expressionEvaluatorMock.createAndFillList(jsonNodes,
+                                                                         new ArrayList<>(),
+                                                                         List.class.getCanonicalName(),
+                                                                         Collections.singletonList(String.class.getCanonicalName()));
+        assertEquals("data", objects.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void convertObject() {
+        // single level
+        ObjectNode objectNode = new ObjectNode(factory);
+        objectNode.put("age", "1");
+
+        Object result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                                    new HashMap<>(),
+                                                                    Map.class.getCanonicalName(),
+                                                                    Collections.singletonList(String.class.getCanonicalName()));
+
+        assertTrue(result instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+
+        assertEquals("1", resultMap.get("age"));
+
+        // nested object
+        objectNode.removeAll();
+        ObjectNode nestedObject = new ObjectNode(factory);
+        objectNode.set("nested", nestedObject);
+        nestedObject.put("field", "fieldValue");
+
+        result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                             new HashMap<>(),
+                                                             String.class.getCanonicalName(),
+                                                             Collections.emptyList());
+
+        assertTrue(result instanceof Map);
+        resultMap = (Map<String, Object>) result;
+
+        assertEquals(1, resultMap.size());
+        Map<String, Object> nested = (Map<String, Object>) resultMap.get("nested");
+        assertEquals(1, nested.size());
+        assertEquals("fieldValue", nested.get("field"));
+
+        // nested list
+        objectNode.removeAll();
+        ArrayNode jsonNodes = new ArrayNode(factory);
+        objectNode.set("listField", jsonNodes);
+        jsonNodes.add(nestedObject);
+
+        result = expressionEvaluatorMock.createAndFillObject(objectNode,
+                                                             new HashMap<>(),
+                                                             String.class.getCanonicalName(),
+                                                             Collections.emptyList());
+
+        assertTrue(result instanceof Map);
+        resultMap = (Map<String, Object>) result;
+
+        assertEquals(1, resultMap.size());
+        List<Map<String, Object>> nestedList = (List<Map<String, Object>>) resultMap.get("listField");
+        assertEquals(1, nestedList.size());
+        assertEquals("fieldValue", nestedList.get(0).get("field"));
+    }
+
+    AbstractExpressionEvaluator expressionEvaluatorMock = new AbstractExpressionEvaluator() {
+
+        @Override
+        public boolean evaluate(Object rawExpression, Object resultValue, Class<?> resultClass) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object getValueForGiven(String className, List<String> genericClasses, Object raw) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Object extractFieldValue(Object result, String fieldName) {
+            return result;
+        }
+
+        @Override
+        protected boolean internalUnaryEvaluation(String rawExpression, Object resultValue, Class<?> resultClass, boolean skipEmptyString) {
+            return true;
+        }
+
+        @Override
+        protected Object internalLiteralEvaluate(String raw, String className) {
+            return raw;
+        }
+
+        @Override
+        protected Object createObject(String className, List<String> genericClasses) {
+            return new HashMap<>();
+        }
+
+        @Override
+        protected void setField(Object toReturn, String fieldName, Object fieldValue) {
+            ((Map) toReturn).put(fieldName, fieldValue);
+        }
+
+        @Override
+        protected Map.Entry<String, List<String>> getFieldClassNameAndGenerics(Object element, String fieldName, String className, List<String> genericClasses) {
+            return new AbstractMap.SimpleEntry<>("", Collections.singletonList(""));
+        }
+    };
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionEvaluatorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/expression/BaseExpressionEvaluatorTest.java
@@ -16,28 +16,70 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.expression;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.workbench.screens.scenariosimulation.backend.server.model.ListMapClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class BaseExpressionEvaluatorTest {
 
-    private final static ClassLoader classLoader = ParameterizedBaseExpressionEvaluatorTest.class.getClassLoader();
+    private final static ClassLoader classLoader = BaseExpressionEvaluatorTest.class.getClassLoader();
 
     @Test
     public void getValueForGiven() {
         BaseExpressionEvaluator baseExpressionEvaluator = new BaseExpressionEvaluator(classLoader);
 
         Object raw = new Object();
-        assertEquals(raw, baseExpressionEvaluator.getValueForGiven(Object.class.getCanonicalName(), raw));
+        assertEquals(raw, baseExpressionEvaluator.getValueForGiven(Object.class.getCanonicalName(), Collections.emptyList(), raw));
 
         raw = "SimpleString";
-        assertEquals(raw, baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), raw));
+        assertEquals(raw, baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), Collections.emptyList(), raw));
 
         raw = "= SimpleString";
-        assertEquals("SimpleString", baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), raw));
+        assertEquals("SimpleString", baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), Collections.emptyList(), raw));
 
-        assertNull(baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), null));
+        assertNull(baseExpressionEvaluator.getValueForGiven(String.class.getCanonicalName(), Collections.emptyList(), null));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void expressionTest() {
+        BaseExpressionEvaluator expressionEvaluator = new BaseExpressionEvaluator(classLoader);
+
+        String listJsonString = "[{\"name\": \"John\"}, " +
+                "{\"name\": \"John\", \"names\" : [{\"value\": \"Anna\"}, {\"value\": \"Mario\"}]}]";
+
+        List<ListMapClass> parsedValue = (List<ListMapClass>) expressionEvaluator.convertResult(listJsonString, List.class.getCanonicalName(),
+                                                                                                Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(2, parsedValue.size());
+        assertEquals(2, parsedValue.get(1).getNames().size());
+        assertTrue(parsedValue.get(1).getNames().contains("Anna"));
+
+        String mapJsonString = "{\"first\": {\"name\": \"John\"}}";
+        Map<String, ListMapClass> parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                                            Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", parsedMap.get("first").getName());
+
+        mapJsonString = "{\"first\": {\"siblings\": [{\"name\" : \"John\"}]}}";
+        parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                  Collections.singletonList(ListMapClass.class.getCanonicalName()));
+        assertEquals(1, parsedMap.size());
+        assertEquals("John", parsedMap.get("first").getSiblings().get(0).getName());
+
+        mapJsonString = "{\"first\": {\"phones\": {\"number\" : \"1\"}}}";
+        parsedMap = (Map<String, ListMapClass>) expressionEvaluator.convertResult(mapJsonString, Map.class.getCanonicalName(),
+                                                                                  Collections.singletonList(ListMapClass.class.getCanonicalName()));
+
+        assertEquals(1, parsedMap.size());
+        assertEquals((Integer) 1, parsedMap.get("first").getPhones().get("number"));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/model/ListMapClass.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/model/ListMapClass.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.backend.server.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class ListMapClass {
+
+    private String name;
+    private List<String> names;
+    private List<ListMapClass> siblings;
+    private Map<String, Integer> phones;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public List<ListMapClass> getSiblings() {
+        return siblings;
+    }
+
+    public void setSiblings(List<ListMapClass> siblings) {
+        this.siblings = siblings;
+    }
+
+    public Map<String, Integer> getPhones() {
+        return phones;
+    }
+
+    public void setPhones(Map<String, Integer> phones) {
+        this.phones = phones;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.backend.server.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.io.Resource;
+import org.kie.dmn.api.core.DMNModel;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DMNSimulationUtilsTest {
+
+    @Test
+    public void findDMNModel() {
+        List<String> pathToFind = Arrays.asList(new StringBuilder("to/find").reverse().toString().split("/"));
+
+        List<DMNModel> models = Stream.of("this/should/not/match", "find", "something/to/find")
+                .map(this::createDMNModelMock).collect(Collectors.toList());
+
+        DMNSimulationUtils.findDMNModel(models, pathToFind, 1);
+
+        List<String> impossibleToFind = Arrays.asList(new StringBuilder("not/find").reverse().toString().split("/"));
+
+        Assertions.assertThatThrownBy(() -> DMNSimulationUtils.findDMNModel(models, impossibleToFind, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Impossible to retrieve DMNModel. Please verify if your model has any " +
+                                    "compilation errors or if there are multiple DMN files in the project " +
+                                    "with the same namespace and name. After that, please build again the project");
+    }
+
+    private DMNModel createDMNModelMock(String path) {
+        DMNModel modelMock = mock(DMNModel.class);
+        Resource resourceMock = mock(Resource.class);
+        when(resourceMock.getSourcePath()).thenReturn(path);
+        when(modelMock.getResource()).thenReturn(resourceMock);
+        return modelMock;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationUtilsTest.java
@@ -46,9 +46,10 @@ public class DMNSimulationUtilsTest {
 
         Assertions.assertThatThrownBy(() -> DMNSimulationUtils.findDMNModel(models, impossibleToFind, 1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Impossible to retrieve DMNModel. Please verify if your model has any " +
-                                    "compilation errors or if there are multiple DMN files in the project " +
-                                    "with the same namespace and name. After that, please build again the project");
+                .hasMessage("Retrieving the DMNModel has failed. Make sure the used DMN asset does not " +
+                                    "produce any compilation errors and that the project does not " +
+                                    "contain multiple DMN assets with the same name and namespace. " +
+                                    "After addressing the issues, build the project again.");
     }
 
     private DMNModel createDMNModelMock(String path) {


### PR DESCRIPTION
This PR add DMN-related dependencies to user project and improve error message in case of broken KieContainer.

https://issues.jboss.org/browse/DROOLS-3496
https://issues.jboss.org/browse/DROOLS-3473
https://issues.jboss.org/browse/DROOLS-3487

NOTE 1: remove ScenarioJunitActivatorTest in an existing project and create/save a scenario to force pom dependency refresh
NOTE 2: KieContainer is broken if the DMN file has a compilation error or if there are more than a single DMN file with same `namespace` and `name`. Use `Build` button in the asset list page to force KieContainer refresh when the error has been fixed
NOTE 3: to build user project from outside using `mvn package` command, you need first to install locally `drools-wb-scenario-simulation-editor`. If you have a compilation error related to `kie-maven-plugin` version please change it to a final version like `7.17.0.Final` because it seems like we have no SNAPSHOT version for that component on nexus 

@kkufova @gitgabrio @Rikkola 