### PR TITLE
[DROOLS-3654] Replacing build-helper-maven-plugin with gwt-helper-maven plugin

### DIFF
--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidget.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidget.java
@@ -148,10 +148,12 @@ public class TemplateDataTableWidget extends Composite
                             height);
     }
 
+    @Override
     public void onDeleteRow(DeleteRowEvent event) {
         model.removeRow(event.getIndex());
     }
 
+    @Override
     public void onCopyRows(CopyRowsEvent event) {
         copiedRows.clear();
         for (Integer iRow : event.getRowIndexes()) {
@@ -160,6 +162,7 @@ public class TemplateDataTableWidget extends Composite
         }
     }
 
+    @Override
     public void onPasteRows(PasteRowsEvent event) {
         if (copiedRows == null || copiedRows.size() == 0) {
             return;
@@ -176,17 +179,20 @@ public class TemplateDataTableWidget extends Composite
         }
     }
 
+    @Override
     public void onInsertRow(InsertRowEvent event) {
         List<String> data = cellValueFactory.makeRowData();
-        model.addRow(Integer.toString(event.getIndex()),
+        model.addRow(event.getIndex(),
                      data.toArray(new String[data.size()]));
     }
 
+    @Override
     public void onAppendRow(AppendRowEvent event) {
         List<String> data = cellValueFactory.makeRowData();
         model.addRow(data.toArray(new String[data.size()]));
     }
 
+    @Override
     public void onUpdateModel(UpdateModelEvent event) {
 
         //Copy data into the underlying model

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidgetTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidgetTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.template.client.editor;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.guided.template.shared.TemplateModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.AbstractCellFactory;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.events.InsertRowEvent;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({AbstractCellFactory.class, VerticalDecoratedTemplateDataGridWidget.class, DateTimeFormat.class})
+public class TemplateDataTableWidgetTest {
+
+    @Mock
+    private EventBus eventBusMock;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracleMock;
+
+    @Mock
+    private TemplateModel modelMock;
+
+    @Mock
+    private TemplateDataCellValueFactory cellValueFactoryMock;
+
+    private TemplateDataTableWidget dataTableWidget;
+
+    @Before
+    public void setUp() throws Exception {
+        dataTableWidget = new TemplateDataTableWidget(modelMock, oracleMock, false, eventBusMock);
+        dataTableWidget.cellValueFactory = cellValueFactoryMock;
+    }
+
+    @Test
+    public void testOnInsertRow() {
+        final int index = 123;
+        final List<String> rowData = Collections.singletonList("abc");
+        final InsertRowEvent insertRowEvent = mock(InsertRowEvent.class);
+        when(insertRowEvent.getIndex()).thenReturn(index);
+        when(cellValueFactoryMock.makeRowData()).thenReturn(rowData);
+
+        dataTableWidget.onInsertRow(insertRowEvent);
+
+        verify(modelMock).addRow(eq(index),
+                                 eq(rowData.toArray(new String[1])));
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionView.java
@@ -65,11 +65,19 @@ public interface CollectionView {
         void showEditingBox();
 
         /**
-         * Toggle the expansion of the collection.
+         * Toggle the expansion of the items included in the collection.
          *
          * @param isShown the <b>current</b> expansion status of the collection
          */
         void onToggleRowExpansion(boolean isShown);
+
+        /**
+         * Updates the <b>expanded</b> status of main collection container to reflect
+         * the status of all contained items, when they have the same <b>expanded</b> status
+         *
+         * @param isShown the <b>current</b> expansion status of the collection
+         */
+        void updateRowExpansionStatus(boolean isShown);
 
         /**
          * Creates a new single <b>item</b> element with values taken from given <code>Map</code>
@@ -142,7 +150,21 @@ public interface CollectionView {
 
     ButtonElement getAddItemButton();
 
+    ButtonElement getCancelButton();
+
+    ButtonElement getRemoveButton();
+
+    ButtonElement getSaveButton();
+
     void toggleRowExpansion();
+
+    /**
+     * Updates the <b>expanded</b> status of main collection container to reflect
+     * the status of all contained items, when they have the same <b>expanded</b> status
+     *
+     * @param isShown the <b>current</b> expansion status of the collection
+     */
+    void updateRowExpansionStatus(boolean isShown);
 
     /**
      * Updates the <b>json</b> representation of the values shown by this editor

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
@@ -201,6 +201,21 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
         return addItemButton;
     }
 
+    @Override
+    public ButtonElement getCancelButton() {
+        return cancelButton;
+    }
+
+    @Override
+    public ButtonElement getRemoveButton() {
+        return removeButton;
+    }
+
+    @Override
+    public ButtonElement getSaveButton() {
+        return saveButton;
+    }
+
     @EventHandler("collectionEditor")
     public void onCollectionEditorClick(ClickEvent clickEvent) {
         clickEvent.stopPropagation();
@@ -270,6 +285,11 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
     @Override
     public void toggleRowExpansion() {
         toggleRowExpansion(!isShown());
+    }
+
+    @Override
+    public void updateRowExpansionStatus(boolean isShown) {
+        toggleRowExpansion(!isShown);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenter.java
@@ -48,9 +48,17 @@ public abstract class ElementPresenter<E extends ElementView> implements Element
     }
 
     @Override
+    public void updateCommonToggleStatus(boolean isShown) {
+        if (elementViewList.stream()
+                .allMatch(elementView ->  !isShown == elementView.isShown())) {
+            collectionEditorPresenter.updateRowExpansionStatus(isShown);
+        }
+    }
+
+    @Override
     public void remove() {
         List<E> newList = new ArrayList<>(elementViewList);
-        newList.forEach(elementView -> onDeleteItem(elementView));
+        newList.forEach(this::onDeleteItem);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
@@ -37,6 +37,13 @@ public interface ElementView<T extends ElementView.Presenter> extends HasPresent
         void onToggleRowExpansion(E itemElementView, boolean shown);
 
         /**
+         * Update the toggle status of the main collection container if all the contained <code>ElementView</code>
+         * have the same one
+         * @param shown
+         */
+        void updateCommonToggleStatus(boolean shown);
+
+        /**
          * Start editing properties of the given <code>itemElementView</code>
          * @param itemElementView
          */

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
@@ -23,7 +23,7 @@ import com.google.gwt.dom.client.LIElement;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.UListElement;
 
-public class ItemElementPresenter extends ElementPresenter<ItemElementView> implements ItemElementView.Presenter  {
+public class ItemElementPresenter extends ElementPresenter<ItemElementView> implements ItemElementView.Presenter {
 
     @Override
     public LIElement getItemContainer(String itemId, Map<String, String> propertiesMap) {
@@ -42,6 +42,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     public void onToggleRowExpansion(ItemElementView itemElementView, boolean isShown) {
         CollectionEditorUtils.toggleRowExpansion(itemElementView.getFaAngleRight(), !isShown);
         propertyPresenter.onToggleRowExpansion(itemElementView.getItemId(), isShown);
+        updateCommonToggleStatus(isShown);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenter.java
@@ -50,6 +50,7 @@ public class KeyValueElementPresenter extends ElementPresenter<KeyValueElementVi
         CollectionEditorUtils.toggleRowExpansion(keyValueElementView.getValueLabel(), isShown);
         List<String> keyValueIds = getKeyValueIds( keyValueElementView.getItemId());
         keyValueIds.forEach(id -> propertyPresenter.onToggleRowExpansion(id, isShown));
+        updateCommonToggleStatus(isShown);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopup.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopup.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.popup;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.uberfire.mvp.Command;
 
-public interface ScenarioConfirmationPopup {
+public interface AbstractScenarioConfirmationPopup {
 
     interface Presenter {
 
@@ -29,7 +29,6 @@ public interface ScenarioConfirmationPopup {
          * @param mainQuestionText
          * @param text1Text
          * @param textQuestionText
-         * @param textWarningText
          * @param okDeleteButtonText
          * @param okDeleteCommand
          */
@@ -37,7 +36,6 @@ public interface ScenarioConfirmationPopup {
                   final String mainQuestionText,
                   final String text1Text,
                   final String textQuestionText,
-                  final String textWarningText,
                   final String okDeleteButtonText,
                   final Command okDeleteCommand);
 
@@ -55,7 +53,6 @@ public interface ScenarioConfirmationPopup {
      * @param mainQuestionText
      * @param text1Text
      * @param textQuestionText
-     * @param textWarningText
      * @param okDeleteButtonText
      * @param okDeleteCommand
      */
@@ -63,7 +60,6 @@ public interface ScenarioConfirmationPopup {
               final String mainQuestionText,
               final String text1Text,
               final String textQuestionText,
-              final String textWarningText,
               final String okDeleteButtonText,
               final Command okDeleteCommand);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupView.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.popup;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.HeadingElement;
+import com.google.gwt.dom.client.ParagraphElement;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.MouseEvent;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.ForEvent;
+import org.uberfire.client.views.pfly.resources.i18n.Constants;
+import org.uberfire.client.views.pfly.widgets.Button;
+import org.uberfire.client.views.pfly.widgets.Modal;
+import org.uberfire.mvp.Command;
+
+public abstract class AbstractScenarioConfirmationPopupView implements AbstractScenarioConfirmationPopup {
+
+    @DataField("main-title")
+    protected HeadingElement mainTitle = Document.get().createHElement(4);
+
+    @DataField("main-question")
+    protected HeadingElement mainQuestion = Document.get().createHElement(2);
+
+    @Inject
+    @DataField("text-1")
+    protected ParagraphElement text1;
+
+    @Inject
+    @DataField("text-question")
+    protected ParagraphElement textQuestion;
+
+    @Inject
+    @DataField("cancel-button")
+    protected Button cancelButton;
+
+    @Inject
+    @DataField("ok-delete-button")
+    protected Button okDeleteButton;
+
+    @Inject
+    @DataField("modal")
+    protected Modal modal;
+
+    @Inject
+    protected TranslationService translationService;
+
+    protected Command okDeleteCommand;
+
+    @PostConstruct
+    public void init() {
+        cancelButton.setText(translationService.getTranslation(Constants.ConfirmPopup_Cancel));
+    }
+
+    @Override
+    public void show(final String mainTitleText,
+                     final String mainQuestionText,
+                     final String text1Text,
+                     final String textQuestionText,
+                     final String okDeleteButtonText,
+                     final Command okDeleteCommand) {
+        this.okDeleteCommand = okDeleteCommand;
+        conditionalShow(mainTitle, mainTitleText);
+        conditionalShow(mainQuestion, mainQuestionText);
+        conditionalShow(text1, text1Text);
+        conditionalShow(textQuestion, textQuestionText);
+        conditionalShow(okDeleteButton, okDeleteCommand, okDeleteButtonText);
+        modal.show();
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return modal.getElement();
+    }
+
+    @Override
+    public void hide() {
+        modal.hide();
+    }
+
+    @EventHandler("ok-delete-button")
+    public void onOkDeleteClick(final @ForEvent("click") MouseEvent event) {
+        if (okDeleteCommand != null) {
+            okDeleteCommand.execute();
+        }
+        hide();
+    }
+
+    @EventHandler("cancel-button")
+    public void onCancelClick(final @ForEvent("click") MouseEvent event) {
+        hide();
+    }
+
+    protected void conditionalShow(Element element, String innerText) {
+        if (innerText != null) {
+            element.setInnerHTML(innerText);
+        } else {
+            element.removeFromParent();
+        }
+    }
+
+    protected void conditionalShow(Button button, Command command, String innerText) {
+        if (command == null) {
+            button.hide();
+        } else {
+            button.setText(innerText);
+        }
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupView.java
@@ -21,7 +21,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 
 @Dependent
 @Templated
-public class ConfirmPopupView extends ScenarioConfirmationPopupView implements ConfirmPopup {
+public class ConfirmPopupView extends AbstractScenarioConfirmationPopupView implements ConfirmPopup {
 
     @Override
     public void show(String mainTitleText, String mainText) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupView.java
@@ -25,7 +25,7 @@ import org.uberfire.mvp.Command;
 
 @Dependent
 @Templated
-public class DeletePopupView extends ScenarioConfirmationPopupView implements DeletePopup {
+public class DeletePopupView extends AbstractScenarioConfirmationPopupView implements DeletePopup {
 
     @Inject
     @DataField("text-danger")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupView.java
@@ -29,7 +29,7 @@ import org.uberfire.mvp.Command;
 
 @Dependent
 @Templated
-public class PreserveDeletePopupView extends ScenarioConfirmationPopupView implements PreserveDeletePopup {
+public class PreserveDeletePopupView extends AbstractScenarioConfirmationPopupView implements PreserveDeletePopup {
 
     @Inject
     @DataField("option-1")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupPresenter.java
@@ -16,11 +16,13 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.uberfire.mvp.Command;
 
-public abstract class ScenarioConfirmationPopupPresenter implements ScenarioConfirmationPopup.Presenter {
+@Dependent
+public class ScenarioConfirmationPopupPresenter implements ScenarioConfirmationPopup.Presenter {
 
     @Inject
     protected ScenarioConfirmationPopupView scenarioConfirmationPopupView;
@@ -30,9 +32,10 @@ public abstract class ScenarioConfirmationPopupPresenter implements ScenarioConf
                      final String mainQuestionText,
                      final String text1Text,
                      final String textQuestionText,
+                     final String textWarningText,
                      final String okDeleteButtonText,
                      final Command okDeleteCommand) {
-        scenarioConfirmationPopupView.show(mainTitleText, mainQuestionText, text1Text, textQuestionText, okDeleteButtonText, okDeleteCommand);
+        scenarioConfirmationPopupView.show(mainTitleText, mainQuestionText, text1Text, textQuestionText, textWarningText, okDeleteButtonText, okDeleteCommand);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.html
@@ -17,6 +17,8 @@
                     <h2 data-field="main-question"></h2>
                     <div>
                         <p data-field="text-1"><p/>
+                        <p data-field="text-question"></p>
+                        <p data-field="text-warning" style="color: red"></p>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupView.java
@@ -15,114 +15,31 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
-import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.HeadingElement;
 import com.google.gwt.dom.client.ParagraphElement;
-import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.dom.MouseEvent;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
-import org.jboss.errai.ui.shared.api.annotations.EventHandler;
-import org.jboss.errai.ui.shared.api.annotations.ForEvent;
-import org.uberfire.client.views.pfly.resources.i18n.Constants;
-import org.uberfire.client.views.pfly.widgets.Button;
-import org.uberfire.client.views.pfly.widgets.Modal;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.mvp.Command;
 
-public abstract class ScenarioConfirmationPopupView implements ScenarioConfirmationPopup {
-
-    @DataField("main-title")
-    protected HeadingElement mainTitle = Document.get().createHElement(4);
-
-    @DataField("main-question")
-    protected HeadingElement mainQuestion = Document.get().createHElement(2);
+@Dependent
+@Templated
+public class ScenarioConfirmationPopupView extends AbstractScenarioConfirmationPopupView implements ScenarioConfirmationPopup {
 
     @Inject
-    @DataField("text-1")
-    protected ParagraphElement text1;
-
-    @Inject
-    @DataField("text-question")
-    protected ParagraphElement textQuestion;
-
-    @Inject
-    @DataField("cancel-button")
-    protected Button cancelButton;
-
-    @Inject
-    @DataField("ok-delete-button")
-    protected Button okDeleteButton;
-
-    @Inject
-    @DataField("modal")
-    protected Modal modal;
-
-    @Inject
-    protected TranslationService translationService;
-
-    protected Command okDeleteCommand;
-
-    @PostConstruct
-    public void init() {
-        cancelButton.setText(translationService.getTranslation(Constants.ConfirmPopup_Cancel));
-    }
+    @DataField("text-warning")
+    protected ParagraphElement textWarning;
 
     @Override
     public void show(final String mainTitleText,
                      final String mainQuestionText,
                      final String text1Text,
                      final String textQuestionText,
+                     final String textWarningText,
                      final String okDeleteButtonText,
                      final Command okDeleteCommand) {
-        this.okDeleteCommand = okDeleteCommand;
-        conditionalShow(mainTitle, mainTitleText);
-        conditionalShow(mainQuestion, mainQuestionText);
-        conditionalShow(text1, text1Text);
-        conditionalShow(textQuestion, textQuestionText);
-        conditionalShow(okDeleteButton, okDeleteCommand, okDeleteButtonText);
-        modal.show();
-    }
-
-    @Override
-    public HTMLElement getElement() {
-        return modal.getElement();
-    }
-
-    @Override
-    public void hide() {
-        modal.hide();
-    }
-
-    @EventHandler("ok-delete-button")
-    public void onOkDeleteClick(final @ForEvent("click") MouseEvent event) {
-        if (okDeleteCommand != null) {
-            okDeleteCommand.execute();
-        }
-        hide();
-    }
-
-    @EventHandler("cancel-button")
-    public void onCancelClick(final @ForEvent("click") MouseEvent event) {
-        hide();
-    }
-
-    protected void conditionalShow(Element element, String innerText) {
-        if (innerText != null) {
-            element.setInnerHTML(innerText);
-        } else {
-            element.removeFromParent();
-        }
-    }
-
-    protected void conditionalShow(Button button, Command command, String innerText) {
-        if (command == null) {
-            button.hide();
-        } else {
-            button.setText(innerText);
-        }
+        conditionalShow(textWarning, textWarningText);
+        show(mainTitleText, mainQuestionText, text1Text, textQuestionText, okDeleteButtonText, okDeleteCommand);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmPopupPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmPopupPresenter.java
@@ -27,7 +27,7 @@ import org.uberfire.mvp.Command;
 public class YesNoConfirmPopupPresenter implements YesNoConfirmPopup.Presenter {
 
     @Inject
-    YesNoConfirmPopupView yesNoConfirmPopupView;
+    protected YesNoConfirmPopupView yesNoConfirmPopupView;
 
     @Override
     public void show(final String title,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -139,4 +139,16 @@ public interface ScenarioSimulationEditorConstants
     String chooseDMN();
 
     String chooseValidDMNAsset();
+
+    String removeCollectionMainTitle();
+
+    String removeCollectionMainQuestion();
+
+    String removeCollectionText1();
+
+    String removeCollectionQuestion();
+
+    String removeCollectionWarningText();
+
+    String collectionError();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 newScenarioSimulationDescription=Test Scenario
+removeCollectionMainTitle=Remove collection
+collectionError=Collection Error
+removeCollectionMainQuestion=Remove the collection?
 factColumnHeader=Fact
 fieldColumnHeader=Field
 contextColumnHeader=Context
@@ -75,5 +78,8 @@ redo=Redo
 sourceType=Source type
 chooseDMN=Choose DMN asset
 chooseValidDMNAsset=Choose a valid DMN asset from the list.
+removeCollectionText1=This action will remove all items from the collection and the collection itself.
+removeCollectionQuestion=Do you want to continue and remove the collection?
+removeCollectionWarningText=This action cannot be undone.
 
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenterTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,6 +90,18 @@ public abstract class ElementPresenterTest<E extends ElementView, T extends Elem
     }
 
     @Test
+    public void updateCommonToggleStatusNotIsShown() {
+        commonUpdateCommonToggleStatus(false, true);
+        commonUpdateCommonToggleStatus(false, false);
+    }
+
+    @Test
+    public void updateCommonToggleStatusIsShown() {
+        commonUpdateCommonToggleStatus(true, true);
+        commonUpdateCommonToggleStatus(true, false);
+    }
+
+    @Test
     public void remove() {
         elementPresenter.remove();
         elementViewListLocal.forEach(elementViewMock -> {
@@ -114,6 +129,22 @@ public abstract class ElementPresenterTest<E extends ElementView, T extends Elem
         });
         verify(editItemButtonMock, times(2)).setDisabled(false);
         verify(deleteItemButtonMock, times(2)).setDisabled(false);
+    }
+
+    private void commonUpdateCommonToggleStatus(boolean isShown, boolean allEquals) {
+        if (allEquals) {
+            elementViewListLocal.forEach(elementViewMock -> doReturn(!isShown).when(elementViewMock).isShown());
+        } else {
+            doReturn(!isShown).when(elementView1Mock).isShown();
+            doReturn(isShown).when(elementView2Mock).isShown();
+        }
+        elementPresenter.updateCommonToggleStatus(isShown);
+        if (allEquals) {
+            verify(collectionPresenterMock, times(1)).updateRowExpansionStatus(eq(isShown));
+        } else {
+            verify(collectionPresenterMock, never()).updateRowExpansionStatus(eq(isShown));
+        }
+        reset(collectionPresenterMock);
     }
 
     private void commonOnToggleRowExpansion(boolean isShown) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractDeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractDeletePopupViewTest.java
@@ -57,6 +57,7 @@ public abstract class AbstractDeletePopupViewTest {
     protected final String MAIN_QUESTION_TEXT = "MAIN_QUESTION_TEXT";
     protected final String TEXT1_TEXT = "TEXT1_TEXT";
     protected final String TEXT_QUESTION_TEXT = "TEXT_QUESTION_TEXT";
+    protected final String TEXT_WARNING_TEXT = "TEXT_WARNING_TEXT";
     protected final String OKDELETE_BUTTON_TEXT = "OKDELETE_BUTTON_TEXT";
     protected final String OPTION1_TEXT = "OPTION1_TEXT";
     protected final String OPTION2_TEXT = "OPTION2_TEXT";

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupViewTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.scenariosimulation.client.popup;
+
+import com.google.gwt.dom.client.ParagraphElement;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.MouseEvent;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.uberfire.client.views.pfly.widgets.Button;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public abstract class AbstractScenarioConfirmationPopupViewTest extends AbstractDeletePopupViewTest {
+
+    protected AbstractScenarioConfirmationPopupView popupView;
+
+    @Mock
+    protected ParagraphElement text1Mock;
+
+    @Mock
+    protected ParagraphElement textQuestionMock;
+
+    @Mock
+    protected Button cancelButtonMock;
+
+    @Mock
+    protected Button okDeleteButtonMock;
+
+    @Mock
+    protected MouseEvent mouseEventMock;
+
+    @Mock
+    protected TranslationService translationServiceMock;
+
+    @Before
+    public void setup() {
+        super.commonSetup();
+    }
+
+    @Test
+    public void init() {
+        popupView.init();
+        verify(cancelButtonMock, times(1)).setText(anyString());
+    }
+
+    @Test
+    public void show() {
+        popupView.show(MAIN_TITLE_TEXT,
+                       MAIN_QUESTION_TEXT,
+                       TEXT1_TEXT,
+                       TEXT_QUESTION_TEXT,
+                       OKDELETE_BUTTON_TEXT,
+                       okDeleteCommandMock);
+        verifyShow(MAIN_TITLE_TEXT,
+                   MAIN_QUESTION_TEXT,
+                   TEXT1_TEXT,
+                   TEXT_QUESTION_TEXT);
+        assertEquals(okDeleteCommandMock, popupView.okDeleteCommand);
+    }
+
+    @Test
+    public void getElement() {
+        final HTMLElement retrieved = popupView.getElement();
+        assertNotNull(retrieved);
+    }
+
+    @Test
+    public void hide() {
+        popupView.hide();
+        verify(modalMock, times(1)).hide();
+    }
+
+    @Test
+    public void onOkDeleteClick() {
+        popupView.okDeleteCommand = null;
+        popupView.onOkDeleteClick(mouseEventMock);
+        verify(okDeleteCommandMock, never()).execute();
+        verify(popupView, times(1)).hide();
+        reset(popupView);
+        popupView.okDeleteCommand = okDeleteCommandMock;
+        popupView.onOkDeleteClick(mouseEventMock);
+        verify(okDeleteCommandMock, times(1)).execute();
+        verify(popupView, times(1)).hide();
+    }
+
+    @Test
+    public void onCancelClick() {
+        popupView.onCancelClick(mouseEventMock);
+        verify(popupView, times(1)).hide();
+    }
+
+    protected void verifyShow(String mainTitleText, String mainQuestionText, String text1Text, String textQuestionText) {
+        verify(popupView, times(1)).conditionalShow(eq(mainTitleMock), eq(mainTitleText));
+        verify(popupView, times(1)).conditionalShow(eq(mainQuestionMock), eq(mainQuestionText));
+        verify(popupView, times(1)).conditionalShow(eq(text1Mock), eq(text1Text));
+        verify(popupView, times(1)).conditionalShow(eq(textQuestionMock), eq(textQuestionText));
+        verify(popupView, times(1)).conditionalShow(eq(okDeleteButtonMock), any(), any());
+        verify(modalMock, times(1)).show();
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import static org.mockito.Mockito.spy;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class ConfirmPopupViewTest extends ScenarioConfirmationPopupViewTest {
+public class ConfirmPopupViewTest extends AbstractScenarioConfirmationPopupViewTest {
 
 
     private final String MAIN_TEXT = "MAIN_TEXT";

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupViewTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class DeletePopupViewTest extends ScenarioConfirmationPopupViewTest {
+public class DeletePopupViewTest extends AbstractScenarioConfirmationPopupViewTest {
 
     @Mock
     private ParagraphElement textDangerMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
-public class PreserveDeletePopupViewTest extends ScenarioConfirmationPopupViewTest {
+public class PreserveDeletePopupViewTest extends AbstractScenarioConfirmationPopupViewTest {
 
     @Mock
     private LIElement option1Mock;
@@ -69,15 +69,15 @@ public class PreserveDeletePopupViewTest extends ScenarioConfirmationPopupViewTe
     @Test
     public void show() {
         ((PreserveDeletePopupView)popupView).show(MAIN_TITLE_TEXT,
-                                     MAIN_QUESTION_TEXT,
-                                     TEXT1_TEXT,
-                                     TEXT_QUESTION_TEXT,
-                                     OPTION1_TEXT,
-                                     OPTION2_TEXT,
-                                     OKPRESERVE_BUTTON_TEXT,
-                                     OKDELETE_BUTTON_TEXT,
-                                     okPreserveCommandMock,
-                                     okDeleteCommandMock);
+                                                          MAIN_QUESTION_TEXT,
+                                                          TEXT1_TEXT,
+                                                          TEXT_QUESTION_TEXT,
+                                                          OPTION1_TEXT,
+                                                          OPTION2_TEXT,
+                                                          OKPRESERVE_BUTTON_TEXT,
+                                                          OKDELETE_BUTTON_TEXT,
+                                                          okPreserveCommandMock,
+                                                          okDeleteCommandMock);
         verifyShow(MAIN_TITLE_TEXT,
                    MAIN_QUESTION_TEXT,
                    TEXT1_TEXT,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewPresenterTest.java
@@ -16,8 +16,10 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.eq;
@@ -25,8 +27,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-//@RunWith(LienzoMockitoTestRunner.class)
-public abstract class ScenarioConfirmationPopupViewPresenterTest extends AbstractDeletePopupViewTest {
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class ScenarioConfirmationPopupViewPresenterTest extends AbstractDeletePopupViewTest {
 
     @Mock
     private ScenarioConfirmationPopupView scenarioConfirmationPopupViewMock;
@@ -37,7 +40,7 @@ public abstract class ScenarioConfirmationPopupViewPresenterTest extends Abstrac
     public void setup() {
         scenarioConfirmationPopupPresenter = spy(new ScenarioConfirmationPopupPresenter() {
             {
-                this.scenarioConfirmationPopupView = ScenarioConfirmationPopupViewPresenterTest.this.scenarioConfirmationPopupViewMock;
+                this.scenarioConfirmationPopupView = scenarioConfirmationPopupViewMock;
             }
         });
     }
@@ -48,9 +51,10 @@ public abstract class ScenarioConfirmationPopupViewPresenterTest extends Abstrac
                                                 MAIN_QUESTION_TEXT,
                                                 TEXT1_TEXT,
                                                 TEXT_QUESTION_TEXT,
+                                                TEXT_WARNING_TEXT,
                                                 OKDELETE_BUTTON_TEXT,
                                                 okDeleteCommandMock);
-        verify(scenarioConfirmationPopupViewMock, times(1)).show(eq(MAIN_TITLE_TEXT), eq(MAIN_QUESTION_TEXT), eq(TEXT1_TEXT), eq(TEXT_QUESTION_TEXT), eq(OKDELETE_BUTTON_TEXT), eq(okDeleteCommandMock));
+        verify(scenarioConfirmationPopupViewMock, times(1)).show(eq(MAIN_TITLE_TEXT), eq(MAIN_QUESTION_TEXT), eq(TEXT1_TEXT), eq(TEXT_QUESTION_TEXT), eq(TEXT_WARNING_TEXT), eq(OKDELETE_BUTTON_TEXT), eq(okDeleteCommandMock));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewTest.java
@@ -16,110 +16,30 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.popup;
 
-import com.google.gwt.dom.client.ParagraphElement;
-import org.jboss.errai.common.client.dom.HTMLElement;
-import org.jboss.errai.common.client.dom.MouseEvent;
-import org.jboss.errai.ui.client.local.spi.TranslationService;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.uberfire.client.views.pfly.widgets.Button;
+import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 
-public abstract class ScenarioConfirmationPopupViewTest extends AbstractDeletePopupViewTest {
-
-    protected ScenarioConfirmationPopupView popupView;
-
-    @Mock
-    protected ParagraphElement text1Mock;
-
-    @Mock
-    protected ParagraphElement textQuestionMock;
-
-    @Mock
-    protected Button cancelButtonMock;
-
-    @Mock
-    protected Button okDeleteButtonMock;
-
-    @Mock
-    protected MouseEvent mouseEventMock;
-
-    @Mock
-    protected TranslationService translationServiceMock;
+@RunWith(LienzoMockitoTestRunner.class)
+public class ScenarioConfirmationPopupViewTest extends AbstractScenarioConfirmationPopupViewTest {
 
     @Before
     public void setup() {
         super.commonSetup();
+        popupView = spy(new ScenarioConfirmationPopupView() {
+            {
+                this.mainTitle = mainTitleMock;
+                this.mainQuestion = mainQuestionMock;
+                this.text1 = text1Mock;
+                this.textQuestion = textQuestionMock;
+                this.cancelButton = cancelButtonMock;
+                this.okDeleteButton = okDeleteButtonMock;
+                this.modal = modalMock;
+                this.translationService = translationServiceMock;
+            }
+        });
     }
 
-    @Test
-    public void init() {
-        popupView.init();
-        verify(cancelButtonMock, times(1)).setText(anyString());
-    }
-
-    @Test
-    public void show() {
-        popupView.show(MAIN_TITLE_TEXT,
-                       MAIN_QUESTION_TEXT,
-                       TEXT1_TEXT,
-                       TEXT_QUESTION_TEXT,
-                       OKDELETE_BUTTON_TEXT,
-                       okDeleteCommandMock);
-        verifyShow(MAIN_TITLE_TEXT,
-                   MAIN_QUESTION_TEXT,
-                   TEXT1_TEXT,
-                   TEXT_QUESTION_TEXT);
-        assertEquals(okDeleteCommandMock, popupView.okDeleteCommand);
-    }
-
-    @Test
-    public void getElement() {
-        final HTMLElement retrieved = popupView.getElement();
-        assertNotNull(retrieved);
-    }
-
-    @Test
-    public void hide() {
-        popupView.hide();
-        verify(modalMock, times(1)).hide();
-    }
-
-    @Test
-    public void onOkDeleteClick() {
-        popupView.okDeleteCommand = null;
-        popupView.onOkDeleteClick(mouseEventMock);
-        verify(okDeleteCommandMock, never()).execute();
-        verify(popupView, times(1)).hide();
-        reset(popupView);
-        popupView.okDeleteCommand = okDeleteCommandMock;
-        popupView.onOkDeleteClick(mouseEventMock);
-        verify(okDeleteCommandMock, times(1)).execute();
-        verify(popupView, times(1)).hide();
-    }
-
-    @Test
-    public void onCancelClick() {
-        popupView.onCancelClick(mouseEventMock);
-        verify(popupView, times(1)).hide();
-    }
-
-    protected void verifyShow(String mainTitleText, String mainQuestionText, String text1Text, String textQuestionText) {
-        verify(popupView, times(1)).conditionalShow(eq(mainTitleMock), eq(mainTitleText));
-        verify(popupView, times(1)).conditionalShow(eq(mainQuestionMock), eq(mainQuestionText));
-        verify(popupView, times(1)).conditionalShow(eq(text1Mock), eq(text1Text));
-        verify(popupView, times(1)).conditionalShow(eq(textQuestionMock), eq(textQuestionText));
-        verify(popupView, times(1)).conditionalShow(eq(okDeleteButtonMock), any(), any());
-        verify(modalMock, times(1)).show();
-    }
 }

--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -35,6 +35,8 @@
   <properties>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
     <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <gwt.helper.includes>Client</gwt.helper.includes>
+    <gwt.helper.rootDirectories>${project.parent.basedir}/drools-wb-screens</gwt.helper.rootDirectories>
   </properties>
 
   <dependencies>
@@ -1432,60 +1434,17 @@
     <plugins>
       <!-- Include additional sources path for hot reload -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-gwthelper-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>add-source</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
             </goals>
             <configuration>
-              <sources>
-                <!-- Include screens sources !-->
-                <source>../drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/resources</source>
-
-                <source>../drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/main/java</source>
-                <source>../drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/main/resources</source>
-              </sources>
+              <includes>${gwt.helper.includes}</includes> <!-- will include all GWT module whose configuration file name match that pattern -->
+              <rootDirectories>${gwt.helper.rootDirectories}</rootDirectories> <!-- will search inside those directories -->
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
@ederign @porcelli @manstis @Rikkola @danielezonca @etirelli 

The main scope of this PR is to allow editing/debugging/hot-reload client-code (GWT) of modules external of drools-wb while working with drools-webapp. This should be configurable on a per-developer basis, modifying personal .m2/settings.xml, without touching the versioned pom.xml
The current solution is based on the build-helper-maven-plugin, but it has two limitations
1) it is needed to statically define every external source inside the plugin configuration
2) it is not possible to override such configuration with the user' .m2/settings.xml.

The gwt-help-maven-plugin (https://github.com/gitgabrio/gwt-helper-maven-plugin) has been designed to overcome this limitations, following suggestions from @ederign:

1) it uses a pattern matching to (recursively) find external sources
2) it uses a list of directories to define the path to read for external sources
3) it may use such pattern/directories defined as properties in the pom, and since properties are overridable with m2./settings.xml profile, it is possible for each user to define its own profile and its own pattern, to match the setting s/he has/needs on its machine.

For the moment being I've developed that plugin in my spare time, and being an "experimental" feature I avoided any reference to RedHat. If it is accepted, I would like to remove all personal reference and use standard RedHat ones. Moreover, it is currently deployed to Sonatype' Nexus, and I am not sure this follows our "policies".
I would also be very happy if someone else would be interested in contributing to it.
