### PR TITLE
DROOLS-1797 : Incorrect V&V results when operator is filled in the row

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/AnalyzerConfigurationMock.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/AnalyzerConfigurationMock.java
@@ -35,6 +35,12 @@ public class AnalyzerConfigurationMock
                       return DateTimeFormat.getFormat("dd-MMM-yyyy")
                               .format(dateValue);
                   }
+
+                  @Override
+                  public Date parse(String dateValue) {
+                      return DateTimeFormat.getFormat("dd-MMM-yyyy")
+                              .parse(dateValue);
+                  }
               },
               new UUIDKeyProvider() {
 

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/AnalyzerBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/AnalyzerBuilder.java
@@ -83,6 +83,12 @@ public class AnalyzerBuilder {
                             return DateTimeFormat.getFormat(initialize.getDateFormat())
                                     .format(dateValue);
                         }
+
+                        @Override
+                        public Date parse(String dateValue) {
+                            return DateTimeFormat.getFormat(initialize.getDateFormat())
+                                    .parse(dateValue);
+                        }
                     },
                     new UUIDKeyProvider() {
                         @Override

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/DTableUpdateManager.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/DTableUpdateManager.java
@@ -102,6 +102,7 @@ public class DTableUpdateManager {
                                                              coordinate);
         } else {
             return new RegularCellUpdateManager(index,
+                                                configuration,
                                                 model,
                                                 coordinate);
         }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BRLConditionBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/BRLConditionBuilder.java
@@ -53,8 +53,10 @@ public class BRLConditionBuilder {
 
         try {
             return new BRLCondition(getColumn(),
-                                    new ValuesResolver(utils,
-                                                       columnIndex,
+                                    new ValuesResolver(configuration,
+                                                       new UtilsTypeResolver(utils,
+                                                                             columnIndex,
+                                                                             conditionColumn),
                                                        conditionColumn,
                                                        realCellValue).getValues(),
                                     configuration);

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/TypeResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/TypeResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.services.verifier.plugin.client.builders;
+
+import java.util.Optional;
+
+public interface TypeResolver {
+
+    String getType(final Optional<String> operatorFromCell)
+            throws ValueResolveException;
+}

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/Utils.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,34 @@
  */
 package org.drools.workbench.services.verifier.plugin.client.builders;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+
 import org.drools.verifier.core.configuration.AnalyzerConfiguration;
 import org.drools.verifier.core.index.model.Field;
 import org.drools.verifier.core.index.model.ObjectField;
 import org.drools.verifier.core.index.model.ObjectType;
+import org.drools.verifier.core.relations.Operator;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryCol;
 
 public class Utils {
+
+    public static Optional<String> findOperatorFromCell(final DTCellValue52 realCellValue) {
+        String value = realCellValue.getStringValue();
+
+        if (value != null) {
+            String[] split = value.trim().split(" ");
+            if (split.length >= 2) {
+                if (!Operator.resolve(split[0]).equals(Operator.NONE)) {
+                    return Optional.of(split[0]);
+                }
+            }
+        }
+        return Optional.empty();
+    }
 
     public static ObjectField resolveObjectField(final ObjectType objectType,
                                                  final String fieldType,
@@ -53,6 +72,66 @@ public class Utils {
             return ((LimitedEntryCol) config52).getValue();
         } else {
             return visibleCellValue;
+        }
+    }
+
+    public static Short tryShort(String stringValue) {
+        try {
+            return new Short(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static Long tryLong(String stringValue) {
+        try {
+            return new Long(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static Double tryDouble(String stringValue) {
+        try {
+            return new Double(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static BigInteger tryBigInteger(String stringValue) {
+        try {
+            return new BigInteger(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static BigDecimal tryBigDecimal(String stringValue) {
+        try {
+            return new BigDecimal(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static Integer tryInteger(String stringValue) {
+        try {
+            return new Integer(stringValue);
+        } catch (final NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    public static Boolean tryBoolean(String stringValue) {
+        if (stringValue == null) {
+            return null;
+        } else if (stringValue.toLowerCase().equals("true")) {
+            return true;
+        } else if (stringValue.toLowerCase().equals("false")) {
+            return false;
+        } else {
+            return null;
         }
     }
 }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/UtilsTypeResolver.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/main/java/org/drools/workbench/services/verifier/plugin/client/builders/UtilsTypeResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.services.verifier.plugin.client.builders;
+
+import java.util.Optional;
+
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+
+public class UtilsTypeResolver
+        implements TypeResolver {
+
+    private final int columnIndex;
+    private final ConditionCol52 conditionColumn;
+    private VerifierColumnUtilities utils;
+
+    public UtilsTypeResolver(final VerifierColumnUtilities utils,
+                             final int columnIndex,
+                             final ConditionCol52 conditionColumn) {
+        this.utils = utils;
+        this.columnIndex = columnIndex;
+        this.conditionColumn = conditionColumn;
+    }
+
+    public String getType(final Optional<String> operatorFromCell)
+            throws ValueResolveException {
+        try {
+            if (operatorFromCell.isPresent()) {
+                return conditionColumn.getFieldType();
+            }
+
+            final String type = utils.getType(conditionColumn,
+                                              columnIndex);
+
+            return type;
+        } catch (final Exception e) {
+            throw new ValueResolveException("Failed to get type for " + ToString.toString(conditionColumn) + " columnIndex: " + columnIndex,
+                                            e);
+        }
+    }
+}

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/AnalyzerUpdateTestBase.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/AnalyzerUpdateTestBase.java
@@ -264,6 +264,12 @@ public abstract class AnalyzerUpdateTestBase {
                              column,
                              value);
                 }
+
+                public void toValue(final Boolean value) {
+                    setValue(row,
+                             column,
+                             value);
+                }
             }
         }
     }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/NoOperatorTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/NoOperatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.services.verifier.plugin.client;
+
+import java.util.Set;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.verifier.api.reporting.CheckType;
+import org.drools.verifier.api.reporting.Issue;
+import org.drools.verifier.api.reporting.Severity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.project.datamodel.oracle.DataType;
+
+import static org.drools.workbench.services.verifier.plugin.client.testutil.TestUtil.assertContains;
+import static org.drools.workbench.services.verifier.plugin.client.testutil.TestUtil.assertDoesNotContain;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NoOperatorTest
+        extends AnalyzerUpdateTestBase {
+
+    @Test
+    public void detectCellOperators() throws
+            Exception {
+        table52 = analyzerProvider.makeAnalyser()
+                .withNoOperatorConditionIntegerColumn("a",
+                                                      "Person",
+                                                      "age")
+                .withNoOperatorConditionIntegerColumn("a",
+                                                      "Person",
+                                                      "age")
+                .withPersonApprovedActionSetField()
+                .withData(DataBuilderProvider
+                                  .row("< 0", ">= 10", true)
+                                  .row(">= 20", ">= 20", true)
+                                  .end())
+                .buildTable();
+
+        fireUpAnalyzer();
+
+        final Set<Issue> analysisReport = analyzerProvider.getAnalysisReport();
+        assertContains(analysisReport,
+                       CheckType.IMPOSSIBLE_MATCH,
+                       Severity.ERROR,
+                       1);
+        assertDoesNotContain(CheckType.IMPOSSIBLE_MATCH,
+                             analysisReport,
+                             2);
+        assertContains(analysisReport,
+                       CheckType.REDUNDANT_CONDITIONS_TITLE,
+                       Severity.NOTE,
+                       2);
+    }
+
+    @Test
+    public void detectCellOperatorsOnUpdate() throws Exception {
+        table52 = analyzerProvider.makeAnalyser()
+                .withNoOperatorConditionIntegerColumn("a",
+                                                      "Person",
+                                                      "age")
+                .withNoOperatorConditionIntegerColumn("a",
+                                                      "Person",
+                                                      "age")
+                .withPersonApprovedActionSetField()
+                .buildTable();
+
+        fireUpAnalyzer();
+
+        appendRow(DataType.DataTypes.STRING,
+                  DataType.DataTypes.STRING,
+                  DataType.DataTypes.BOOLEAN);
+
+        setCoordinate().row(0).column(2).toValue(">= 20");
+        setCoordinate().row(0).column(3).toValue(">= 20");
+        setCoordinate().row(0).column(4).toValue(Boolean.TRUE);
+
+        final Set<Issue> analysisReport = analyzerProvider.getAnalysisReport();
+        assertDoesNotContain(CheckType.IMPOSSIBLE_MATCH,
+                             analysisReport);
+        assertContains(analysisReport,
+                       CheckType.REDUNDANT_CONDITIONS_TITLE,
+                       Severity.NOTE,
+                       1);
+    }
+}

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/AnalyzerBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/AnalyzerBuilder.java
@@ -82,6 +82,15 @@ public class AnalyzerBuilder
     }
 
     @Override
+    public AnalyzerBuilder withNoOperatorConditionIntegerColumn(final String boundName,
+                                                                final String factType,
+                                                                final String field) {
+        return (AnalyzerBuilder) super.withNoOperatorConditionIntegerColumn(boundName,
+                                                                            factType,
+                                                                            field);
+    }
+
+    @Override
     public AnalyzerBuilder withConditionIntegerColumn(final String boundName,
                                                       final String factType,
                                                       final String field,

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/DateTimeFormatProviderMock.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/DateTimeFormatProviderMock.java
@@ -29,4 +29,10 @@ public class DateTimeFormatProviderMock
         return DateTimeFormat.getFormat("dd-MMM-yyyy")
                 .format(dateValue);
     }
+
+    @Override
+    public Date parse(String dateValue) {
+        return DateTimeFormat.getFormat("dd-MMM-yyyy")
+                .parse(dateValue);
+    }
 }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/ExtendedGuidedDecisionTableBuilder.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-guided-decision-table-adapter/src/test/java/org/drools/workbench/services/verifier/plugin/client/testutil/ExtendedGuidedDecisionTableBuilder.java
@@ -63,6 +63,36 @@ public class ExtendedGuidedDecisionTableBuilder
         return brlConditionColumn;
     }
 
+    public static ActionSetFieldCol52 createActionSetField(String boundName,
+                                                           String factField,
+                                                           String typeNumericInteger) {
+        ActionSetFieldCol52 column = new ActionSetFieldCol52();
+        column.setBoundName(boundName);
+        column.setFactField(factField);
+        column.setType(typeNumericInteger);
+        return column;
+    }
+
+    public static BRLActionColumn createBRLActionColumn() {
+        final BRLActionColumn brlActionColumn = new BRLActionColumn();
+        final ArrayList<IAction> definition = new ArrayList<IAction>();
+        definition.add(mock(IAction.class));
+        brlActionColumn.setDefinition(definition);
+        return brlActionColumn;
+    }
+
+    public static ActionInsertFactCol52 createActionInsertFact(String factType,
+                                                               String boundName,
+                                                               String factField,
+                                                               String type) {
+        ActionInsertFactCol52 column = new ActionInsertFactCol52();
+        column.setFactType(factType);
+        column.setBoundName(boundName);
+        column.setFactField(factField);
+        column.setType(type);
+        return column;
+    }
+
     public AbstractDecisionTableBuilder withActionBRLFragment() {
 
         final BRLActionColumn brlActionColumn = createBRLActionColumn();
@@ -126,6 +156,24 @@ public class ExtendedGuidedDecisionTableBuilder
         con1.setFactField(field);
         con1.setHeader("Applicant age");
         con1.setOperator(operator);
+        pattern.getChildColumns().add(con1);
+
+        addPattern(pattern);
+
+        return this;
+    }
+
+    public ExtendedGuidedDecisionTableBuilder withNoOperatorConditionIntegerColumn(String boundName,
+                                                                                   String factType,
+                                                                                   String field) {
+        Pattern52 pattern = findPattern(boundName, factType);
+
+        ConditionCol52 con1 = new ConditionCol52();
+        con1.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        con1.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        con1.setFactField(field);
+        con1.setHeader("Applicant age");
+        con1.setOperator("");
         pattern.getChildColumns().add(con1);
 
         addPattern(pattern);
@@ -216,41 +264,11 @@ public class ExtendedGuidedDecisionTableBuilder
         return this;
     }
 
-    public static ActionSetFieldCol52 createActionSetField(String boundName,
-                                                           String factField,
-                                                           String typeNumericInteger) {
-        ActionSetFieldCol52 column = new ActionSetFieldCol52();
-        column.setBoundName(boundName);
-        column.setFactField(factField);
-        column.setType(typeNumericInteger);
-        return column;
-    }
-
     public ExtendedGuidedDecisionTableBuilder withConditionBRLColumn() {
         final BRLConditionColumn column = createBRLConditionColumn();
 
         table.getConditions().add(column);
 
         return this;
-    }
-
-    public static BRLActionColumn createBRLActionColumn() {
-        final BRLActionColumn brlActionColumn = new BRLActionColumn();
-        final ArrayList<IAction> definition = new ArrayList<IAction>();
-        definition.add(mock(IAction.class));
-        brlActionColumn.setDefinition(definition);
-        return brlActionColumn;
-    }
-
-    public static ActionInsertFactCol52 createActionInsertFact(String factType,
-                                                               String boundName,
-                                                               String factField,
-                                                               String type) {
-        ActionInsertFactCol52 column = new ActionInsertFactCol52();
-        column.setFactType(factType);
-        column.setBoundName(boundName);
-        column.setFactField(factField);
-        column.setType(type);
-        return column;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-1797

@jomarko @manstis I would appreciate reviews on these two PRs.

I touched several locations just to get the info about field type. 
Main change is that it is possible to detect the value and operator from the cell.
Another change is that updates should now go more smoothly for existing edits since update manager now uses ValuesResolver. The updates also support changing the condition operator.

Part of a bundle:
https://github.com/kiegroup/drools/pull/2289
https://github.com/kiegroup/drools-wb/pull/1104