### PR TITLE
[DROOLS-3662] Verify Collection editor is always shown on center of the widget

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/CollectionEditorDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/CollectionEditorDOMElement.java
@@ -108,6 +108,8 @@ public class CollectionEditorDOMElement extends BaseDOMElement<String, Collectio
         final double widgetHeight = (shownHeight * 0.5);
         widget.setFixedHeight(widgetHeight, Style.Unit.PX);
         widgetContainer.getElement().getStyle().setTop(0, Style.Unit.PX);
+        // Verify Collection editor is always shown on center of the widget, even when clicked cell left margin is outside of the grid
+        widgetContainer.getElement().getStyle().clearProperty("clip");
     }
 
     @Override


### PR DESCRIPTION
@jomarko @danielezonca @Rikkola 


https://issues.jboss.org/browse/DROOLS-3662