### PR TITLE
[DROOLS-3818] Assign a complex type object to a property with modified label leads to NPE

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSetHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSetHeaderCommand.java
@@ -89,25 +89,25 @@ public abstract class AbstractSetHeaderCommand extends AbstractScenarioSimulatio
      * Sets the editable headers on a given <code>ScenarioGridColumn</code> and returns a <code>FactIdentifier</code>.
      * @param context
      * @param selectedColumn
-     * @param className
+     * @param aliasName
      * @param canonicalClassName
      * @return
      */
-    protected FactIdentifier setEditableHeadersAndGetFactIdentifier(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn, String className, String canonicalClassName) {
+    protected FactIdentifier setEditableHeadersAndGetFactIdentifier(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn, String aliasName, String canonicalClassName) {
         final ScenarioSimulationModel.Type simulationModelType = context.getModel().getSimulation().get().getSimulationDescriptor().getType();
         selectedColumn.setEditableHeaders(!simulationModelType.equals(ScenarioSimulationModel.Type.DMN));
-        String nameToUseForCreation = simulationModelType.equals(ScenarioSimulationModel.Type.DMN) ? className : selectedColumn.getInformationHeaderMetaData().getColumnId();
-        return getFactIdentifierByColumnTitle(className, context).orElse(FactIdentifier.create(nameToUseForCreation, canonicalClassName));
+        String nameToUseForCreation = simulationModelType.equals(ScenarioSimulationModel.Type.DMN) ? aliasName : selectedColumn.getInformationHeaderMetaData().getColumnId();
+        return getFactIdentifierByColumnTitle(aliasName, context).orElse(FactIdentifier.create(nameToUseForCreation, canonicalClassName));
     }
 
     /**
      * Sets the metadata for an instance header on a given <code>ScenarioGridColumn</code>.
      * @param scenarioGridColumn
-     * @param className
+     * @param aliasName
      * @param factIdentifier
      */
-    protected void setInstanceHeaderMetaData(ScenarioGridColumn scenarioGridColumn, String className, FactIdentifier factIdentifier) {
-        scenarioGridColumn.getInformationHeaderMetaData().setTitle(className);
+    protected void setInstanceHeaderMetaData(ScenarioGridColumn scenarioGridColumn, String aliasName, FactIdentifier factIdentifier) {
+        scenarioGridColumn.getInformationHeaderMetaData().setTitle(aliasName);
         scenarioGridColumn.setInstanceAssigned(true);
         scenarioGridColumn.setFactIdentifier(factIdentifier);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
@@ -45,7 +45,8 @@ public class SetPropertyHeaderCommand extends AbstractSetHeaderCommand {
     protected void executeIfSelectedColumn(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn) {
         int columnIndex = context.getModel().getColumns().indexOf(selectedColumn);
         String value = context.getStatus().getValue();
-        String aliasName = value.split("\\.")[0];
+        final List<String> valuesElements = Arrays.asList(value.split("\\."));
+        String aliasName = valuesElements.get(0);
         String canonicalClassName = getFullPackage(context) + aliasName;
         FactIdentifier factIdentifier = setEditableHeadersAndGetFactIdentifier(context, selectedColumn, aliasName, canonicalClassName);
         String className = factIdentifier.getClassName();
@@ -68,14 +69,14 @@ public class SetPropertyHeaderCommand extends AbstractSetHeaderCommand {
                                                 propertyClass, context.getStatus().isKeepData());
         if (ScenarioSimulationSharedUtils.isCollection(propertyClass)) {
             final SortedMap<String, FactModelTree> dataObjectFieldsMap = context.getDataObjectFieldsMap();
-            final List<String> elements = Arrays.asList(className.split("\\."));
-            final FactModelTree nestedFactModelTree = navigateComplexObject(dataObjectFieldsMap.get(elements.get(elements.size() - 1)),
-                                                                            elements,
+            final List<String> classNameElements = Arrays.asList(className.split("\\."));
+            final FactModelTree nestedFactModelTree = navigateComplexObject(dataObjectFieldsMap.get(classNameElements.get(classNameElements.size() - 1)),
+                                                                            classNameElements,
                                                                             dataObjectFieldsMap);
 
             selectedColumn.setFactory(context.getCollectionEditorSingletonDOMElementFactory());
             final FactMapping factMappingByIndex = context.getModel().getSimulation().get().getSimulationDescriptor().getFactMappingByIndex(columnIndex);
-            factMappingByIndex.setGenericTypes(nestedFactModelTree.getGenericTypeInfo(elements.get(elements.size() - 1)));
+            factMappingByIndex.setGenericTypes(nestedFactModelTree.getGenericTypeInfo(valuesElements.get(valuesElements.size() - 1)));
         } else {
             selectedColumn.setFactory(context.getScenarioCellTextAreaSingletonDOMElementFactory());
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
@@ -45,16 +45,17 @@ public class SetPropertyHeaderCommand extends AbstractSetHeaderCommand {
     protected void executeIfSelectedColumn(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn) {
         int columnIndex = context.getModel().getColumns().indexOf(selectedColumn);
         String value = context.getStatus().getValue();
-        String className = value.split("\\.")[0];
-        String canonicalClassName = getFullPackage(context) + className;
-        FactIdentifier factIdentifier = setEditableHeadersAndGetFactIdentifier(context, selectedColumn, className, canonicalClassName);
+        String aliasName = value.split("\\.")[0];
+        String canonicalClassName = getFullPackage(context) + aliasName;
+        FactIdentifier factIdentifier = setEditableHeadersAndGetFactIdentifier(context, selectedColumn, aliasName, canonicalClassName);
+        String className = factIdentifier.getClassName();
         String propertyHeaderTitle = getPropertyHeaderTitle(context, factIdentifier);
         final GridData.Range instanceLimits = context.getModel().getInstanceLimits(columnIndex);
         IntStream.range(instanceLimits.getMinRowIndex(), instanceLimits.getMaxRowIndex() + 1)
                 .forEach(index -> {
                     final ScenarioGridColumn scenarioGridColumn = (ScenarioGridColumn) context.getModel().getColumns().get(index);
                     if (!scenarioGridColumn.isInstanceAssigned()) { // We have not defined the instance, yet
-                        setInstanceHeaderMetaData(scenarioGridColumn, className, factIdentifier);
+                        setInstanceHeaderMetaData(scenarioGridColumn, aliasName, factIdentifier);
                     }
                 });
         selectedColumn.getPropertyHeaderMetaData().setColumnGroup(getPropertyMetaDataGroup(selectedColumn.getInformationHeaderMetaData().getColumnGroup()));
@@ -67,8 +68,8 @@ public class SetPropertyHeaderCommand extends AbstractSetHeaderCommand {
                                                 propertyClass, context.getStatus().isKeepData());
         if (ScenarioSimulationSharedUtils.isCollection(propertyClass)) {
             final SortedMap<String, FactModelTree> dataObjectFieldsMap = context.getDataObjectFieldsMap();
-            final List<String> elements = Arrays.asList(context.getStatus().getValue().split("\\."));
-            final FactModelTree nestedFactModelTree = navigateComplexObject(dataObjectFieldsMap.get(className),
+            final List<String> elements = Arrays.asList(className.split("\\."));
+            final FactModelTree nestedFactModelTree = navigateComplexObject(dataObjectFieldsMap.get(elements.get(elements.size() - 1)),
                                                                             elements,
                                                                             dataObjectFieldsMap);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -165,6 +165,8 @@ public abstract class AbstractScenarioSimulationTest {
 
     protected final String VALUE_CLASS_NAME = String.class.getName();
 
+    protected final String LIST_CLASS_NAME = List.class.getName();
+
     protected final String FACT_IDENTIFIER_NAME = "FACT_IDENTIFIER_NAME";
 
     protected final FactMappingType factMappingType = FactMappingType.valueOf(COLUMN_GROUP);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -38,10 +39,13 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -53,6 +57,8 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
 
     @Mock
     private List<GridColumn<?>> gridColumnsMock;
+    @Mock
+    protected FactModelTree factModelTreeMock;
 
     @Before
     public void setup() {
@@ -70,6 +76,11 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
         scenarioSimulationContextLocal.getStatus().setValueClassName(VALUE_CLASS_NAME);
         assertTrue(command.isUndoable());
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
+
+        Map<String, String> simplePropertiesMock = mock(SortedMap.class);
+        when(factModelTreeMock.getSimpleProperties()).thenReturn(simplePropertiesMock);
+        when(factModelTreeMock.getExpandableProperties()).thenReturn(mock(SortedMap.class));
+        when(dataObjectFieldsMapMock.get(anyString())).thenReturn(factModelTreeMock);
     }
 
     @Test
@@ -111,6 +122,17 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
         verify(propertyHeaderMetaDataMock, times(1)).setTitle(VALUE);
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
         verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), eq(gridColumnMock), eq(VALUE), eq(VALUE_CLASS_NAME), eq(true));
+    }
+
+    @Test
+    public void executeWithPropertyAsCollection() {
+        scenarioSimulationContextLocal.getStatus().setValueClassName(LIST_CLASS_NAME);
+        command.execute(scenarioSimulationContextLocal);
+        verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
+        verify(propertyHeaderMetaDataMock, times(1)).setTitle(VALUE);
+        verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
+        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), eq(gridColumnMock), eq(VALUE), eq(LIST_CLASS_NAME), anyBoolean());
+        verify((SetPropertyHeaderCommand) command, times(1)).navigateComplexObject(eq(factModelTreeMock), any(List.class), eq(scenarioSimulationContextLocal.getDataObjectFieldsMap()));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -39,7 +39,6 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -54,6 +53,8 @@ import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationCommandTest {
+
+    final protected String FULL_CLASSNAME_CREATED = FULL_PACKAGE + "." + VALUE;
 
     @Mock
     private List<GridColumn<?>> gridColumnsMock;
@@ -132,7 +133,8 @@ public class SetPropertyHeaderCommandTest extends AbstractScenarioSimulationComm
         verify(propertyHeaderMetaDataMock, times(1)).setTitle(VALUE);
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
         verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), eq(gridColumnMock), eq(VALUE), eq(LIST_CLASS_NAME), anyBoolean());
-        verify((SetPropertyHeaderCommand) command, times(1)).navigateComplexObject(eq(factModelTreeMock), any(List.class), eq(scenarioSimulationContextLocal.getDataObjectFieldsMap()));
+        List<String> elements = Arrays.asList((FULL_CLASSNAME_CREATED).split("\\."));
+        verify((SetPropertyHeaderCommand) command, times(1)).navigateComplexObject(eq(factModelTreeMock), eq(elements), eq(scenarioSimulationContextLocal.getDataObjectFieldsMap()));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3818

Steps to reproduce it:
- Open a new scenario asset
- Assign a instance (eg . Author)
- Rename it (eg. Author_test)
- Try to assign a Complex type as a property (eg. a Collection)
- A NPE is thown.

Basically, the issue was in SetPropertyHeaderCommand.java lines 71/72, where it tried to FactModelTree using the aliasName (column title) instead of the fact classname.
Some variable has been renamed to avoid confusion beetween aliasName and className.

@kkufova @gitgabrio @danielezonca please test it and review.