### PR TITLE
[DROOLS-3730] Add support to DMN constraints on inputs (report input validation errors)

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
@@ -141,6 +141,11 @@
       <artifactId>kie-dmn-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-model</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/pom.xml
@@ -136,6 +136,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -150,11 +155,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-dmn-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -164,9 +164,9 @@ public class DMNTypeServiceImpl
     }
 
     private void visitType(DMNType type,
-                             boolean alreadyInCollection,
-                             ErrorHolder errorHolder,
-                             String path) {
+                           boolean alreadyInCollection,
+                           ErrorHolder errorHolder,
+                           String path) {
         if (type.isComposite()) {
             for (Map.Entry<String, DMNType> entry : type.getFields().entrySet()) {
                 String name = entry.getKey();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
@@ -151,8 +151,8 @@ public class ScenarioSimulationServiceImpl
 
     @Override
     public Map<Integer, Scenario> runScenario(final Path path,
-                                               final SimulationDescriptor simulationDescriptor,
-                                               final Map<Integer, Scenario> scenarioMap) {
+                                              final SimulationDescriptor simulationDescriptor,
+                                              final Map<Integer, Scenario> scenarioMap) {
         return scenarioRunnerService.runTest(user.getIdentifier(),
                                              path,
                                              simulationDescriptor,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/DMNScenarioExecutableBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/fluent/DMNScenarioExecutableBuilder.java
@@ -24,6 +24,8 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.RequestContext;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.dmn.core.compiler.RuntimeTypeCheckOption;
+import org.kie.dmn.core.impl.DMNRuntimeImpl;
 import org.kie.internal.builder.fluent.DMNRuntimeFluent;
 import org.kie.internal.builder.fluent.ExecutableBuilder;
 import org.kie.internal.command.RegistryContext;
@@ -42,7 +44,16 @@ public class DMNScenarioExecutableBuilder {
 
         dmnRuntimeFluent = executableBuilder.newApplicationContext(applicationName)
                 .setKieContainer(kieContainer)
-                .newDMNRuntime();
+                .newDMNRuntime()
+                .addCommand(context -> {
+                    RegistryContext registryContext = (RegistryContext) context;
+
+                    DMNRuntime dmnRuntime = registryContext.lookup(DMNRuntime.class);
+
+                    // force typeCheck to enable constraints
+                    ((DMNRuntimeImpl) dmnRuntime).setOption(new RuntimeTypeCheckOption(true));
+                    return dmnRuntime;
+                });
     }
 
     private DMNScenarioExecutableBuilder(KieContainer kieContainer) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/AbstractRunnerHelper.java
@@ -89,7 +89,7 @@ public abstract class AbstractRunnerHelper {
             Object bean = getDirectMapping(paramsForBean)
                     .orElseGet(() -> createObject(factIdentifier.getClassName(), paramsForBean, classLoader));
 
-            scenarioGiven.add(new ScenarioGiven(factIdentifier, bean));
+            scenarioGiven.add(new ScenarioGiven(factIdentifier, bean, entry.getValue()));
         }
 
         return scenarioGiven;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelper.java
@@ -98,7 +98,7 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
     }
 
     /**
-     * Iterate over DMNMessages to report errors on input data (validation errors)
+     * Iterate over <code>DMNMessage</code>s to report errors on input data (validation errors)
      * @param messages
      * @param givens
      */
@@ -113,7 +113,7 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
     }
 
     /**
-     * Return the name of the input node that failed if exists (a DMNMessage can have no source)
+     * Return the name of the input node that failed if exists (a <code>DMNMessage</code> can have no source)
      * @param message
      * @return
      */
@@ -127,7 +127,7 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
     }
 
     /**
-     * Look for an input node with the required name and set the error status
+     * Look for a <code>ScenarioGiven</code> mapped to the given <b>name</b> and set its errore status to <code>true</code>
      * @param name
      * @param givens
      */

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelper.java
@@ -97,16 +97,26 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
         }
     }
 
+    /**
+     * Iterate over DMNMessages to report errors on input data (validation errors)
+     * @param messages
+     * @param givens
+     */
     protected void verifyInputConstraints(List<DMNMessage> messages, List<ScenarioGiven> givens) {
 
         messages.stream()
-                // filter out invalid messages (only errors with sourceId)
+                // filter out invalid messages (only errors with sourceReference)
                 .filter(message -> Message.Level.ERROR.equals(message.getLevel()) &&
                         message.getSourceReference() != null)
                 .flatMap(this::retrieveInputNodeName)
-                .forEach(name -> applyErrorIfUsed(name, givens));
+                .forEach(name -> reportErrorIfUsed(name, givens));
     }
 
+    /**
+     * Return the name of the input node that failed if exists (a DMNMessage can have no source)
+     * @param message
+     * @return
+     */
     protected Stream<String> retrieveInputNodeName(DMNMessage message) {
         Object sourceReference = message.getSourceReference();
         if (sourceReference instanceof NamedElement &&
@@ -116,7 +126,12 @@ public class DMNScenarioRunnerHelper extends AbstractRunnerHelper {
         return Stream.empty();
     }
 
-    protected void applyErrorIfUsed(String name, List<ScenarioGiven> givens) {
+    /**
+     * Look for an input node with the required name and set the error status
+     * @param name
+     * @param givens
+     */
+    protected void reportErrorIfUsed(String name, List<ScenarioGiven> givens) {
         for (ScenarioGiven given : givens) {
             if (name.equals(given.getFactIdentifier().getName())) {
                 given.getFactMappingValues().forEach(fmv -> fmv.setError(true));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/model/ScenarioGiven.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/model/ScenarioGiven.java
@@ -16,16 +16,27 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server.runner.model;
 
-import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
+import java.util.List;
 
+import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingValue;
+
+/**
+ * This class wrap an entire given fact. It contains factIdentifier, instance of the
+ * bean and list of values (columns) used to create it
+ */
 public class ScenarioGiven {
 
     private final FactIdentifier factIdentifier;
     private final Object value;
+    private final List<FactMappingValue> factMappingValues;
 
-    public ScenarioGiven(FactIdentifier factIdentifier, Object value) {
+    public ScenarioGiven(FactIdentifier factIdentifier,
+                         Object value,
+                         List<FactMappingValue> factMappingValues) {
         this.factIdentifier = factIdentifier;
         this.value = value;
+        this.factMappingValues = factMappingValues;
     }
 
     public FactIdentifier getFactIdentifier() {
@@ -34,5 +45,9 @@ public class ScenarioGiven {
 
     public Object getValue() {
         return value;
+    }
+
+    public List<FactMappingValue> getFactMappingValues() {
+        return factMappingValues;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
@@ -241,7 +241,7 @@ public class DMNScenarioRunnerHelperTest {
     }
 
     @Test
-    public void applyErrorIfUsed() {
+    public void reportErrorIfUsed() {
         String TEST = "TEST";
         FactIdentifier factIdentifier = FactIdentifier.create(TEST, String.class.getCanonicalName());
         FactMappingValue fmv = new FactMappingValue(factIdentifier, mock(ExpressionIdentifier.class), "");

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
@@ -215,14 +215,14 @@ public class DMNScenarioRunnerHelperTest {
         runnerHelper.verifyInputConstraints(dmnMessages, Collections.emptyList());
 
         verify(runnerHelper, never()).retrieveInputNodeName(any());
-        verify(runnerHelper, never()).applyErrorIfUsed(any(), any());
+        verify(runnerHelper, never()).reportErrorIfUsed(any(), any());
 
         when(dmnMessageMock.getSourceReference()).thenReturn(namedElementMock);
         when(dmnMessageMock.getLevel()).thenReturn(Message.Level.ERROR);
         runnerHelper.verifyInputConstraints(dmnMessages, Collections.emptyList());
 
         verify(runnerHelper, times(1)).retrieveInputNodeName(any());
-        verify(runnerHelper, times(1)).applyErrorIfUsed(any(), any());
+        verify(runnerHelper, times(1)).reportErrorIfUsed(any(), any());
     }
 
     @Test
@@ -250,11 +250,11 @@ public class DMNScenarioRunnerHelperTest {
 
         List<ScenarioGiven> scenarioGivens = singletonList(new ScenarioGiven(factIdentifier, "", factMappingValues));
 
-        runnerHelper.applyErrorIfUsed("noMatch", scenarioGivens);
+        runnerHelper.reportErrorIfUsed("noMatch", scenarioGivens);
 
         assertFalse(fmv.isError());
 
-        runnerHelper.applyErrorIfUsed(TEST, scenarioGivens);
+        runnerHelper.reportErrorIfUsed(TEST, scenarioGivens);
 
         assertTrue(fmv.isError());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/DMNScenarioRunnerHelperTest.java
@@ -28,6 +28,7 @@ import org.drools.workbench.screens.scenariosimulation.backend.server.expression
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Dispute;
 import org.drools.workbench.screens.scenariosimulation.backend.server.model.Person;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioExpect;
+import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioGiven;
 import org.drools.workbench.screens.scenariosimulation.backend.server.runner.model.ScenarioRunnerData;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
@@ -39,19 +40,28 @@ import org.drools.workbench.screens.scenariosimulation.model.Simulation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.api.builder.Message;
 import org.kie.api.runtime.RequestContext;
 import org.kie.dmn.api.core.DMNDecisionResult;
+import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.model.api.NamedElement;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -72,8 +82,8 @@ public class DMNScenarioRunnerHelperTest {
     private static final String TEST_DESCRIPTION = "Test description";
     private static final ClassLoader classLoader = RuleScenarioRunnerHelperTest.class.getClassLoader();
     private static final ExpressionEvaluator expressionEvaluator = new DMNFeelExpressionEvaluator(classLoader);
-    private static final DMNScenarioRunnerHelper runnerHelper = new DMNScenarioRunnerHelper();
 
+    private DMNScenarioRunnerHelper runnerHelper;
     private Simulation simulation;
     private FactIdentifier personFactIdentifier;
     private ExpressionIdentifier firstNameGivenExpressionIdentifier;
@@ -92,6 +102,8 @@ public class DMNScenarioRunnerHelperTest {
 
     @Before
     public void init() {
+        runnerHelper = spy(new DMNScenarioRunnerHelper());
+
         simulation = new Simulation();
         personFactIdentifier = FactIdentifier.create("Fact 1", Person.class.getCanonicalName());
         firstNameGivenExpressionIdentifier = ExpressionIdentifier.create("First Name Given", FactMappingType.GIVEN);
@@ -191,5 +203,59 @@ public class DMNScenarioRunnerHelperTest {
         Map<String, Object> creator = (Map<String, Object>) object.get("creator");
         assertEquals("TestName", creator.get("name"));
         assertEquals("TestSurname", creator.get("surname"));
+    }
+
+    @Test
+    public void verifyInputConstraints() {
+        DMNMessage dmnMessageMock = mock(DMNMessage.class);
+        NamedElement namedElementMock = mock(NamedElement.class);
+        when(namedElementMock.getName()).thenReturn("");
+
+        List<DMNMessage> dmnMessages = singletonList(dmnMessageMock);
+        runnerHelper.verifyInputConstraints(dmnMessages, Collections.emptyList());
+
+        verify(runnerHelper, never()).retrieveInputNodeName(any());
+        verify(runnerHelper, never()).applyErrorIfUsed(any(), any());
+
+        when(dmnMessageMock.getSourceReference()).thenReturn(namedElementMock);
+        when(dmnMessageMock.getLevel()).thenReturn(Message.Level.ERROR);
+        runnerHelper.verifyInputConstraints(dmnMessages, Collections.emptyList());
+
+        verify(runnerHelper, times(1)).retrieveInputNodeName(any());
+        verify(runnerHelper, times(1)).applyErrorIfUsed(any(), any());
+    }
+
+    @Test
+    public void retrieveInputNodeName() {
+        final String INPUT_NAME = "INPUT_NAME";
+        DMNMessage dmnMessageMock = mock(DMNMessage.class);
+        NamedElement nodeMock = mock(NamedElement.class);
+        when(dmnMessageMock.getSourceReference()).thenReturn(nodeMock);
+        when(nodeMock.getName()).thenReturn(INPUT_NAME);
+        List<String> result = runnerHelper.retrieveInputNodeName(dmnMessageMock).collect(toList());
+        assertEquals(1, result.size());
+        assertEquals(INPUT_NAME, result.get(0));
+
+        result = runnerHelper.retrieveInputNodeName(mock(DMNMessage.class)).collect(toList());
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void applyErrorIfUsed() {
+        String TEST = "TEST";
+        FactIdentifier factIdentifier = FactIdentifier.create(TEST, String.class.getCanonicalName());
+        FactMappingValue fmv = new FactMappingValue(factIdentifier, mock(ExpressionIdentifier.class), "");
+
+        List<FactMappingValue> factMappingValues = singletonList(fmv);
+
+        List<ScenarioGiven> scenarioGivens = singletonList(new ScenarioGiven(factIdentifier, "", factMappingValues));
+
+        runnerHelper.applyErrorIfUsed("noMatch", scenarioGivens);
+
+        assertFalse(fmv.isError());
+
+        runnerHelper.applyErrorIfUsed(TEST, scenarioGivens);
+
+        assertTrue(fmv.isError());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/runner/RuleScenarioRunnerHelperTest.java
@@ -216,7 +216,7 @@ public class RuleScenarioRunnerHelperTest {
 
         Person person = new Person();
         person.setFirstName("ANOTHER STRING");
-        ScenarioGiven newInput = new ScenarioGiven(personFactIdentifier, person);
+        ScenarioGiven newInput = new ScenarioGiven(personFactIdentifier, person, Collections.emptyList());
 
         List<ScenarioResult> scenario3Results = runnerHelper.getScenarioResultsFromGivenFacts(simulation.getSimulationDescriptor(), scenario1Outputs, newInput, expressionEvaluator);
         assertTrue(scenario1Outputs.get(0).getExpectedResult().get(0).isError());


### PR DESCRIPTION
@kkufova @gitgabrio @Rikkola 

How to test:
- Import a dmn file with an input constraint like [DMNString.dmn.txt](https://github.com/kiegroup/drools-wb/files/3005478/DMNString.dmn.txt) (remove `.txt`)
- Create a scesim file on it
- Put an invalid input (accepted values are only `"Example1"`, `"Example2"` and `"Example3"`)
- Run

https://issues.jboss.org/browse/DROOLS-3730
