### PR TITLE
DROOLS-3752: Update header cells edit mode invocation

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
@@ -181,7 +181,9 @@ public abstract class AbstractScenarioSimulationCommand extends AbstractCommand<
     protected CommandResult<ScenarioSimulationViolation> commonExecution(ScenarioSimulationContext context) {
         context.getScenarioGridPanel().onResize();
         context.getScenarioGridPanel().select();
-        context.getScenarioGridPanel().setFocus(true);
+        if (undoable) {
+            context.getScenarioGridPanel().setFocus(true);
+        }
         return CommandResultBuilder.SUCCESS;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
@@ -135,7 +135,7 @@ public class CommonEditHandler {
     }
 
     // Indirection add for test
-    protected static boolean isEditableHeaderLocal(GridColumn<?> scenarioGridColumn, Integer uiHeaderRowIndex) {
+    protected static boolean isEditableHeaderLocal(ScenarioGridColumn scenarioGridColumn, Integer uiHeaderRowIndex) {
         return ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumn, uiHeaderRowIndex);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
@@ -100,7 +100,7 @@ public class ScenarioSimulationGridHeaderUtilities {
                                            final Integer uiHeaderRowIndex) {
         final GridColumn.HeaderMetaData headerMetaData = column.getHeaderMetaData().get(uiHeaderRowIndex);
         if (!(headerMetaData instanceof ScenarioHeaderMetaData)) {
-            return false;
+            throw new IllegalStateException("Header metadata has to be an instance of ScenarioHeaderMetaData");
         }
 
         final ScenarioHeaderMetaData scenarioHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
@@ -90,10 +90,29 @@ public class ScenarioSimulationGridHeaderUtilities {
         return ci.getColumn();
     }
 
-    public static boolean isEditableHeader(final GridColumn<?> column,
+    /**
+     * Checks whether the edit mode can be invoked on header cell from given column on given row.
+     * @param column
+     * @param uiHeaderRowIndex
+     * @return true if conditions are met, false otherwise
+     */
+    public static boolean isEditableHeader(final ScenarioGridColumn column,
                                            final Integer uiHeaderRowIndex) {
-        GridColumn.HeaderMetaData headerMetaData = column.getHeaderMetaData().get(uiHeaderRowIndex);
-        return headerMetaData instanceof ScenarioHeaderMetaData && !((ScenarioHeaderMetaData) headerMetaData).isReadOnly();
+        final GridColumn.HeaderMetaData headerMetaData = column.getHeaderMetaData().get(uiHeaderRowIndex);
+        if (!(headerMetaData instanceof ScenarioHeaderMetaData)) {
+            return false;
+        }
+
+        final ScenarioHeaderMetaData scenarioHeaderMetaData = (ScenarioHeaderMetaData) headerMetaData;
+        if (scenarioHeaderMetaData.isEditingMode() || scenarioHeaderMetaData.isReadOnly()) {
+            return false;
+        }
+
+        if (!column.isInstanceAssigned() || !column.isEditableHeaders()) {
+            return false;
+        }
+
+        return scenarioHeaderMetaData.isInstanceHeader() || (scenarioHeaderMetaData.isPropertyHeader() && column.isPropertyAssigned());
     }
 
     public static EnableRightPanelEvent getEnableRightPanelEvent(final ScenarioGrid scenarioGrid,
@@ -135,12 +154,5 @@ public class ScenarioSimulationGridHeaderUtilities {
                 .stream()
                 .map(ExpressionElement::getStep)
                 .collect(Collectors.toList()));
-    }
-
-    public static boolean isHeaderEditable(BaseGridRendererHelper rendererHelper, ScenarioHeaderMetaData clickedScenarioHeaderMetadata, ScenarioGridColumn scenarioGridColumn) {
-        if (rendererHelper == null || clickedScenarioHeaderMetadata.isEditingMode() || !scenarioGridColumn.isInstanceAssigned() || !scenarioGridColumn.isEditableHeaders()) {
-            return false;
-        }
-        return (clickedScenarioHeaderMetadata.isInstanceHeader() || (clickedScenarioHeaderMetadata.isPropertyHeader() && scenarioGridColumn.isPropertyAssigned()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommandTest.java
@@ -26,7 +26,9 @@ import org.mockito.Mock;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -88,7 +90,7 @@ public abstract class AbstractScenarioSimulationCommandTest extends AbstractScen
         try {
             verify(command, times(1)).internalExecute(eq(scenarioSimulationContextLocal));
             assertNotEquals(status, command.restorableStatus);
-        } catch(Exception e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
     }
@@ -113,6 +115,16 @@ public abstract class AbstractScenarioSimulationCommandTest extends AbstractScen
             verify(scenarioGridPanelMock, times(1)).onResize();
             verify(scenarioGridPanelMock, times(1)).select();
             verify(scenarioGridPanelMock, times(1)).setFocus(eq(true));
+        }
+    }
+
+    @Test
+    public void commonExecutionNotUndoable() {
+        if (!command.isUndoable()) {
+            command.commonExecution(scenarioSimulationContextLocal);
+            verify(scenarioGridPanelMock, times(1)).onResize();
+            verify(scenarioGridPanelMock, times(1)).select();
+            verify(scenarioGridPanelMock, never()).setFocus(anyBoolean());
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -38,6 +38,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.Grid
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
@@ -232,6 +233,17 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
         assertThat(result).as("Instance and Property Assigned and Property selected").isTrue();
+    }
+
+    @Test
+    public void testHeaderMetadataInstanceOf() {
+        final ScenarioGridColumn invalidColumn = mockGridColumn(100,
+                                                                Collections.singletonList(mock(GridColumn.HeaderMetaData.class)));
+
+        assertThatThrownBy(() -> ScenarioSimulationGridHeaderUtilities.isEditableHeader(invalidColumn,
+                                                                                        0))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Header metadata has to be an instance of ScenarioHeaderMetaData");
     }
 
     private ScenarioGridColumn mockGridColumn(final double width) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -176,6 +176,64 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         Assertions.assertThat(event.isNotEqualsSearch()).isFalse();
     }
 
+    @Test
+    public void testIsHeaderEditableNorInstanceNorPropertyAssigned() {
+        final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
+
+        Assertions.assertThat(result).as("Nor Instance nor Property assigned").isFalse();
+    }
+
+    @Test
+    public void testIsHeaderEditableInstanceAssignedAndSelected() {
+        when(scenarioGridColumnOne.isInstanceAssigned()).thenReturn(true);
+
+        final ScenarioHeaderMetaData metaDataMock = (ScenarioHeaderMetaData) scenarioGridColumnOne.getHeaderMetaData().get(0);
+        when(metaDataMock.isInstanceHeader()).thenReturn(true);
+
+        final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
+
+        Assertions.assertThat(result).as("Instance Assigned and selected").isTrue();
+    }
+
+    @Test
+    public void testIsHeaderEditableInstanceAssignedButPropertySelected() {
+        when(scenarioGridColumnOne.isInstanceAssigned()).thenReturn(true);
+
+        final ScenarioHeaderMetaData metaDataMock = (ScenarioHeaderMetaData) scenarioGridColumnOne.getHeaderMetaData().get(0);
+        when(metaDataMock.isPropertyHeader()).thenReturn(true);
+
+        final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
+
+        Assertions.assertThat(result).as("Instance Assigned but Property selected").isFalse();
+    }
+
+    @Test
+    public void testIsHeaderEditableInstanceAndPropertyAssignedButNotSelected() {
+        when(scenarioGridColumnOne.isInstanceAssigned()).thenReturn(true);
+        when(scenarioGridColumnOne.isPropertyAssigned()).thenReturn(true);
+
+        final ScenarioHeaderMetaData metaDataMock = (ScenarioHeaderMetaData) scenarioGridColumnOne.getHeaderMetaData().get(0);
+        when(metaDataMock.isPropertyHeader()).thenReturn(false);
+        when(metaDataMock.isInstanceHeader()).thenReturn(false);
+
+        final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
+
+        Assertions.assertThat(result).as("Instance and Property Assigned but not selected").isFalse();
+    }
+
+    @Test
+    public void testIsHeaderEditableInstanceAndPropertyAssignedAndPropertySelected() {
+        when(scenarioGridColumnOne.isInstanceAssigned()).thenReturn(true);
+        when(scenarioGridColumnOne.isPropertyAssigned()).thenReturn(true);
+
+        final ScenarioHeaderMetaData metaDataMock = (ScenarioHeaderMetaData) scenarioGridColumnOne.getHeaderMetaData().get(0);
+        when(metaDataMock.isPropertyHeader()).thenReturn(true);
+
+        final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
+
+        Assertions.assertThat(result).as("Instance and Property Assigned and Property selected").isTrue();
+    }
+
     private ScenarioGridColumn mockGridColumn(final double width) {
         final List<GridColumn.HeaderMetaData> headerMetaData = new ArrayList<>();
         headerMetaData.add(mock(GridColumn.HeaderMetaData.class));
@@ -204,6 +262,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         when(informationHeader.getTitle()).thenReturn(columnTitle);
 
         when(uiColumn.getInformationHeaderMetaData()).thenReturn(informationHeader);
+        when(uiColumn.isEditableHeaders()).thenReturn(true);
 
         return uiColumn;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import org.assertj.core.api.Assertions;
 import org.drools.workbench.screens.scenariosimulation.client.AbstractScenarioSimulationTest;
 import org.drools.workbench.screens.scenariosimulation.client.events.EnableRightPanelEvent;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
@@ -38,6 +37,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRende
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
@@ -142,8 +142,8 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
                                                                                                            uiColumnIndex,
                                                                                                            columnGroup);
 
-        Assertions.assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
-        Assertions.assertThat(event.isNotEqualsSearch()).isTrue();
+        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
+        assertThat(event.isNotEqualsSearch()).isTrue();
     }
 
     @Test
@@ -156,8 +156,8 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
                                                                                                            uiColumnIndex,
                                                                                                            columnGroup);
 
-        Assertions.assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
-        Assertions.assertThat(event.isNotEqualsSearch()).isTrue();
+        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
+        assertThat(event.isNotEqualsSearch()).isTrue();
     }
 
     @Test
@@ -171,16 +171,16 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
                                                                                                            uiColumnIndex,
                                                                                                            columnGroup);
 
-        Assertions.assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle);
-        Assertions.assertThat(event.getPropertyName()).isNull();
-        Assertions.assertThat(event.isNotEqualsSearch()).isFalse();
+        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle);
+        assertThat(event.getPropertyName()).isNull();
+        assertThat(event.isNotEqualsSearch()).isFalse();
     }
 
     @Test
     public void testIsHeaderEditableNorInstanceNorPropertyAssigned() {
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
-        Assertions.assertThat(result).as("Nor Instance nor Property assigned").isFalse();
+        assertThat(result).as("Nor Instance nor Property assigned").isFalse();
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
 
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
-        Assertions.assertThat(result).as("Instance Assigned and selected").isTrue();
+        assertThat(result).as("Instance Assigned and selected").isTrue();
     }
 
     @Test
@@ -204,7 +204,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
 
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
-        Assertions.assertThat(result).as("Instance Assigned but Property selected").isFalse();
+        assertThat(result).as("Instance Assigned but Property selected").isFalse();
     }
 
     @Test
@@ -218,7 +218,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
 
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
-        Assertions.assertThat(result).as("Instance and Property Assigned but not selected").isFalse();
+        assertThat(result).as("Instance and Property Assigned but not selected").isFalse();
     }
 
     @Test
@@ -231,7 +231,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
 
         final boolean result = ScenarioSimulationGridHeaderUtilities.isEditableHeader(scenarioGridColumnOne, 0);
 
-        Assertions.assertThat(result).as("Instance and Property Assigned and Property selected").isTrue();
+        assertThat(result).as("Instance and Property Assigned and Property selected").isTrue();
     }
 
     private ScenarioGridColumn mockGridColumn(final double width) {


### PR DESCRIPTION
There were two issues:
- `AbstractScenarioSimulationCommand.commonExecution` previously re-enforced grid panel focusing for all commands. This focus was causing flushing `ScenarioHeaderTextAreaDOMElement` and this edit box was immediatelly discarded. Now `AbstractScenarioSimulationCommand.commonExecution` re-enforces grid panel focus, just for commands that change grid structure, for example append row, column, etc.
- `ScenarioSimulationGridHeaderUtilities` contained two methods for edit header precondition (`isEditableHeader` and `isHeaderEditable`) while the second one wasn't used at all but still contained valid logic. Now both are merged and used in `CommonEditHandler.manageHeaderLeftClick`

@kkufova @gitgabrio could you please take a look when you have a moment. Thank you in advance.