### PR TITLE
[DROOLS-3609] Add warning message if unsupported DMN + UI improvements 

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTuple.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTuple.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.model.typedescriptor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SortedMap;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -27,6 +29,9 @@ public class FactModelTuple {
 
     private SortedMap<String, FactModelTree> visibleFacts;
     private SortedMap<String, FactModelTree> hiddenFacts;
+    private List<String> topLevelCollectionError = new ArrayList<>();
+    private List<String> multipleNestedCollectionError = new ArrayList<>();
+    private List<String> multipleNestedObjectError = new ArrayList<>();
 
     public FactModelTuple() {
         // CDI
@@ -43,5 +48,29 @@ public class FactModelTuple {
 
     public SortedMap<String, FactModelTree> getHiddenFacts() {
         return hiddenFacts;
+    }
+
+    public void addTopLevelCollectionError(String error) {
+        this.topLevelCollectionError.add(error);
+    }
+
+    public void addMultipleNestedCollectionError(String error) {
+        this.multipleNestedCollectionError.add(error);
+    }
+
+    public void addMultipleNestedObjectError(String error) {
+        this.multipleNestedObjectError.add(error);
+    }
+
+    public List<String> getTopLevelCollectionError() {
+        return topLevelCollectionError;
+    }
+
+    public List<String> getMultipleNestedCollectionError() {
+        return multipleNestedCollectionError;
+    }
+
+    public List<String> getMultipleNestedObjectError() {
+        return multipleNestedObjectError;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,15 +50,30 @@ public class DMNTypeServiceImpl
         DMNModel dmnModel = getDMNModel(path, dmnPath);
         SortedMap<String, FactModelTree> visibleFacts = new TreeMap<>();
         SortedMap<String, FactModelTree> hiddenFacts = new TreeMap<>();
+
+        ErrorHolder errorHolder = new ErrorHolder();
+
         for (InputDataNode input : dmnModel.getInputs()) {
             DMNType type = input.getType();
+
+            checkTypeSupport(type, errorHolder, input.getName());
+
             visibleFacts.put(input.getName(), createFactModelTree(input.getName(), input.getName(), type, hiddenFacts, FactModelTree.Type.INPUT));
         }
         for (DecisionNode decision : dmnModel.getDecisions()) {
             DMNType type = decision.getResultType();
+
+            checkTypeSupport(type, errorHolder, decision.getName());
+
             visibleFacts.put(decision.getName(), createFactModelTree(decision.getName(), decision.getName(), type, hiddenFacts, FactModelTree.Type.DECISION));
         }
-        return new FactModelTuple(visibleFacts, hiddenFacts);
+        FactModelTuple factModelTuple = new FactModelTuple(visibleFacts, hiddenFacts);
+
+        errorHolder.getTopLevelCollection().forEach(factModelTuple::addTopLevelCollectionError);
+        errorHolder.getMultipleNestedCollection().forEach(factModelTuple::addMultipleNestedCollectionError);
+        errorHolder.getMultipleNestedObject().forEach(factModelTuple::addMultipleNestedObjectError);
+
+        return factModelTuple;
     }
 
     public DMNModel getDMNModel(Path path, String dmnPath) {
@@ -138,5 +154,54 @@ public class DMNTypeServiceImpl
         simpleFields.put(name, List.class.getCanonicalName());
 
         return genericKey;
+    }
+
+    protected void checkTypeSupport(DMNType type, ErrorHolder errorHolder, String path) {
+        if (type.isCollection()) {
+            errorHolder.getTopLevelCollection().add(path);
+        }
+        visitType(type, false, errorHolder, path);
+    }
+
+    protected void visitType(DMNType type,
+                             boolean alreadyInCollection,
+                             ErrorHolder errorHolder,
+                             String path) {
+        if (type.isComposite()) {
+            for (Map.Entry<String, DMNType> entry : type.getFields().entrySet()) {
+                String name = entry.getKey();
+                DMNType nestedType = entry.getValue();
+                String nestedPath = path + "." + name;
+                if (alreadyInCollection && nestedType.isCollection()) {
+                    errorHolder.getMultipleNestedCollection().add(nestedPath);
+                }
+                if (alreadyInCollection && nestedType.isComposite()) {
+                    errorHolder.getMultipleNestedObject().add(nestedPath);
+                }
+                visitType(nestedType,
+                          alreadyInCollection || nestedType.isCollection(),
+                          errorHolder,
+                          nestedPath);
+            }
+        }
+    }
+
+    static class ErrorHolder {
+
+        List<String> topLevelCollection = new ArrayList<>();
+        List<String> multipleNestedObject = new ArrayList<>();
+        List<String> multipleNestedCollection = new ArrayList<>();
+
+        public List<String> getTopLevelCollection() {
+            return topLevelCollection;
+        }
+
+        public List<String> getMultipleNestedObject() {
+            return multipleNestedObject;
+        }
+
+        public List<String> getMultipleNestedCollection() {
+            return multipleNestedCollection;
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -163,7 +163,7 @@ public class DMNTypeServiceImpl
         visitType(type, false, errorHolder, path);
     }
 
-    protected void visitType(DMNType type,
+    private void visitType(DMNType type,
                              boolean alreadyInCollection,
                              ErrorHolder errorHolder,
                              String path) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenter.java
@@ -121,7 +121,7 @@ public class CollectionPresenter implements CollectionView.Presenter {
         final UListElement elementsContainer = collectionView.getElementsContainer();
         String itemId = String.valueOf(elementsContainer.getChildCount() - 1);
         final LIElement itemElement = listElementPresenter.getItemContainer(itemId, propertiesValues);
-        elementsContainer.insertBefore(itemElement, objectSeparatorLI);
+        elementsContainer.appendChild(itemElement);
     }
 
     @Override
@@ -129,7 +129,7 @@ public class CollectionPresenter implements CollectionView.Presenter {
         final UListElement elementsContainer = collectionView.getElementsContainer();
         String itemId = String.valueOf(elementsContainer.getChildCount() - 1);
         final LIElement itemElement = mapElementPresenter.getKeyValueContainer(itemId, keyPropertiesValues, valuePropertiesValues);
-        elementsContainer.insertBefore(itemElement, objectSeparatorLI);
+        elementsContainer.appendChild(itemElement);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenter.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.LIElement;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.UListElement;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
@@ -164,6 +165,8 @@ public class CollectionPresenter implements CollectionView.Presenter {
         this.collectionView.getEditorTitle().setInnerText(key);
         this.collectionView.getPropertyTitle().setInnerText(propertyName);
         objectSeparatorLI = collectionView.getObjectSeparator();
+        objectSeparatorLI.addClassName("kie-object-list");
+        objectSeparatorLI.getStyle().setPadding(5, Style.Unit.PX);
     }
 
     protected void populateList(JSONValue jsonValue) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
@@ -1,5 +1,5 @@
-<div class="kie-dataTypesList-modal modal-wide" tabindex="-1" style="width:100%"  role="dialog" id="collectionEditor">
-    <div class="modal-dialog" style="width:100%"  role="document" data-field="collectionEditorModalDialog">
+<div class="kie-dataTypesList-modal modal-wide" tabindex="-1" style="width:100%" role="dialog" id="collectionEditor">
+    <div class="modal-dialog" style="width:100%" role="document" data-field="collectionEditorModalDialog">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close" data-field="closeCollectionEditorButton">
@@ -15,14 +15,9 @@
                             <!-- first right side panel -->
                             <div class="tab-pane active" id="kie-ObjectListItem1" aria-labelledby="#kie-ObjectListTab1">
                                 <ul class="list-group list-group kie-object-lis" data-field="elementsContainer">
-                                    <li class="list-group-item">
+                                    <li class="list-group-item" style="list-style-type: none;">
                                         <span class="fa fa-angle-down kie-object-list__expander" data-field="faAngleRight"></span>
                                         <span class="kie-object-list__field-value" data-field="propertyTitle">visitedcities</span>
-                                    </li>
-                                    <li class="list-group-item kie-object-list__separator" data-field="objectSeparator">
-                                        <button class="btn btn-link" data-field="addItemButton">
-                                            <span class="fa fa-plus"></span> Add new item
-                                        </button>
                                     </li>
                                 </ul>
                             </div>
@@ -30,7 +25,13 @@
                     </div>
                 </div>
             </div>
+            <div class="kie-object-list__separator" data-field="objectSeparator">
+                <button class="btn btn-link" data-field="addItemButton">
+                    <span class="fa fa-plus"></span> Add new item
+                </button>
+            </div>
             <div class="modal-footer">
+
                 <button type="button" class="btn btn-default" data-dismiss="modal" data-field="cancelButton">Cancel</button>
                 <button type="button" class="btn btn-danger" data-dismiss="modal" data-field="removeButton">Remove</button>
                 <button type="button" class="btn btn-primary" data-dismiss="modal" data-field="saveButton">Save</button>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
@@ -80,7 +80,7 @@ public interface ElementView<T extends ElementView.Presenter> extends HasPresent
 
     void onCancelChangeButton(ClickEvent clickEvent);
 
-    void toggleRowExpansion(boolean clickEvent);
+    void toggleRowExpansion(boolean toExpand);
 
     /**
      * Set the <b>id</b> of the item shown by the current <code><ListEditorElementView/code>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
@@ -46,6 +46,9 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
 
     @Override
     public void onEditItem(ItemElementView itemElementView) {
+        if (!itemElementView.isShown()) {
+            onToggleRowExpansion(itemElementView, false);
+        }
         propertyPresenter.editProperties(itemElementView.getItemId());
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.INLINE);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementViewImpl.html
@@ -1,6 +1,6 @@
-<li data-field="itemContainer">
+<li data-field="itemContainer" style="list-style-type: none;">
     <ul data-field="innerItemContainer">
-        <li class="list-group-item node-treeview-object1 kie-drools-object-separator" data-field="itemSeparator">
+        <li class="list-group-item node-treeview-object1 kie-drools-object-separator" data-field="itemSeparator" style="list-style-type: none;">
             <!--<span class="indent"></span>-->
             <span class="icon expand-icon fa fa-angle-down" data-field="faAngleRight"></span>Item
             <div class="pull-right">
@@ -12,7 +12,7 @@
                 </button>
             </div>
         </li>
-        <li class="list-group-item" data-field="saveChange" style="display: none">
+        <li class="list-group-item" data-field="saveChange" style="display: none; list-style-type: none;">
             <button class="btn btn-link" data-field="saveChangeButton">
                 <span class="fa fa-check"></span> Save changes
             </button>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenter.java
@@ -54,6 +54,9 @@ public class KeyValueElementPresenter extends ElementPresenter<KeyValueElementVi
 
     @Override
     public void onEditItem(KeyValueElementView keyValueElementView) {
+        if (!keyValueElementView.isShown()) {
+            onToggleRowExpansion(keyValueElementView, false);
+        }
         List<String> keyValueIds = getKeyValueIds( keyValueElementView.getItemId());
         keyValueIds.forEach(id -> propertyPresenter.editProperties(id));
         keyValueElementView.getSaveChange().getStyle().setDisplay(Style.Display.INLINE);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementViewImpl.html
@@ -1,6 +1,6 @@
-<li data-field="itemContainer">
+<li data-field="itemContainer" style="list-style-type: none;">
     <ul class="list-group" data-field="innerItemContainer">
-        <li class="list-group-item kie-object-list__separator" data-field="itemSeparator">
+        <li class="list-group-item kie-object-list__separator" data-field="itemSeparator" style="list-style-type: none;">
             <span class="fa fa-angle-down kie-object-list__expander" data-field="faAngleRight"></span> Item
             <div class="pull-right">
                 <button class="btn btn-link" aria-label="Edit item" data-field="editItemButton">
@@ -11,19 +11,19 @@
                 </button>
             </div>
         </li>
-        <li class="list-group-item" data-field="keyValueContainer">
+        <li class="list-group-item" data-field="keyValueContainer" style="list-style-type: none;">
             <ul class="list-group kie-object-list kie-object-list--mapping" data-field="keyContainer">
-                <li class="list-group-item" data-field="keyLabel">
+                <li class="list-group-item" data-field="keyLabel" style="list-style-type: none;">
                     <span data-i18n-key="KEY">KEY</span>
                 </li>
             </ul>
             <ul class="list-group kie-object-list kie-object-list--mapping" data-field="valueContainer">
-                <li class="list-group-item node-treeview-object-edit node-hidden" data-field="valueLabel">
+                <li class="list-group-item node-treeview-object-edit node-hidden" data-field="valueLabel" style="list-style-type: none;">
                     <span>VALUE</span>
                 </li>
             </ul>
         </li>
-        <li class="list-group-item" data-field="saveChange" style="display: none">
+        <li class="list-group-item" data-field="saveChange" style="display: none; list-style-type: none;">
             <button class="btn btn-link" data-field="saveChangeButton">
                 <span class="fa fa-check"></span> Save changes
             </button>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyViewImpl.html
@@ -1,4 +1,4 @@
-<li class="list-group-item" data-field="propertyFields">
+<li class="list-group-item" data-field="propertyFields" style="list-style-type: none;">
     <span class="kie-object-list__field-value" data-field="propertyValueSpan">Rome</span>
     <input type="text" placeholder="" data-field="propertyValueInput">
     <span class="kie-object-list__field-label" data-field="propertyName" style="color: gray">#city</span>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxImpl.html
@@ -1,4 +1,4 @@
-<li data-field="editingBox" >
+<li data-field="editingBox" style="list-style-type: none;">
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title" data-field="editingBoxTitle">Edit visitedcities</h3>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxImpl.html
@@ -1,11 +1,11 @@
-<li data-field="editingBox" style="list-style-type: none;">
+<li data-field="editingBox" style="list-style-type: none; margin-top: 5px;">
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title" data-field="editingBoxTitle">Edit visitedcities</h3>
         </div>
         <div class="panel-body">
             <div class="kie-object-list treeview" id="treeview-object-edit">
-                <ul class="list-group" data-field="propertiesContainer"></ul>
+                <ul class="list-group" data-field="propertiesContainer" style="margin-top: 20px;"></ul>
             </div>
 
         </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxImpl.html
@@ -1,4 +1,4 @@
-<li data-field="editingBox">
+<li data-field="editingBox" style="list-style-type: none;">
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title" data-field="editingBoxTitle">Edit visitedcities</h3>
@@ -6,15 +6,15 @@
         <div class="panel-body">
             <div class="kie-object-list treeview" id="treeview-object-edit">
                 <ul class="list-group" data-field="propertiesContainer">
-                    <li data-field="keyValueContainer">
+                    <li data-field="keyValueContainer" style="list-style-type: none;">
                         <div style="display: inline-table;">
                             <ul data-field="keyContainer" style="display: inline-block; vertical-align: top;">
-                                <li class="list-group-item node-treeview-object-edit">
+                                <li class="list-group-item node-treeview-object-edit" style="list-style-type: none;">
                                     <span>KEY</span>
                                 </li>
                             </ul>
                             <ul data-field="valueContainer" style="display: inline-block; vertical-align: top;">
-                                <li class="list-group-item node-treeview-object-edit">
+                                <li class="list-group-item node-treeview-object-edit" style="list-style-type: none;">
                                     <span>VALUE</span>
                                 </li>
                             </ul>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxImpl.html
@@ -1,11 +1,11 @@
-<li data-field="editingBox" style="list-style-type: none;">
+<li data-field="editingBox" style="list-style-type: none; margin-top: 5px;">
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title" data-field="editingBoxTitle">Edit visitedcities</h3>
         </div>
         <div class="panel-body">
             <div class="kie-object-list treeview" id="treeview-object-edit">
-                <ul class="list-group" data-field="propertiesContainer">
+                <ul class="list-group" data-field="propertiesContainer" style="margin-top: 20px;">
                     <li data-field="keyValueContainer" style="list-style-type: none;">
                         <div style="display: inline-table;">
                             <ul data-field="keyContainer" style="display: inline-block; vertical-align: top;">

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -374,7 +374,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
 
     @Override
     public void onEvent(UnsupportedDMNEvent event) {
-        confirmPopupPresenter.show("Unsupported DMN", event.getMessage());
+        confirmPopupPresenter.show("Unsupported DMN asset", event.getMessage());
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -64,6 +64,7 @@ import org.drools.workbench.screens.scenariosimulation.client.events.SetCellValu
 import org.drools.workbench.screens.scenariosimulation.client.events.SetInstanceHeaderEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.SetPropertyHeaderEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.UndoEvent;
+import org.drools.workbench.screens.scenariosimulation.client.events.UnsupportedDMNEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.AppendColumnEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.AppendRowEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.DeleteColumnEventHandler;
@@ -83,6 +84,8 @@ import org.drools.workbench.screens.scenariosimulation.client.handlers.SetCellVa
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetInstanceHeaderEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetPropertyHeaderEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.UndoEventHandler;
+import org.drools.workbench.screens.scenariosimulation.client.handlers.UnsupportedDMNEventHandler;
+import org.drools.workbench.screens.scenariosimulation.client.popup.ConfirmPopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.DeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.PreserveDeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
@@ -115,10 +118,12 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
                                                        SetCellValueEventHandler,
                                                        SetInstanceHeaderEventHandler,
                                                        SetPropertyHeaderEventHandler,
-                                                       UndoEventHandler {
+                                                       UndoEventHandler,
+                                                       UnsupportedDMNEventHandler {
 
     protected DeletePopupPresenter deletePopupPresenter;
     protected PreserveDeletePopupPresenter preserveDeletePopupPresenter;
+    protected ConfirmPopupPresenter confirmPopupPresenter;
 
     protected EventBus eventBus;
 
@@ -147,6 +152,10 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
 
     public void setPreserveDeletePopupPresenter(PreserveDeletePopupPresenter preserveDeletePopupPresenter) {
         this.preserveDeletePopupPresenter = preserveDeletePopupPresenter;
+    }
+
+    public void setConfirmPopupPresenter(ConfirmPopupPresenter confirmPopupPresenter) {
+        this.confirmPopupPresenter = confirmPopupPresenter;
     }
 
     public void setNotificationEvent(Event<NotificationEvent> notificationEvent) {
@@ -359,6 +368,11 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
         }
     }
 
+    @Override
+    public void onEvent(UnsupportedDMNEvent event) {
+        confirmPopupPresenter.show("Unsupported DMN", event.getMessage());
+    }
+
     /**
      * Common method to execute the given <code>Command</code> inside the given <code>ScenarioSimulationContext</code>
      * If successful, it adds the command to the <code>ScenarioCommandRegistry</code>, otherwise it fire a new <code>ScenarioNotificationEvent</code>
@@ -412,5 +426,6 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
         handlerRegistrationList.add(eventBus.addHandler(SetInstanceHeaderEvent.TYPE, this));
         handlerRegistrationList.add(eventBus.addHandler(SetPropertyHeaderEvent.TYPE, this));
         handlerRegistrationList.add(eventBus.addHandler(UndoEvent.TYPE, this));
+        handlerRegistrationList.add(eventBus.addHandler(UnsupportedDMNEvent.TYPE, this));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -415,7 +415,7 @@ public class ScenarioSimulationEditorPresenter
             dataManagementStrategy = new DMODataManagementStrategy(oracleFactory, context);
         }
         else {
-            dataManagementStrategy = new DMNDataManagementStrategy(dmnTypeService, context);
+            dataManagementStrategy = new DMNDataManagementStrategy(dmnTypeService, context, eventBus);
         }
         dataManagementStrategy.manageScenarioSimulationModelContent(versionRecordManager.getCurrentPath(), content);
         populateRightPanel();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategy.java
@@ -111,19 +111,19 @@ public class DMNDataManagementStrategy extends AbstractDataManagementStrategy {
         boolean showError = false;
         if (factModelTuple.getTopLevelCollectionError().size() > 0) {
             showError = true;
-            builder.append("Top level collections are not supported:<br/>");
+            builder.append("Top-level collections are not supported! Violated by:<br/>");
             factModelTuple.getTopLevelCollectionError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
             builder.append("<br/>");
         }
         if (factModelTuple.getMultipleNestedCollectionError().size() > 0) {
             showError = true;
-            builder.append("Multiple collections nested are not supported:<br/>");
+            builder.append("Nested collections are not supported! Violated by:<br/>");
             factModelTuple.getMultipleNestedCollectionError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
             builder.append("<br/>");
         }
         if (factModelTuple.getMultipleNestedObjectError().size() > 0) {
             showError = true;
-            builder.append("Multiple nested objects inside a collection are not supported:<br/>");
+            builder.append("Complex nested objects inside a collection are not supported! Violated by:<br/>");
             factModelTuple.getMultipleNestedObjectError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
         }
         if (showError) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategy.java
@@ -100,24 +100,30 @@ public class DMNDataManagementStrategy extends AbstractDataManagementStrategy {
 
     private void showErrorsAndCleanupState(FactModelTuple factModelTuple) {
         StringBuilder builder = new StringBuilder();
+        boolean showError = false;
         if (factModelTuple.getTopLevelCollectionError().size() > 0) {
+            showError = true;
             builder.append("Top level collections are not supported:<br/>");
             factModelTuple.getTopLevelCollectionError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
             builder.append("<br/>");
         }
         if (factModelTuple.getMultipleNestedCollectionError().size() > 0) {
+            showError = true;
             builder.append("Multiple collections nested are not supported:<br/>");
             factModelTuple.getMultipleNestedCollectionError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
             builder.append("<br/>");
         }
         if (factModelTuple.getMultipleNestedObjectError().size() > 0) {
+            showError = true;
             builder.append("Multiple nested objects inside a collection are not supported:<br/>");
             factModelTuple.getMultipleNestedObjectError().forEach(error -> builder.append("<b>"+ error + "</b><br/>"));
         }
-        factModelTuple.getTopLevelCollectionError().clear();
-        factModelTuple.getMultipleNestedCollectionError().clear();
-        factModelTuple.getMultipleNestedObjectError().clear();
-        eventBus.fireEvent(new UnsupportedDMNEvent(builder.toString()));
+        if (showError) {
+            factModelTuple.getTopLevelCollectionError().clear();
+            factModelTuple.getMultipleNestedCollectionError().clear();
+            factModelTuple.getMultipleNestedObjectError().clear();
+            eventBus.fireEvent(new UnsupportedDMNEvent(builder.toString()));
+        }
     }
 
     private ErrorCallback<Object> getErrorCallback(RightPanelView.Presenter rightPanelPresenter) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/UnsupportedDMNEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/UnsupportedDMNEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.events;
+
+import com.google.gwt.event.shared.GwtEvent;
+import org.drools.workbench.screens.scenariosimulation.client.handlers.UnsupportedDMNEventHandler;
+
+/**
+ * <code>GwtEvent</code> to show a notification
+ */
+public class UnsupportedDMNEvent extends GwtEvent<UnsupportedDMNEventHandler> {
+
+    public static Type<UnsupportedDMNEventHandler> TYPE = new Type<>();
+    private final String message;
+
+    public UnsupportedDMNEvent(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public Type<UnsupportedDMNEventHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    protected void dispatch(UnsupportedDMNEventHandler handler) {
+        handler.onEvent(this);
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/UnsupportedDMNEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/UnsupportedDMNEventHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.handlers;
+
+import com.google.gwt.event.shared.EventHandler;
+import org.drools.workbench.screens.scenariosimulation.client.events.UnsupportedDMNEvent;
+
+/**
+ * <code>EventHandler</code> for {@link UnsupportedDMNEvent}
+ */
+public interface UnsupportedDMNEventHandler extends EventHandler {
+    void onEvent(UnsupportedDMNEvent event);
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopup.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopup.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.popup;
+
+import org.jboss.errai.common.client.dom.HTMLElement;
+
+public interface ConfirmPopup {
+
+    interface Presenter {
+
+        /**
+         * Makes the <code>ConfirmPopup</code> visible with OK buttons.
+         * @param mainTitleText
+         * @param mainText
+         */
+        void show(final String mainTitleText,
+                  final String mainText);
+
+        /**
+         * Makes this popup container(and the main content along with it) invisible. Has no effect if the popup is not
+         * already showing.
+         */
+        void hide();
+    }
+
+    /**
+     * Makes the <code>ConfirmPopup</code> visible with OK.
+     * @param mainTitleText
+     * @param mainText
+     */
+    void show(final String mainTitleText,
+              final String mainText);
+
+    HTMLElement getElement();
+
+    /**
+     * Makes this popup container(and the main content along with it) invisible. Has no effect if the popup is not
+     * already showing.
+     */
+    void hide();
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenter.java
@@ -19,27 +19,19 @@ package org.drools.workbench.screens.scenariosimulation.client.popup;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.uberfire.mvp.Command;
-
 @Dependent
-public class DeletePopupPresenter implements DeletePopup.Presenter {
+public class ConfirmPopupPresenter implements ConfirmPopup.Presenter {
 
     @Inject
-    protected DeletePopupView deletePopupView;
+    protected ConfirmPopup confirmPopupView;
 
     @Override
-    public void show(final String mainTitleText,
-                     final String mainQuestionText,
-                     final String text1Text,
-                     final String textQuestionText,
-                     final String textDangerText,
-                     final String okDeleteButtonText,
-                     final Command okDeleteCommand) {
-        deletePopupView.show(mainTitleText, mainQuestionText, text1Text, textQuestionText, textDangerText, okDeleteButtonText, okDeleteCommand);
+    public void show(String mainTitleText, String mainText) {
+        confirmPopupView.show(mainTitleText, mainText);
     }
 
     @Override
     public void hide() {
-        deletePopupView.hide();
+        confirmPopupView.hide();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.html
@@ -1,0 +1,31 @@
+<div class="modal fade" id="confirmation-delete">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                    <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" data-field="main-title"></h4>
+            </div>
+            <div class="modal-body">
+                <div class="pull-left">
+                    <h2>
+                        <span class="pficon pficon-warning-triangle-o"></span>
+                    </h2>
+                </div>
+                <div style="margin-left: 3em;">
+                    <h2 data-field="main-question"></h2>
+                    <div>
+                        <p data-field="text-1"><p/>
+                        <p data-field="text-question"></p>
+                        <p class="text-danger" data-field="text-danger"></p>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal" data-field="cancel-button"></button>
+                    <button type="button" class="btn btn-danger" data-dismiss="modal" data-field="ok-delete-button"></button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.java
@@ -13,33 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
 import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
 
-import org.uberfire.mvp.Command;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
 
 @Dependent
-public class DeletePopupPresenter implements DeletePopup.Presenter {
-
-    @Inject
-    protected DeletePopupView deletePopupView;
+@Templated
+public class ConfirmPopupView extends ScenarioConfirmationPopupView implements ConfirmPopup {
 
     @Override
-    public void show(final String mainTitleText,
-                     final String mainQuestionText,
-                     final String text1Text,
-                     final String textQuestionText,
-                     final String textDangerText,
-                     final String okDeleteButtonText,
-                     final Command okDeleteCommand) {
-        deletePopupView.show(mainTitleText, mainQuestionText, text1Text, textQuestionText, textDangerText, okDeleteButtonText, okDeleteCommand);
+    public void show(String mainTitleText, String mainText) {
+        super.show(mainTitleText, null, mainText, null,
+                   null,
+                   null);
+        cancelButton.setText("OK");
     }
 
-    @Override
-    public void hide() {
-        deletePopupView.hide();
-    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.java
@@ -19,6 +19,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.dom.client.ParagraphElement;
 import org.jboss.errai.common.client.dom.HTMLElement;
@@ -78,11 +79,11 @@ public abstract class ScenarioConfirmationPopupView implements ScenarioConfirmat
                      final String okDeleteButtonText,
                      final Command okDeleteCommand) {
         this.okDeleteCommand = okDeleteCommand;
-        mainTitle.setInnerHTML(mainTitleText);
-        mainQuestion.setInnerHTML(mainQuestionText);
-        text1.setInnerText(text1Text);
-        textQuestion.setInnerText(textQuestionText);
-        okDeleteButton.setText(okDeleteButtonText);
+        conditionalShow(mainTitle, mainTitleText);
+        conditionalShow(mainQuestion, mainQuestionText);
+        conditionalShow(text1, text1Text);
+        conditionalShow(textQuestion, textQuestionText);
+        conditionalShow(okDeleteButton, okDeleteCommand, okDeleteButtonText);
         modal.show();
     }
 
@@ -107,5 +108,21 @@ public abstract class ScenarioConfirmationPopupView implements ScenarioConfirmat
     @EventHandler("cancel-button")
     public void onCancelClick(final @ForEvent("click") MouseEvent event) {
         hide();
+    }
+
+    protected void conditionalShow(Element element, String innerText) {
+        if (innerText != null) {
+            element.setInnerHTML(innerText);
+        } else {
+            element.removeFromParent();
+        }
+    }
+
+    protected void conditionalShow(Button button, Command command, String innerText) {
+        if (command == null) {
+            button.hide();
+        } else {
+            button.setText(innerText);
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioSimulationProducer.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioSimulationProducer.java
@@ -27,6 +27,7 @@ import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioS
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.editor.ScenarioSimulationView;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.ScenarioSimulationKeyboardEditHandler;
+import org.drools.workbench.screens.scenariosimulation.client.popup.ConfirmPopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.DeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.PreserveDeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
@@ -55,6 +56,8 @@ public class ScenarioSimulationProducer {
     protected DeletePopupPresenter deletePopupPresenter;
     @Inject
     protected PreserveDeletePopupPresenter preserveDeletePopupPresenter;
+    @Inject
+    protected ConfirmPopupPresenter confirmPopupPresenter;
 
     @Inject
     protected ScenarioSimulationEventHandler scenarioSimulationEventHandler;
@@ -87,6 +90,7 @@ public class ScenarioSimulationProducer {
         scenarioSimulationEventHandler.setEventBus(getEventBus());
         scenarioSimulationEventHandler.setDeletePopupPresenter(deletePopupPresenter);
         scenarioSimulationEventHandler.setPreserveDeletePopupPresenter(preserveDeletePopupPresenter);
+        scenarioSimulationEventHandler.setConfirmPopupPresenter(confirmPopupPresenter);
         scenarioSimulationEventHandler.setNotificationEvent(notificationEvent);
         scenarioSimulationEventHandler.setContext(getScenarioSimulationContext());
         scenarioSimulationEventHandler.setScenarioCommandManager(scenarioCommandManager);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.dom.client.LIElement;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.UListElement;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONObject;
@@ -97,6 +98,9 @@ public class CollectionPresenterTest extends AbstractCollectionEditorTest {
     private LIElement itemElementMock;
 
     @Mock
+    private Style styleMock;
+
+    @Mock
     private JSONValue jsonValueMock;
 
     @Mock
@@ -145,6 +149,7 @@ public class CollectionPresenterTest extends AbstractCollectionEditorTest {
         when(collectionViewMock.getEditorTitle()).thenReturn(editorTitleMock);
         when(collectionViewMock.getPropertyTitle()).thenReturn(propertyTitleMock);
         when(collectionViewMock.getObjectSeparator()).thenReturn(objectSeparatorLIMock);
+        when(objectSeparatorLIMock.getStyle()).thenReturn(styleMock);
 
         when(nestedValue1Mock.keySet()).thenReturn(KEY_SET);
         when(nestedValue1Mock.get(eq("prop1"))).thenReturn(jsonValueNeph1Mock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
@@ -270,7 +270,7 @@ public class CollectionPresenterTest extends AbstractCollectionEditorTest {
         verify(collectionViewMock, times(1)).getElementsContainer();
         verify(elementsContainerMock, times(1)).getChildCount();
         verify(listElementPresenterMock, times(1)).getItemContainer(eq(ITEM_ID), eq(propertyMapLocal));
-        verify(elementsContainerMock, times(1)).insertBefore(eq(itemElementMock), eq(objectSeparatorLIMock));
+        verify(elementsContainerMock, times(1)).appendChild(eq(itemElementMock));
     }
 
     @Test
@@ -279,7 +279,7 @@ public class CollectionPresenterTest extends AbstractCollectionEditorTest {
         verify(collectionViewMock, times(1)).getElementsContainer();
         verify(elementsContainerMock, times(1)).getChildCount();
         verify(mapElementPresenterMock, times(1)).getKeyValueContainer(eq(ITEM_ID), eq(keyPropertyMapLocal), eq(propertyMapLocal));
-        verify(elementsContainerMock, times(1)).insertBefore(eq(itemElementMock), eq(objectSeparatorLIMock));
+        verify(elementsContainerMock, times(1)).appendChild(eq(itemElementMock));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
@@ -32,7 +32,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -78,8 +80,19 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
     }
 
     @Test
-    public void onEditItem() {
+    public void onEditItemShown() {
+        doReturn(true).when(elementView1Mock).isShown();
         elementPresenter.onEditItem(elementView1Mock);
+        verify(elementPresenter, never()).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
+        verify(propertyPresenterMock, times(1)).editProperties(anyString());
+        verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
+    }
+
+    @Test
+    public void onEditItemNotShown() {
+        doReturn(false).when(elementView1Mock).isShown();
+        elementPresenter.onEditItem(elementView1Mock);
+        verify(elementPresenter, times(1)).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).editProperties(anyString());
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
     }
@@ -87,6 +100,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
     @Test
     public void onStopEditingItem() {
         elementPresenter.onStopEditingItem(elementView1Mock);
+        verify(elementPresenter, never()).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).stopEditProperties(eq(ELEMENT1_ID));
         verify(styleMock, times(1)).setDisplay(eq(Style.Display.NONE));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenterTest.java
@@ -32,7 +32,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -104,8 +106,19 @@ public class KeyValueElementPresenterTest extends ElementPresenterTest<KeyValueE
     }
 
     @Test
-    public void onEditItem() {
+    public void onEditItemShown() {
+        doReturn(true).when(elementView1Mock).isShown();
         elementPresenter.onEditItem(elementView1Mock);
+        verify(elementPresenter, never()).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
+        verify(propertyPresenterMock, times(2)).editProperties(anyString());
+        verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
+    }
+
+    @Test
+    public void onEditItemNotShown() {
+        doReturn(false).when(elementView1Mock).isShown();
+        elementPresenter.onEditItem(elementView1Mock);
+        verify(elementPresenter, times(1)).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(2)).editProperties(anyString());
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -57,10 +57,13 @@ import org.drools.workbench.screens.scenariosimulation.client.events.SetCellValu
 import org.drools.workbench.screens.scenariosimulation.client.events.SetInstanceHeaderEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.SetPropertyHeaderEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.UndoEvent;
+import org.drools.workbench.screens.scenariosimulation.client.events.UnsupportedDMNEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.RedoEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.ReloadRightPanelEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetCellValueEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.UndoEventHandler;
+import org.drools.workbench.screens.scenariosimulation.client.handlers.UnsupportedDMNEventHandler;
+import org.drools.workbench.screens.scenariosimulation.client.popup.ConfirmPopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.DeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.PreserveDeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
@@ -126,11 +129,16 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
     private HandlerRegistration setPropertyHeaderEventHandlerMock;
     @Mock
     private HandlerRegistration undoEventHandlerRegistrationMock;
+    @Mock
+    private HandlerRegistration unsupportedDMNEventHandlerRegistrationMock;
+
 
     @Mock
     private DeletePopupPresenter deletePopupPresenterMock;
     @Mock
     private PreserveDeletePopupPresenter preserveDeletePopupPresenterMock;
+    @Mock
+    private ConfirmPopupPresenter confirmPopupPresenterMock;
 
     private ScenarioSimulationEventHandler scenarioSimulationEventHandler;
 
@@ -155,6 +163,8 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         when(eventBusMock.addHandler(eq(SetInstanceHeaderEvent.TYPE), isA(ScenarioSimulationEventHandler.class))).thenReturn(setInstanceHeaderEventHandlerMock);
         when(eventBusMock.addHandler(eq(SetPropertyHeaderEvent.TYPE), isA(ScenarioSimulationEventHandler.class))).thenReturn(setPropertyHeaderEventHandlerMock);
         when(eventBusMock.addHandler(eq(UndoEvent.TYPE), isA(UndoEventHandler.class))).thenReturn(undoEventHandlerRegistrationMock);
+        when(eventBusMock.addHandler(eq(UnsupportedDMNEvent.TYPE), isA(UnsupportedDMNEventHandler.class))).thenReturn(unsupportedDMNEventHandlerRegistrationMock);
+
         when(scenarioCommandManagerMock.execute(eq(scenarioSimulationContextLocal), isA(AbstractScenarioSimulationCommand.class))).thenReturn(CommandResultBuilder.SUCCESS);
         scenarioSimulationEventHandler = spy(new ScenarioSimulationEventHandler() {
             {
@@ -162,6 +172,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
                 this.handlerRegistrationList = handlerRegistrationListMock;
                 this.deletePopupPresenter = deletePopupPresenterMock;
                 this.preserveDeletePopupPresenter = preserveDeletePopupPresenterMock;
+                this.confirmPopupPresenter = confirmPopupPresenterMock;
                 this.context = scenarioSimulationContextLocal;
                 this.scenarioCommandManager = scenarioCommandManagerMock;
                 this.scenarioCommandRegistry = scenarioCommandRegistryMock;
@@ -382,6 +393,14 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
     }
 
     @Test
+    public void onUnsupportedDMNEvent() {
+        String DMN_ERROR = "DMN_ERROR";
+        UnsupportedDMNEvent event = new UnsupportedDMNEvent(DMN_ERROR);
+        scenarioSimulationEventHandler.onEvent(event);
+        verify(confirmPopupPresenterMock, times(1)).show(anyString(), eq(DMN_ERROR));
+    }
+
+    @Test
     public void commonExecution() {
         when(scenarioCommandManagerMock.execute(eq(scenarioSimulationContextLocal), eq(appendRowCommandMock))).thenReturn(CommandResultBuilder.SUCCESS);
         scenarioSimulationEventHandler.commonExecution(scenarioSimulationContextLocal, appendRowCommandMock);
@@ -435,5 +454,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         verify(handlerRegistrationListMock, times(1)).add(eq(setPropertyHeaderEventHandlerMock));
         verify(eventBusMock, times(1)).addHandler(eq(UndoEvent.TYPE), isA(UndoEventHandler.class));
         verify(handlerRegistrationListMock, times(1)).add(eq(undoEventHandlerRegistrationMock));
+        verify(eventBusMock, times(1)).addHandler(eq(UnsupportedDMNEvent.TYPE), isA(UnsupportedDMNEventHandler.class));
+        verify(handlerRegistrationListMock, times(1)).add(eq(unsupportedDMNEventHandlerRegistrationMock));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMNDataManagementStrategyTest.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.scenariosimulation.client.editor.strategies
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import com.google.gwt.event.shared.EventBus;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.editor.AbstractScenarioSimulationEditorTest;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModelContent;
@@ -66,7 +67,9 @@ public class DMNDataManagementStrategyTest extends AbstractScenarioSimulationEdi
         factModelTreeHolderlocal.factModelTuple = factModelTupleLocal;
         when(dmnTypeServiceMock.retrieveType(any(), anyString())).thenReturn(mock(FactModelTuple.class));
         modelLocal.getSimulation().getSimulationDescriptor().setDmnFilePath("dmn_file_path");
-        dmnDataManagementStrategy = spy(new DMNDataManagementStrategy(new CallerMock<>(dmnTypeServiceMock), scenarioSimulationContextLocal) {
+        dmnDataManagementStrategy = spy(new DMNDataManagementStrategy(new CallerMock<>(dmnTypeServiceMock),
+                                                                      scenarioSimulationContextLocal,
+                                                                      mock(EventBus.class)) {
             {
                 this.currentPath = mock(Path.class);
                 this.model = modelLocal;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.client.popup;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class ConfirmPopupPresenterTest extends AbstractDeletePopupViewTest {
+
+    @Mock
+    private ConfirmPopupView confirmPopupViewMock;
+
+    private ConfirmPopupPresenter confirmPopupPresenter;
+
+    private final String MAIN_TEXT = "MAIN_TEXT";
+
+    @Before
+    public void setup() {
+        confirmPopupPresenter = spy(new ConfirmPopupPresenter() {
+            {
+                this.confirmPopupView = confirmPopupViewMock;
+            }
+        });
+    }
+
+    @Test
+    public void show() {
+        confirmPopupPresenter.show(MAIN_TITLE_TEXT,
+                                   MAIN_TEXT);
+        verify(confirmPopupViewMock, times(1)).show(eq(MAIN_TITLE_TEXT), eq(MAIN_TEXT));
+    }
+
+    @Test
+    public void hide() {
+        confirmPopupPresenter.hide();
+        verify(confirmPopupViewMock, times(1)).hide();
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
@@ -17,35 +17,27 @@
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.google.gwt.dom.client.ParagraphElement;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class DeletePopupViewTest extends ScenarioConfirmationPopupViewTest {
+public class ConfirmPopupViewTest extends ScenarioConfirmationPopupViewTest {
 
-    @Mock
-    private ParagraphElement textDangerMock;
 
-    private final String TEXT_DANGER_TEXT = "TEXT_DANGER_TEXT";
+    private final String MAIN_TEXT = "MAIN_TEXT";
 
     @Before
     public void setup() {
         super.commonSetup();
-        popupView = spy(new DeletePopupView() {
+        popupView = spy(new ConfirmPopupView() {
             {
                 this.mainTitle = mainTitleMock;
                 this.mainQuestion = mainQuestionMock;
                 this.text1 = text1Mock;
                 this.textQuestion = textQuestionMock;
-                this.textDanger = textDangerMock;
                 this.cancelButton = cancelButtonMock;
                 this.okDeleteButton = okDeleteButtonMock;
                 this.modal = modalMock;
@@ -56,18 +48,10 @@ public class DeletePopupViewTest extends ScenarioConfirmationPopupViewTest {
 
     @Test
     public void show() {
-        ((DeletePopupView) popupView).show(MAIN_TITLE_TEXT,
-                                           MAIN_QUESTION_TEXT,
-                                           TEXT1_TEXT,
-                                           TEXT_QUESTION_TEXT,
-                                           TEXT_DANGER_TEXT,
-                                           OKDELETE_BUTTON_TEXT,
-                                           okDeleteCommandMock);
+        ((ConfirmPopupView) popupView).show(MAIN_TITLE_TEXT,
+                                            MAIN_TEXT);
         verifyShow(MAIN_TITLE_TEXT,
-                   MAIN_QUESTION_TEXT,
-                   TEXT1_TEXT,
-                   TEXT_QUESTION_TEXT);
-        verify(textDangerMock, times(1)).setInnerText(eq(TEXT_DANGER_TEXT));
+                   null, MAIN_TEXT, null);
     }
 
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
@@ -78,7 +78,10 @@ public class PreserveDeletePopupViewTest extends ScenarioConfirmationPopupViewTe
                                      OKDELETE_BUTTON_TEXT,
                                      okPreserveCommandMock,
                                      okDeleteCommandMock);
-        verifyShow();
+        verifyShow(MAIN_TITLE_TEXT,
+                   MAIN_QUESTION_TEXT,
+                   TEXT1_TEXT,
+                   TEXT_QUESTION_TEXT);
         assertEquals(okPreserveCommandMock, ((PreserveDeletePopupView)popupView).okPreserveCommand);
         verify(option1Mock, times(1)).setInnerText(eq(OPTION1_TEXT));
         verify(option2Mock, times(1)).setInnerText(eq(OPTION2_TEXT));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewTest.java
@@ -27,6 +27,7 @@ import org.uberfire.client.views.pfly.widgets.Button;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -75,7 +76,10 @@ public abstract class ScenarioConfirmationPopupViewTest extends AbstractDeletePo
                        TEXT_QUESTION_TEXT,
                        OKDELETE_BUTTON_TEXT,
                        okDeleteCommandMock);
-        verifyShow();
+        verifyShow(MAIN_TITLE_TEXT,
+                   MAIN_QUESTION_TEXT,
+                   TEXT1_TEXT,
+                   TEXT_QUESTION_TEXT);
         assertEquals(okDeleteCommandMock, popupView.okDeleteCommand);
     }
 
@@ -110,12 +114,12 @@ public abstract class ScenarioConfirmationPopupViewTest extends AbstractDeletePo
         verify(popupView, times(1)).hide();
     }
 
-    protected void verifyShow() {
-        verify(mainTitleMock, times(1)).setInnerHTML(eq(MAIN_TITLE_TEXT));
-        verify(mainQuestionMock, times(1)).setInnerHTML(eq(MAIN_QUESTION_TEXT));
-        verify(text1Mock, times(1)).setInnerText(eq(TEXT1_TEXT));
-        verify(textQuestionMock, times(1)).setInnerText(eq(TEXT_QUESTION_TEXT));
-        verify(okDeleteButtonMock, times(1)).setText(eq(OKDELETE_BUTTON_TEXT));
+    protected void verifyShow(String mainTitleText, String mainQuestionText, String text1Text, String textQuestionText) {
+        verify(popupView, times(1)).conditionalShow(eq(mainTitleMock), eq(mainTitleText));
+        verify(popupView, times(1)).conditionalShow(eq(mainQuestionMock), eq(mainQuestionText));
+        verify(popupView, times(1)).conditionalShow(eq(text1Mock), eq(text1Text));
+        verify(popupView, times(1)).conditionalShow(eq(textQuestionMock), eq(textQuestionText));
+        verify(popupView, times(1)).conditionalShow(eq(okDeleteButtonMock), any(), any());
         verify(modalMock, times(1)).show();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/AbstractProducerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/AbstractProducerTest.java
@@ -24,6 +24,7 @@ import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.screens.scenariosimulation.client.AbstractScenarioSimulationTest;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationEventHandler;
 import org.drools.workbench.screens.scenariosimulation.client.editor.ScenarioSimulationView;
+import org.drools.workbench.screens.scenariosimulation.client.popup.ConfirmPopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.DeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.PreserveDeletePopupPresenter;
 import org.junit.Before;
@@ -43,6 +44,8 @@ public abstract class AbstractProducerTest extends AbstractScenarioSimulationTes
     protected DeletePopupPresenter deletePopupPresenterMock;
     @Mock
     protected PreserveDeletePopupPresenter preserveDeletePopupPresenterMock;
+    @Mock
+    protected ConfirmPopupPresenter confirmPopupPresenterMock;
     @Mock
     protected ScenarioSimulationEventHandler scenarioSimulationEventHandlerMock;
     @Mock

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioSimulationProducerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/producers/ScenarioSimulationProducerTest.java
@@ -45,6 +45,7 @@ public class ScenarioSimulationProducerTest extends AbstractProducerTest {
                 this.scenarioSimulationEventHandler = scenarioSimulationEventHandlerMock;
                 this.deletePopupPresenter = deletePopupPresenterMock;
                 this.preserveDeletePopupPresenter = preserveDeletePopupPresenterMock;
+                this.confirmPopupPresenter = confirmPopupPresenterMock;
                 this.eventBusProducer = eventBusProducerMock;
                 this.scenarioSimulationViewProducer = scenarioSimulationViewProducerMock;
                 this.notificationEvent = notificationEventNew;
@@ -64,6 +65,7 @@ public class ScenarioSimulationProducerTest extends AbstractProducerTest {
         verify(scenarioSimulationEventHandlerMock, times(1)).setEventBus(eq(eventBusMock));
         verify(scenarioSimulationEventHandlerMock, times(1)).setDeletePopupPresenter(eq(deletePopupPresenterMock));
         verify(scenarioSimulationEventHandlerMock, times(1)).setPreserveDeletePopupPresenter(eq(preserveDeletePopupPresenterMock));
+        verify(scenarioSimulationEventHandlerMock, times(1)).setConfirmPopupPresenter(eq(confirmPopupPresenterMock));
         verify(scenarioSimulationEventHandlerMock, times(1)).setNotificationEvent(eq(notificationEventNew));
         verify(scenarioSimulationEventHandlerMock, times(1)).setContext(eq(retrieved));
         verify(scenarioSimulationEventHandlerMock, times(1)).setScenarioCommandManager(eq(scenarioCommandManagerMock));


### PR DESCRIPTION
DMN unsupported features:
- top level collections
- multiple nested complex objects inside a collection
- multiple nested collections

This file contains all of them [dmn-unsupported.txt](https://github.com/kiegroup/drools-wb/files/2844736/dmn-unsupported.txt)  (please change the extensions to DMN). The warning popup contains the list of the fields unsupported and appears every time user open the scenario.

UI improvements in collection popup:
- Moved "Add Item" outside the scrolling div
- Remove bullet points from ul/li elements
- Improved padding/margin

@kkufova @Rikkola @gitgabrio 