### PR TITLE
[DROOLS-3767] Reset "isEditing" status flag inside gridcell

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
@@ -120,11 +120,7 @@ public class CommonEditHandler {
         if (((ScenarioGridCell) cell).isEditingMode()) {
             return true;
         }
-        ((ScenarioGridCell) cell).setEditingMode((!scenarioGridColumn.isReadOnly()));
-        if (scenarioGridColumn.isReadOnly()) {
-            return false;
-        }
-        scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex);
+        ((ScenarioGridCell) cell).setEditingMode((!scenarioGridColumn.isReadOnly()) && scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex));
         return ((ScenarioGridCell) cell).isEditingMode();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/CommonEditHandler.java
@@ -120,7 +120,11 @@ public class CommonEditHandler {
         if (((ScenarioGridCell) cell).isEditingMode()) {
             return true;
         }
-        ((ScenarioGridCell) cell).setEditingMode((!scenarioGridColumn.isReadOnly()) && scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex));
+        ((ScenarioGridCell) cell).setEditingMode((!scenarioGridColumn.isReadOnly()));
+        if (scenarioGridColumn.isReadOnly()) {
+            return false;
+        }
+        scenarioGrid.startEditingCell(uiRowIndex, uiColumnIndex);
         return ((ScenarioGridCell) cell).isEditingMode();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridColumn.java
@@ -81,15 +81,20 @@ public class ScenarioGridColumn extends BaseGridColumn<String> {
     public void edit(GridCell<String> cell, GridBodyCellRenderContext context, Consumer<GridCellValue<String>> callback) {
         factory.attachDomElement(context,
                                  e -> {
-                                     final GridCell<String> stringGridCell = assertCell(cell);
-                                     if (e instanceof ScenarioCellTextAreaDOMElement) {
-                                         ((ScenarioCellTextAreaDOMElement) e).getWidget().setValue(stringGridCell.getValue().getValue());
-                                         ((ScenarioCellTextAreaDOMElement) e).setScenarioGridCell((ScenarioGridCell) cell);
-                                     } else if (e instanceof CollectionEditorDOMElement) {
-                                         CollectionEditorDOMElement collectionEditorDOMElement = (CollectionEditorDOMElement) e;
-                                         collectionEditorDOMElement.getWidget().setValue(stringGridCell.getValue().getValue());
-                                         ((ScenarioGridCell) cell).setListMap(collectionEditorDOMElement.getWidget().isListWidget());
-                                         collectionEditorDOMElement.setScenarioGridCell((ScenarioGridCell) cell);
+                                     try {
+                                         final GridCell<String> stringGridCell = assertCell(cell);
+                                         if (e instanceof ScenarioCellTextAreaDOMElement) {
+                                             ((ScenarioCellTextAreaDOMElement) e).getWidget().setValue(stringGridCell.getValue().getValue());
+                                             ((ScenarioCellTextAreaDOMElement) e).setScenarioGridCell((ScenarioGridCell) cell);
+                                         } else if (e instanceof CollectionEditorDOMElement) {
+                                             CollectionEditorDOMElement collectionEditorDOMElement = (CollectionEditorDOMElement) e;
+                                             collectionEditorDOMElement.getWidget().setValue(stringGridCell.getValue().getValue());
+                                             ((ScenarioGridCell) cell).setListMap(collectionEditorDOMElement.getWidget().isListWidget());
+                                             collectionEditorDOMElement.setScenarioGridCell((ScenarioGridCell) cell);
+                                         }
+                                     } catch (Exception ex) {
+                                         ((ScenarioGridCell) cell).setEditingMode(false);
+                                         throw ex;
                                      }
                                  },
                                  e -> {


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3767

To avoid the described (and wrong) behaviour, a try - catch block was added in `ScenarioGridModel.edit()` method. Then, is ANY execption is catched, the "isEditing" status is reset as required.

About tests: in my opinion the current tests are enough: I don't know how to test the case where an exception is thrown during the process, feel free to give me some advice.

@danielezonca @gitgabrio  @kkufova please review. 