### PR TITLE
DROOLS-3673: Values are getting missed/changed from Guided Rule Template when rows are inserted with + icon

### DIFF
--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidget.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataTableWidget.java
@@ -178,7 +178,7 @@ public class TemplateDataTableWidget extends Composite
 
     public void onInsertRow(InsertRowEvent event) {
         List<String> data = cellValueFactory.makeRowData();
-        model.addRow(Integer.toString(event.getIndex()),
+        model.addRow(event.getIndex(),
                      data.toArray(new String[data.size()]));
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3673

This replaces https://github.com/kiegroup/drools-wb/pull/1072 as a new JIRA was required.