### PR TITLE
Drools 3862 If an instance alias contains ".", it is not possible to set a property mapping

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactIdentifier.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/FactIdentifier.java
@@ -48,6 +48,14 @@ public class FactIdentifier {
         return className;
     }
 
+    public String getClassNameWithoutPackage() {
+        if (className.contains(".")) {
+            return className.substring(className.lastIndexOf(".")+1);
+        } else {
+            return className;
+        }
+    }
+
     public static FactIdentifier create(String name, String className) {
         return new FactIdentifier(name, className);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
@@ -211,9 +211,9 @@ public class ScenarioSimulationContext {
         protected List<String> propertyNameElements;
 
         /**
-         * The <code>List</code> of elements of a header cell
+         * The <b>content</b> of a header cell
          */
-        protected List<String> headerCellElements;
+        protected String headerCellValue;
 
         /**
          * Disable the <b>TestTools</b>
@@ -369,12 +369,12 @@ public class ScenarioSimulationContext {
             this.gridCellValue = gridCellValue;
         }
 
-        public List<String> getHeaderCellElements() {
-            return headerCellElements;
+        public String getHeaderCellValue() {
+            return headerCellValue;
         }
 
-        public void setHeaderCellElements(List<String> headerCellElements) {
-            this.headerCellElements = headerCellElements;
+        public void setHeaderCellValue(String headerCellValue) {
+            this.headerCellValue = headerCellValue;
         }
 
         public Simulation getSimulation() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
@@ -188,7 +188,7 @@ public class ScenarioSimulationContext {
         protected String valueClassName;
         protected boolean keepData;
 
-        protected String cellValue;
+        protected String gridCellValue;
 
         protected int rowIndex;
 
@@ -209,6 +209,11 @@ public class ScenarioSimulationContext {
          * The <code>List</code> to <b>eventually</b> use to select the property in the test tools  panel
          */
         protected List<String> propertyNameElements;
+
+        /**
+         * The <code>List</code> of elements of a header cell
+         */
+        protected List<String> headerCellElements;
 
         /**
          * Disable the <b>TestTools</b>
@@ -356,12 +361,20 @@ public class ScenarioSimulationContext {
             this.openDock = openDock;
         }
 
-        public String getCellValue() {
-            return cellValue;
+        public String getGridCellValue() {
+            return gridCellValue;
         }
 
-        public void setCellValue(String cellValue) {
-            this.cellValue = cellValue;
+        public void setGridCellValue(String gridCellValue) {
+            this.gridCellValue = gridCellValue;
+        }
+
+        public List<String> getHeaderCellElements() {
+            return headerCellElements;
+        }
+
+        public void setHeaderCellElements(List<String> headerCellElements) {
+            this.headerCellElements = headerCellElements;
         }
 
         public Simulation getSimulation() {
@@ -384,7 +397,7 @@ public class ScenarioSimulationContext {
             toReturn.value = this.value;
             toReturn.valueClassName = this.valueClassName;
             toReturn.keepData = this.keepData;
-            toReturn.cellValue = this.cellValue;
+            toReturn.gridCellValue = this.gridCellValue;
             toReturn.rowIndex = this.rowIndex;
             toReturn.simulation = this.simulation.cloneSimulation();
             return toReturn;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
@@ -15,6 +15,7 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
+import java.util.List;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -205,9 +206,9 @@ public class ScenarioSimulationContext {
         protected boolean notEqualsSearch = false;
 
         /**
-         * The string to <b>eventually</b> use to select the property in the right panel
+         * The <code>List</code> to <b>eventually</b> use to select the property in the test tools  panel
          */
-        protected String propertyName;
+        protected List<String> propertyNameElements;
 
         /**
          * Disable the <b>TestTools</b>
@@ -331,12 +332,12 @@ public class ScenarioSimulationContext {
             this.notEqualsSearch = notEqualsSearch;
         }
 
-        public String getPropertyName() {
-            return propertyName;
+        public List<String> getPropertyNameElements() {
+            return propertyNameElements;
         }
 
-        public void setPropertyName(String propertyName) {
-            this.propertyName = propertyName;
+        public void setPropertyNameElements(List<String> propertyNameElements) {
+            this.propertyNameElements = propertyNameElements;
         }
 
         public boolean isDisable() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -339,7 +339,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(SetHeaderCellValueEvent event) {
         context.getStatus().setRowIndex(event.getRowIndex());
         context.getStatus().setColumnIndex(event.getColumnIndex());
-        context.getStatus().setHeaderCellElements(event.getHeaderCellElements());
+        context.getStatus().setHeaderCellValue(event.getHeaderCellValue());
         commonExecution(context, new SetHeaderCellValueCommand(event.isInstanceHeader(), event.isPropertyHeader()));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -305,7 +305,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(SetGridCellValueEvent event) {
         context.getStatus().setRowIndex(event.getRowIndex());
         context.getStatus().setColumnIndex(event.getColumnIndex());
-        context.getStatus().setCellValue(event.getCellValue());
+        context.getStatus().setGridCellValue(event.getCellValue());
         commonExecution(context, new SetGridCellValueCommand());
     }
 
@@ -313,7 +313,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(SetHeaderCellValueEvent event) {
         context.getStatus().setRowIndex(event.getRowIndex());
         context.getStatus().setColumnIndex(event.getColumnIndex());
-        context.getStatus().setCellValue(event.getCellValue());
+        context.getStatus().setHeaderCellElements(event.getHeaderCellElements());
         commonExecution(context, new SetHeaderCellValueCommand(event.isInstanceHeader(), event.isPropertyHeader()));
     }
 
@@ -347,16 +347,17 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
         if (context.getModel().getSelectedColumn() == null) {
             return;
         }
-        if (context.getModel().isAlreadyAssignedProperty(event.getValue())) {
-            onEvent(new ScenarioNotificationEvent("Property \"" + event.getValue() + "\" already assigned", NotificationEvent.NotificationType.ERROR));
+        if (context.getModel().isAlreadyAssignedProperty(event.getPropertyNameElements())) {
+            String value = String.join(".", event.getPropertyNameElements());
+            onEvent(new ScenarioNotificationEvent("Property \"" + value + "\" already assigned", NotificationEvent.NotificationType.ERROR));
             return;
         }
         context.getStatus().setFullPackage(event.getFullPackage());
-        context.getStatus().setValue(event.getValue());
+        context.getStatus().setPropertyNameElements(event.getPropertyNameElements());
         context.getStatus().setValueClassName(event.getValueClassName());
         if (context.getModel().isSelectedColumnEmpty()) {
             commonExecution(context, new SetPropertyHeaderCommand());
-        } else if (context.getModel().isSameSelectedColumnProperty(event.getValue())) {
+        } else if (context.getModel().isSameSelectedColumnProperty(event.getPropertyNameElements())) {
             return;
         } else if (context.getModel().isSameSelectedColumnType(event.getValueClassName())) {
             org.uberfire.mvp.Command okDeleteCommand = () -> {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -238,7 +238,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     @Override
     public void onEvent(EnableTestToolsEvent event) {
         context.getStatus().setFilterTerm(event.getFilterTerm());
-        context.getStatus().setPropertyName(event.getPropertyName());
+        context.getStatus().setPropertyNameElements(event.getPropertyNameElements());
         context.getStatus().setNotEqualsSearch(event.isNotEqualsSearch());
         commonExecution(context, new EnableTestToolsCommand());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
@@ -15,7 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -159,19 +158,17 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioSimu
      * It assigns a property to the selected <code>ScenarioGridColumn</code>
      * @param context It contains the <b>Context</b> inside which the commands will be executed
      * @param selectedColumn The selected <code>ScenarioGridColumn</code> where the command was launched
-     * @param value It contains the path instance_name.property.name (eg. Author.isAlive)
+     * @param propertyNameElements The <code>List</code> with the path instance_name.property.name (eg. Author.isAlive)
      * @param propertyClass it contains the full classname of the instance (eg. com.Author)
      * @param propertyHeaderTitle The title to assign to this property. Can be null, in this case it will be retrieved used <code>getPropertyHeaderTitle()</code> method
      */
-    protected void setPropertyHeader(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn, String value, String propertyClass, Optional<String> propertyHeaderTitle) {
+    protected void setPropertyHeader(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn, List<String> propertyNameElements, String propertyClass, Optional<String> propertyHeaderTitle) {
         int columnIndex = context.getModel().getColumns().indexOf(selectedColumn);
-        String fullPropertyPath = context.getStatus().getValue();
-        final List<String> fullPropertyPathElements = Arrays.asList(fullPropertyPath.split("\\."));
-        String aliasName = fullPropertyPathElements.get(0);
+        String aliasName = propertyNameElements.get(0);
         String canonicalClassName = getFullPackage(context) + aliasName;
         final FactIdentifier factIdentifier = setEditableHeadersAndGetFactIdentifier(context, selectedColumn, aliasName, canonicalClassName);
         String className = factIdentifier.getClassName();
-        String propertyTitle = propertyHeaderTitle.isPresent() ? propertyHeaderTitle.get() : getPropertyHeaderTitle(context, value, factIdentifier);
+        String propertyTitle = propertyHeaderTitle.isPresent() ? propertyHeaderTitle.get() : getPropertyHeaderTitle(context, String.join(".", propertyNameElements), factIdentifier);
         final GridData.Range instanceLimits = context.getModel().getInstanceLimits(columnIndex);
         IntStream.range(instanceLimits.getMinRowIndex(), instanceLimits.getMaxRowIndex() + 1)
                 .forEach(index -> {
@@ -185,10 +182,10 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioSimu
         selectedColumn.setPropertyAssigned(true);
         context.getModel().updateColumnProperty(columnIndex,
                                                 selectedColumn,
-                                                fullPropertyPath,
+                                                propertyNameElements,
                                                 propertyClass, context.getStatus().isKeepData());
         if (ScenarioSimulationSharedUtils.isCollection(propertyClass)) {
-            manageCollectionProperty(context, selectedColumn, className, columnIndex, fullPropertyPathElements);
+            manageCollectionProperty(context, selectedColumn, className, columnIndex, propertyNameElements);
         } else {
             selectedColumn.setFactory(context.getScenarioCellTextAreaSingletonDOMElementFactory());
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommand.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -54,11 +56,13 @@ public class DuplicateInstanceCommand extends AbstractSelectedColumnCommand {
                             int originalColumnIndex = context.getModel().getColumns().indexOf(originalColumn);
                             int createdColumnIndex = context.getModel().getColumns().indexOf(createdColumn);
                             final FactMapping originalFactMapping = context.getModel().getSimulation().get().getSimulationDescriptor().getFactMappingByIndex(originalColumnIndex);
-                            /*  Rebuilt the value, which is composed by: factName.property . The property MUST be the original property name */
-                            String value = alias + "." + originalFactMapping.getExpressionElements().stream().skip(1).map(ExpressionElement::getStep).collect(Collectors.joining("."));
+                            /*  Rebuilt propertyNameElements, which is composed by: factName.property . The property MUST be the original property name */
+                            List<String> propertyNameElements = new ArrayList();
+                            propertyNameElements.add(alias);
+                            propertyNameElements.addAll(originalFactMapping.getExpressionElementsWithoutClass().stream().map(ExpressionElement::getStep).collect(Collectors.toList()));
                             setPropertyHeader(context,
                                               createdColumn,
-                                              value,
+                                              propertyNameElements,
                                               originalFactMapping.getClassName(),
                                               Optional.of(originalColumn.getPropertyHeaderMetaData().getTitle()));
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommand.java
@@ -40,7 +40,7 @@ public class EnableTestToolsCommand extends AbstractScenarioSimulationCommand {
             if (status.getFilterTerm() == null) {
                 context.getTestToolsPresenter().onEnableEditorTab();
             } else {
-                context.getTestToolsPresenter().onEnableEditorTab(status.getFilterTerm(), status.getPropertyName(), status.isNotEqualsSearch());
+                context.getTestToolsPresenter().onEnableEditorTab(status.getFilterTerm(), status.getPropertyNameElements(), status.isNotEqualsSearch());
             }
         }
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
@@ -36,7 +36,7 @@ public class SetGridCellValueCommand extends AbstractScenarioSimulationCommand {
         final ScenarioSimulationContext.Status status = context.getStatus();
         context.getModel().setCellValue(status.getRowIndex(),
                                         status.getColumnIndex(),
-                                        new ScenarioGridCellValue(status.getCellValue(), ScenarioSimulationEditorConstants.INSTANCE.insertValue()));
+                                        new ScenarioGridCellValue(status.getGridCellValue(), ScenarioSimulationEditorConstants.INSTANCE.insertValue()));
         context.getModel().resetErrors(status.getRowIndex());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.enterprise.context.Dependent;
@@ -45,23 +47,25 @@ public class SetHeaderCellValueCommand extends AbstractScenarioSimulationCommand
     @Override
     protected void internalExecute(ScenarioSimulationContext context) throws Exception {
         final ScenarioSimulationContext.Status status = context.getStatus();
-        List<String> nameElements = status.getHeaderCellElements();
+        String headerCellValue = status.getHeaderCellValue();
+        List<String> nameElements = Collections.unmodifiableList(Arrays.asList(headerCellValue.split("\\.")));
         boolean valid = false;
         if (isInstanceHeader) {
-            valid = validateInstanceHeader(context, nameElements, status.getColumnIndex());
+            valid = validateInstanceHeader(context, headerCellValue, status.getColumnIndex());
         }  else if (isPropertyHeader) {
             valid = validatePropertyHeader(context, nameElements, status.getColumnIndex());
         }
         if (valid) {
-            context.getModel().updateHeader(status.getColumnIndex(), status.getRowIndex(), nameElements);
+            context.getModel().updateHeader(status.getColumnIndex(), status.getRowIndex(), headerCellValue);
         } else {
-            throw new Exception("Name \"" + String.join(".", nameElements) + "\" cannot be used");
+            throw new Exception("Name \"" + String.join(".", headerCellValue) + "\" cannot be used");
         }
     }
 
-    protected boolean validateInstanceHeader(ScenarioSimulationContext context, List<String> instanceNameElements, int columnIndex) {
+    protected boolean validateInstanceHeader(ScenarioSimulationContext context, String headerCellValue, int columnIndex) {
+        List<String> instanceNameElements = Collections.unmodifiableList(Arrays.asList(headerCellValue.split("\\.")));
         boolean isADataType = instanceNameElements.size() == 1 && context.getDataObjectFieldsMap().containsKey(instanceNameElements.get(0));
-        return context.getModel().validateInstanceHeaderUpdate(instanceNameElements, columnIndex, isADataType);
+        return context.getModel().validateInstanceHeaderUpdate(headerCellValue, columnIndex, isADataType);
     }
 
     protected boolean validatePropertyHeader(ScenarioSimulationContext context, List<String> propertyNameElements, int columnIndex) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
@@ -48,12 +48,11 @@ public class SetHeaderCellValueCommand extends AbstractScenarioSimulationCommand
     protected void internalExecute(ScenarioSimulationContext context) throws Exception {
         final ScenarioSimulationContext.Status status = context.getStatus();
         String headerCellValue = status.getHeaderCellValue();
-        List<String> nameElements = Collections.unmodifiableList(Arrays.asList(headerCellValue.split("\\.")));
         boolean valid = false;
         if (isInstanceHeader) {
             valid = validateInstanceHeader(context, headerCellValue, status.getColumnIndex());
         }  else if (isPropertyHeader) {
-            valid = validatePropertyHeader(context, nameElements, status.getColumnIndex());
+            valid = validatePropertyHeader(context, headerCellValue, status.getColumnIndex());
         }
         if (valid) {
             context.getModel().updateHeader(status.getColumnIndex(), status.getRowIndex(), headerCellValue);
@@ -68,12 +67,13 @@ public class SetHeaderCellValueCommand extends AbstractScenarioSimulationCommand
         return context.getModel().validateInstanceHeaderUpdate(headerCellValue, columnIndex, isADataType);
     }
 
-    protected boolean validatePropertyHeader(ScenarioSimulationContext context, List<String> propertyNameElements, int columnIndex) {
+    protected boolean validatePropertyHeader(ScenarioSimulationContext context, String headerCellValue, int columnIndex) {
+        List<String> propertyNameElements = Collections.unmodifiableList(Arrays.asList(headerCellValue.split("\\.")));
         final FactMapping factMappingByIndex = context.getStatus().getSimulation().getSimulationDescriptor().getFactMappingByIndex(columnIndex);
         String className = factMappingByIndex.getFactIdentifier().getClassNameWithoutPackage();
         final FactModelTree factModelTree = context.getDataObjectFieldsMap().get(className);
         boolean isPropertyType = factModelTree != null && recursivelyFindIsPropertyType(context, factModelTree, propertyNameElements);
-        return context.getModel().validatePropertyHeaderUpdate(propertyNameElements, columnIndex, isPropertyType);
+        return context.getModel().validatePropertyHeaderUpdate(headerCellValue, columnIndex, isPropertyType);
     }
 
     protected boolean recursivelyFindIsPropertyType(ScenarioSimulationContext context, FactModelTree factModelTree, List<String> propertyNameElements) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommand.java
@@ -58,7 +58,7 @@ public class SetHeaderCellValueCommand extends AbstractScenarioSimulationCommand
 
     protected void validateInstanceHeader(ScenarioSimulationContext context, String headerCellValue, int columnIndex) throws Exception {
         List<String> instanceNameElements = Collections.unmodifiableList(Arrays.asList(headerCellValue.split("\\.")));
-        boolean isADataType = instanceNameElements.size() == 1 && context.getDataObjectFieldsMap().containsKey(instanceNameElements.get(0));
+        boolean isADataType = !headerCellValue.endsWith(".") && instanceNameElements.size() == 1 && context.getDataObjectFieldsMap().containsKey(instanceNameElements.get(0));
         context.getModel().validateInstanceHeaderUpdate(headerCellValue, columnIndex, isADataType);
     }
 
@@ -67,7 +67,7 @@ public class SetHeaderCellValueCommand extends AbstractScenarioSimulationCommand
         final FactMapping factMappingByIndex = context.getStatus().getSimulation().getSimulationDescriptor().getFactMappingByIndex(columnIndex);
         String className = factMappingByIndex.getFactIdentifier().getClassNameWithoutPackage();
         final FactModelTree factModelTree = context.getDataObjectFieldsMap().get(className);
-        boolean isPropertyType = factModelTree != null && recursivelyFindIsPropertyType(context, factModelTree, propertyNameElements);
+        boolean isPropertyType = !headerCellValue.endsWith(".") && factModelTree != null && recursivelyFindIsPropertyType(context, factModelTree, propertyNameElements);
         context.getModel().validatePropertyHeaderUpdate(headerCellValue, columnIndex, isPropertyType);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommand.java
@@ -32,7 +32,7 @@ public class SetPropertyHeaderCommand extends AbstractSelectedColumnCommand {
     protected void executeIfSelectedColumn(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn) {
         setPropertyHeader(context,
                           selectedColumn,
-                          context.getStatus().getValue(),
+                          context.getStatus().getPropertyNameElements(),
                           context.getStatus().getValueClassName(),
                           Optional.empty());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -16,9 +16,6 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.domelements;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 import org.drools.workbench.screens.scenariosimulation.client.events.ReloadTestToolsEvent;
@@ -62,8 +59,7 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
         try {
             boolean isInstanceHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.INSTANCE);
             boolean isPropertyHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.PROPERTY);
-            List<String> nameElements = Collections.unmodifiableList(Arrays.asList(value.split("\\.")));
-            ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetHeaderCellValueEvent(rowIndex, columnIndex, nameElements, isInstanceHeader, isPropertyHeader));
+            ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetHeaderCellValueEvent(rowIndex, columnIndex, value, isInstanceHeader, isPropertyHeader));
             ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new ReloadTestToolsEvent(true));
         } catch (Exception e) {
             throw new IllegalArgumentException(new StringBuilder().append("Impossible to update header (").append(rowIndex)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.domelements;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -61,7 +62,7 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
         try {
             boolean isInstanceHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.INSTANCE);
             boolean isPropertyHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.PROPERTY);
-            List<String> nameElements = Arrays.asList(value.split("\\."));
+            List<String> nameElements = Collections.unmodifiableList(Arrays.asList(value.split("\\.")));
             ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetHeaderCellValueEvent(rowIndex, columnIndex, nameElements, isInstanceHeader, isPropertyHeader));
             ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new ReloadTestToolsEvent(true));
         } catch (Exception e) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.domelements;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.drools.workbench.screens.scenariosimulation.client.events.ReloadTestToolsEvent;
@@ -59,7 +61,8 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
         try {
             boolean isInstanceHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.INSTANCE);
             boolean isPropertyHeader = scenarioHeaderMetaData != null && Objects.equals(scenarioHeaderMetaData.getMetadataType(), ScenarioHeaderMetaData.MetadataType.PROPERTY);
-            ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetHeaderCellValueEvent(rowIndex, columnIndex, value, isInstanceHeader, isPropertyHeader));
+            List<String> nameElements = Arrays.asList(value.split("\\."));
+            ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new SetHeaderCellValueEvent(rowIndex, columnIndex, nameElements, isInstanceHeader, isPropertyHeader));
             ((ScenarioGrid) gridWidget).getEventBus().fireEvent(new ReloadTestToolsEvent(true));
         } catch (Exception e) {
             throw new IllegalArgumentException(new StringBuilder().append("Impossible to update header (").append(rowIndex)

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.editor.strategies;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -113,7 +114,7 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
                                             if  (propertyNameElements.isEmpty()) {
                                                 propertyNameElements.add("value");
                                             }
-                                            return propertyNameElements;
+                                            return Collections.unmodifiableList(propertyNameElements);
                                         })
                                         .collect(Collectors.toList()));
             });

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -168,10 +168,7 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
                     .stream()
                     .filter(factMapping -> !Objects.equals(FactMappingType.OTHER, factMapping.getExpressionIdentifier().getType()))
                     .forEach(factMapping -> {
-                        String dataObjectName = factMapping.getFactIdentifier().getClassName();
-                        if (dataObjectName.contains(".")) {
-                            dataObjectName = dataObjectName.substring(dataObjectName.lastIndexOf(".") + 1);
-                        }
+                        String dataObjectName = factMapping.getFactIdentifier().getClassNameWithoutPackage();
                         final String instanceName = factMapping.getFactAlias();
                         if (!instanceName.equals(dataObjectName)) {
                             final FactModelTree factModelTree = sourceMap.get(dataObjectName);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -72,8 +72,8 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
      * @param scenarioGridModel
      * @return
      */
-    protected Map<String, List<String>> getPropertiesToHide(ScenarioGridModel scenarioGridModel) {
-        final Map<String, List<String>> toReturn = new HashMap<>();
+    protected Map<String, List<List<String>>> getPropertiesToHide(ScenarioGridModel scenarioGridModel) {
+        final Map<String, List<List<String>>> toReturn = new HashMap<>();
         final ScenarioGridColumn selectedColumn = (ScenarioGridColumn) scenarioGridModel.getSelectedColumn();
         if (selectedColumn != null) {
             if (selectedColumn.isInstanceAssigned()) {
@@ -96,8 +96,8 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
      * @param scenarioGridModel
      * @return
      */
-    protected List<String> getPropertiesToHide(ScenarioGridColumn selectedColumn, ScenarioGridModel scenarioGridModel) {
-        List<String> toReturn = new ArrayList<>();
+    protected List<List<String>> getPropertiesToHide(ScenarioGridColumn selectedColumn, ScenarioGridModel scenarioGridModel) {
+        List<List<String>> toReturn = new ArrayList<>();
         if (!selectedColumn.isPropertyAssigned()) {
             scenarioGridModel.getSimulation().ifPresent(simulation -> {
                 final SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
@@ -106,12 +106,14 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
                                         .filter(ScenarioGridColumn::isPropertyAssigned)
                                         .map(instanceColumn -> scenarioGridModel.getColumns().indexOf(instanceColumn))
                                         .map(columnIndex -> {
-                                            String propertyString = String.join(".", simulationDescriptor.getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
+                                            List<String> propertyNameElements =  simulationDescriptor.getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
                                                     .stream()
                                                     .map(ExpressionElement::getStep)
-                                                    .collect(Collectors.toList()));
-                                            propertyString = propertyString.isEmpty() ? "value" : propertyString;
-                                            return propertyString;
+                                                    .collect(Collectors.toList());
+                                            if  (propertyNameElements.isEmpty()) {
+                                                propertyNameElements.add("value");
+                                            }
+                                            return propertyNameElements;
                                         })
                                         .collect(Collectors.toList()));
             });
@@ -124,7 +126,7 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
      */
     protected void storeData(final FactModelTuple factModelTuple, final TestToolsView.Presenter testToolsPresenter, final ScenarioGridModel scenarioGridModel) {
         // Instantiate a map of already assigned properties
-        final Map<String, List<String>> propertiesToHide = getPropertiesToHide(scenarioGridModel);
+        final Map<String, List<List<String>>> propertiesToHide = getPropertiesToHide(scenarioGridModel);
         final SortedMap<String, FactModelTree> visibleFacts = factModelTuple.getVisibleFacts();
         final Map<Boolean, List<Map.Entry<String, FactModelTree>>> partitionBy = visibleFacts.entrySet().stream()
                 .collect(Collectors.partitioningBy(stringFactModelTreeEntry -> stringFactModelTreeEntry.getValue().isSimple()));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/EnableTestToolsEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/EnableTestToolsEvent.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.events;
 
+import java.util.List;
+
 import com.google.gwt.event.shared.GwtEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.EnableTestToolsEventHandler;
 
@@ -37,9 +39,9 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
     private final boolean notEqualsSearch;
 
     /**
-     * The string to <b>eventually</b> use to select the property in the test tools  panel
+     * The <code>List</code> to <b>eventually</b> use to select the property in the test tools  panel
      */
-    private final String propertyName;
+    private final List<String> propertyNameElements;
 
     /**
      * Fire this event to show all the first-level data models <b>enabled</b> (i.e. <b>double-clickable</b> to map to an <i>instance</i> header/column)
@@ -48,7 +50,7 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
     public EnableTestToolsEvent() {
         filterTerm = null;
         notEqualsSearch = false;
-        propertyName = null;
+        propertyNameElements = null;
     }
 
     /**
@@ -60,7 +62,7 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
     public EnableTestToolsEvent(String filterTerm) {
         this.filterTerm = filterTerm;
         notEqualsSearch = false;
-        propertyName = null;
+        propertyNameElements = null;
     }
 
     /**
@@ -68,12 +70,12 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
      * and their properties <b>enabled</b> (i.e. <b>double-clickable</b> to map to a <i>property</i> header/column below the belonging data model instance one).
      * It show only results <b>equals</b> to filterTerm
      * @param filterTerm
-     * @param propertyName
+     * @param propertyNameElements The <code>List</code> to <b>eventually</b> use to select the property in the test tools  panel
      */
-    public EnableTestToolsEvent(String filterTerm, String propertyName) {
+    public EnableTestToolsEvent(String filterTerm, List<String> propertyNameElements) {
         this.filterTerm = filterTerm;
         notEqualsSearch = false;
-        this.propertyName = propertyName;
+        this.propertyNameElements = propertyNameElements;
     }
 
     /**
@@ -85,7 +87,7 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
     public EnableTestToolsEvent(String filterTerm, boolean notEqualsSearch) {
         this.filterTerm = filterTerm;
         this.notEqualsSearch = notEqualsSearch;
-        propertyName = null;
+        propertyNameElements = null;
     }
 
     @Override
@@ -101,8 +103,8 @@ public class EnableTestToolsEvent extends GwtEvent<EnableTestToolsEventHandler> 
         return notEqualsSearch;
     }
 
-    public String getPropertyName() {
-        return propertyName;
+    public List<String> getPropertyNameElements() {
+        return propertyNameElements;
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetHeaderCellValueEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetHeaderCellValueEvent.java
@@ -15,8 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.events;
 
-import java.util.List;
-
 import com.google.gwt.event.shared.GwtEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetHeaderCellValueEventHandler;
 
@@ -29,7 +27,7 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
 
     private int rowIndex;
     private int columnIndex;
-    private List<String> headerCellElements;
+    private String headerCellValue;
     private final boolean isInstanceHeader;
     private final boolean isPropertyHeader;
 
@@ -37,13 +35,13 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
      *
      * @param rowIndex
      * @param columnIndex
-     * @param headerCellElements
+     * @param headerCellValue
      * @param isPropertyHeader set to <code>true</code> if the edited cell is inside the header
      */
-    public SetHeaderCellValueEvent(int rowIndex, int columnIndex, List<String> headerCellElements, boolean isInstanceHeader, boolean isPropertyHeader) {
+    public SetHeaderCellValueEvent(int rowIndex, int columnIndex, String headerCellValue, boolean isInstanceHeader, boolean isPropertyHeader) {
         this.rowIndex = rowIndex;
         this.columnIndex = columnIndex;
-        this.headerCellElements = headerCellElements;
+        this.headerCellValue = headerCellValue;
         this.isInstanceHeader = isInstanceHeader;
         this.isPropertyHeader = isPropertyHeader;
     }
@@ -61,8 +59,8 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
         return columnIndex;
     }
 
-    public List<String> getHeaderCellElements() {
-        return headerCellElements;
+    public String getHeaderCellValue() {
+        return headerCellValue;
     }
 
     public boolean isInstanceHeader() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetHeaderCellValueEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetHeaderCellValueEvent.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.events;
 
+import java.util.List;
+
 import com.google.gwt.event.shared.GwtEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetHeaderCellValueEventHandler;
 
@@ -27,7 +29,7 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
 
     private int rowIndex;
     private int columnIndex;
-    private String cellValue;
+    private List<String> headerCellElements;
     private final boolean isInstanceHeader;
     private final boolean isPropertyHeader;
 
@@ -35,13 +37,13 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
      *
      * @param rowIndex
      * @param columnIndex
-     * @param cellValue
+     * @param headerCellElements
      * @param isPropertyHeader set to <code>true</code> if the edited cell is inside the header
      */
-    public SetHeaderCellValueEvent(int rowIndex, int columnIndex, String cellValue, boolean isInstanceHeader, boolean isPropertyHeader) {
+    public SetHeaderCellValueEvent(int rowIndex, int columnIndex, List<String> headerCellElements, boolean isInstanceHeader, boolean isPropertyHeader) {
         this.rowIndex = rowIndex;
         this.columnIndex = columnIndex;
-        this.cellValue = cellValue;
+        this.headerCellElements = headerCellElements;
         this.isInstanceHeader = isInstanceHeader;
         this.isPropertyHeader = isPropertyHeader;
     }
@@ -59,8 +61,8 @@ public class SetHeaderCellValueEvent extends GwtEvent<SetHeaderCellValueEventHan
         return columnIndex;
     }
 
-    public String getCellValue() {
-        return cellValue;
+    public List<String> getHeaderCellElements() {
+        return headerCellElements;
     }
 
     public boolean isInstanceHeader() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetPropertyHeaderEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/SetPropertyHeaderEvent.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.events;
 
+import java.util.List;
+
 import com.google.gwt.event.shared.GwtEvent;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.SetPropertyHeaderEventHandler;
 
@@ -26,19 +28,19 @@ public class SetPropertyHeaderEvent extends GwtEvent<SetPropertyHeaderEventHandl
     public static Type<SetPropertyHeaderEventHandler> TYPE = new Type<>();
 
     private String fullPackage;
-    private String value;
+    private List<String> propertyNameElements;
     private String valueClassName;
 
     /**
      * Use this constructor to modify the <i>property</i> level header
      *
      * @param fullPackage
-     * @param value
+     * @param propertyNameElements
      * @param valueClassName
      */
-    public SetPropertyHeaderEvent(String fullPackage, String value, String valueClassName) {
+    public SetPropertyHeaderEvent(String fullPackage, List<String> propertyNameElements, String valueClassName) {
         this.fullPackage = fullPackage;
-        this.value = value;
+        this.propertyNameElements = propertyNameElements;
         this.valueClassName = valueClassName;
     }
 
@@ -51,8 +53,8 @@ public class SetPropertyHeaderEvent extends GwtEvent<SetPropertyHeaderEventHandl
         return fullPackage;
     }
 
-    public String getValue() {
-        return value;
+    public List<String> getPropertyNameElements() {
+        return propertyNameElements;
     }
 
     public String getValueClassName() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -56,6 +56,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.workbench.events.NotificationEvent;
 
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias;
+
 public class ScenarioGridModel extends BaseGridData {
 
     public static final int HEADER_ROW_COUNT = 3;
@@ -289,15 +291,7 @@ public class ScenarioGridModel extends BaseGridData {
         }
         replaceColumn(columnIndex, column);
         final FactMapping factMappingByIndex = simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex);
-        String actualClassName = factMappingByIndex.getFactIdentifier().getClassName();
-        if (actualClassName.contains(".")) {
-            actualClassName = actualClassName.substring(actualClassName.lastIndexOf(".") + 1);
-        }
-        List<String> propertyNameElementsClone = new ArrayList<>(); // We have to keep the original List unmodified
-        propertyNameElementsClone.addAll(propertyNameElements);
-        if (propertyNameElementsClone.size() > 1) {
-            propertyNameElementsClone.set(0, actualClassName);
-        }
+        List<String> propertyNameElementsClone = getPropertyNameElementsWithoutAlias(propertyNameElements, factMappingByIndex.getFactIdentifier());
         // This is because the value starts with the alias of the fact; i.e. it may be Book.name but also Bookkk.name,
         // while the first element of ExpressionElements is always the class name
         IntStream.range(0, propertyNameElementsClone.size())

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -717,8 +717,9 @@ public class ScenarioGridModel extends BaseGridData {
         return (isADataType && isSameInstanceHeader && isUniqueInstanceHeaderTitle(instanceHeaderCellValue, columnIndex)) || (!isADataType && isUniqueInstanceHeaderTitle(instanceHeaderCellValue, columnIndex));
     }
 
-    public boolean validatePropertyHeaderUpdate(List<String> propertyNameElements, int columnIndex, boolean isPropertyType) {
-        return (isPropertyType && isSamePropertyHeader(columnIndex, propertyNameElements) && isUniquePropertyHeaderTitle(propertyNameElements, columnIndex)) || (!isPropertyType && !isAlreadyAssignedProperty(columnIndex, propertyNameElements) && isUniquePropertyHeaderTitle(propertyNameElements, columnIndex));
+    public boolean validatePropertyHeaderUpdate(String propertyHeaderCellValue, int columnIndex, boolean isPropertyType) {
+        List<String> propertyNameElements = Collections.unmodifiableList(Arrays.asList(propertyHeaderCellValue.split("\\.")));
+        return (isPropertyType && isSamePropertyHeader(columnIndex, propertyNameElements) && isUniquePropertyHeaderTitle(propertyHeaderCellValue, columnIndex)) || (!isPropertyType && !isAlreadyAssignedProperty(columnIndex, propertyNameElements) && isUniquePropertyHeaderTitle(propertyHeaderCellValue, columnIndex));
     }
 
     /**
@@ -861,12 +862,11 @@ public class ScenarioGridModel extends BaseGridData {
 
     /**
      * Verify the given value is not already used as property header name <b>inside the same group</b>
-     * @param propertyNameElements
+     * @param propertyHeaderCellValue
      * @param columnIndex
      * @return
      */
-    protected boolean isUniquePropertyHeaderTitle(List<String> propertyNameElements, int columnIndex) {
-        String value = String.join(".", propertyNameElements);
+    protected boolean isUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) {
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
         FactIdentifier factIdentifier = simulationDescriptor.getFactMappingByIndex(columnIndex).getFactIdentifier();
         return IntStream.range(0, getColumnCount())
@@ -875,7 +875,7 @@ public class ScenarioGridModel extends BaseGridData {
                 .mapToObj(index -> (ScenarioGridColumn) getColumns().get(index))
                 .filter(elem -> elem.getPropertyHeaderMetaData() != null)
                 .map(ScenarioGridColumn::getPropertyHeaderMetaData)
-                .noneMatch(elem -> Objects.equals(elem.getTitle(), value));
+                .noneMatch(elem -> Objects.equals(elem.getTitle(), propertyHeaderCellValue));
     }
 
     protected boolean isNewInstanceName(String value) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -729,9 +729,8 @@ public class ScenarioGridModel extends BaseGridData {
      * @throws Exception with message specific to failed check
      */
     public void validateInstanceHeaderUpdate(String instanceHeaderCellValue, int columnIndex, boolean isADataType) throws Exception {
-        List<String> instanceNameElements = Collections.unmodifiableList(Arrays.asList(instanceHeaderCellValue.split("\\.")));
         if (isADataType) {
-            checkSameInstanceHeader(columnIndex, instanceNameElements.get(instanceNameElements.size() - 1));
+            checkSameInstanceHeader(columnIndex, instanceHeaderCellValue);
             checkValidAndUniqueInstanceHeaderTitle(instanceHeaderCellValue, columnIndex);
         } else {
             checkValidAndUniqueInstanceHeaderTitle(instanceHeaderCellValue, columnIndex);
@@ -884,7 +883,7 @@ public class ScenarioGridModel extends BaseGridData {
      */
     protected void checkValidAndUniqueInstanceHeaderTitle(String instanceHeaderCellValue, int columnIndex) throws Exception {
         if (instanceHeaderCellValue.contains(".")) {
-            throw new Exception("Instance alias can not contains dot!");
+            throw new Exception("An instance alias cannot contain periods!");
         }
         Range instanceLimits = getInstanceLimits(columnIndex);
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
@@ -909,7 +908,7 @@ public class ScenarioGridModel extends BaseGridData {
      */
     protected void checkValidAndUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) throws Exception {
         if (propertyHeaderCellValue.contains(".")) {
-            throw new Exception("Property alias can not contains dot!");
+            throw new Exception("A property alias cannot contain periods!");
         }
         checkUniquePropertyHeaderTitle(propertyHeaderCellValue, columnIndex);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -333,7 +334,7 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
                 String value = isSimple(baseClass) ?
                         selectedFieldItemView.getFullPath() :
                         selectedFieldItemView.getFullPath() + "." + selectedFieldItemView.getFieldName();
-                List<String> propertyNameElements = Arrays.asList(value.split("\\."));
+                List<String> propertyNameElements = Collections.unmodifiableList(Arrays.asList(value.split("\\.")));
                 getFullPackage(baseClass).ifPresent(fullPackage -> eventBus.fireEvent(new SetPropertyHeaderEvent(fullPackage, propertyNameElements, selectedFieldItemView.getClassName())));
             }
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -333,7 +333,8 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
                 String value = isSimple(baseClass) ?
                         selectedFieldItemView.getFullPath() :
                         selectedFieldItemView.getFullPath() + "." + selectedFieldItemView.getFieldName();
-                getFullPackage(baseClass).ifPresent(fullPackage -> eventBus.fireEvent(new SetPropertyHeaderEvent(fullPackage, value, selectedFieldItemView.getClassName())));
+                List<String> propertyNameElements = Arrays.asList(value.split("\\."));
+                getFullPackage(baseClass).ifPresent(fullPackage -> eventBus.fireEvent(new SetPropertyHeaderEvent(fullPackage, propertyNameElements, selectedFieldItemView.getClassName())));
             }
         }
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -289,15 +289,14 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
     }
 
     @Override
-    public void onEnableEditorTab(String factName, String propertyName, boolean notEqualsSearch) {
+    public void onEnableEditorTab(String factName, List<String> propertyNameElements, boolean notEqualsSearch) {
         onDisableEditorTab();
         onPerfectMatchSearchedEvent(factName, notEqualsSearch);
         listGroupItemPresenter.enable(factName);
         editingColumnEnabled = true;
         view.enableEditorTab();
-        if (propertyName != null && !notEqualsSearch) {
-            List<String> propertyParts = propertyName.contains(".") ? Arrays.asList(propertyName.split("\\.")) : Collections.singletonList(propertyName);
-            listGroupItemPresenter.selectProperty(factName, propertyParts);
+        if (propertyNameElements != null && !notEqualsSearch) {
+            listGroupItemPresenter.selectProperty(factName, propertyNameElements);
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -17,7 +17,6 @@
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -176,11 +175,10 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
     }
 
     @Override
-    public void hideProperties(Map<String, List<String>> propertiesToHide) {
+    public void hideProperties(Map<String, List<List<String>>> propertiesToHide) {
         listGroupItemPresenter.showAll();
         propertiesToHide.entrySet().stream().forEach(
-                stringListEntry -> stringListEntry.getValue().forEach(s -> {
-                    List<String> propertyParts = s.contains(".") ? Arrays.asList(s.split("\\.")) : Collections.singletonList(s);
+                stringListEntry -> stringListEntry.getValue().forEach(propertyParts -> {
                     listGroupItemPresenter.hideProperty(stringListEntry.getKey(), propertyParts);
                 })
         );

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
@@ -117,7 +117,7 @@ public interface TestToolsView extends SubDockView<TestToolsView.Presenter> {
 
         void setInstanceFieldsMap(SortedMap<String, FactModelTree> factTypeFieldsMap);
 
-        void hideProperties(Map<String, List<String>> propertiesToHide);
+        void hideProperties(Map<String, List<List<String>>> propertiesToHide);
 
         void setSimpleJavaInstanceFieldsMap(SortedMap<String, FactModelTree> factTypeFieldsMap);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
@@ -147,10 +147,10 @@ public interface TestToolsView extends SubDockView<TestToolsView.Presenter> {
          * Call this method to show only the data model with the given name, <b>disabled</b> (i.e. <b>not double-clickable</b>)
          * and their properties <b>enabled</b> (i.e. <b>double-clickable</b> to map to a <i>property</i> header/column below the belonging data model instance one)
          * @param factName
-         * @param propertyName the string to <b>eventually</b> use to select the property in the right panel
+         * @param propertyNameElements The <code>List</code> to <b>eventually</b> use to select the property in the test tools  panel
          * @param notEqualsSearch set to <code>true</code> to perform a <b>not</b> filter, i.e. to show only results <b>different</b> than filterTerm
          */
-        void onEnableEditorTab(String factName, String propertyName, boolean notEqualsSearch);
+        void onEnableEditorTab(String factName, List<String> propertyNameElements, boolean notEqualsSearch);
 
         /**
          * By default the <b>Editor Tab</b> must be disabled (no user interaction allowed).

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -152,9 +153,9 @@ public class ScenarioSimulationGridHeaderUtilities {
     }
 
     public static List<String> getPropertyNameElements(final Simulation simulation, final int columnIndex) {
-        return  simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
+        return Collections.unmodifiableList(simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
                 .stream()
                 .map(ExpressionElement::getStep)
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilities.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -125,13 +126,13 @@ public class ScenarioSimulationGridHeaderUtilities {
             String complexSearch = getExistingInstances(columnGroup, scenarioGrid.getModel());
             return new EnableTestToolsEvent(complexSearch, true);
         } else if (Objects.equals(clickedScenarioHeaderMetadata.getMetadataType(), ScenarioHeaderMetaData.MetadataType.PROPERTY)) {
-            String propertyName = null;
+            List<String> propertyNameElements = null;
             if (scenarioGridColumn.isPropertyAssigned()) {
                 final Optional<Simulation> optionalSimulation = scenarioGrid.getModel().getSimulation();
-                propertyName = optionalSimulation.map(simulation -> getPropertyName(simulation, uiColumnIndex)).orElse(null);
+                propertyNameElements = optionalSimulation.map(simulation -> getPropertyNameElements(simulation, uiColumnIndex)).orElse(null);
             }
-            return propertyName != null ? new EnableTestToolsEvent(scenarioGridColumn.getInformationHeaderMetaData()
-                                                                            .getTitle(), propertyName) : new EnableTestToolsEvent(scenarioGridColumn.getInformationHeaderMetaData().getTitle());
+            return propertyNameElements != null ? new EnableTestToolsEvent(scenarioGridColumn.getInformationHeaderMetaData()
+                                                                            .getTitle(), propertyNameElements) : new EnableTestToolsEvent(scenarioGridColumn.getInformationHeaderMetaData().getTitle());
         } else {
             String complexSearch = getExistingInstances(columnGroup, scenarioGrid.getModel());
             return new EnableTestToolsEvent(complexSearch, true);
@@ -150,10 +151,10 @@ public class ScenarioSimulationGridHeaderUtilities {
                 .collect(Collectors.toSet()));
     }
 
-    public static String getPropertyName(final Simulation simulation, final int columnIndex) {
-        return String.join(".", simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
+    public static List<String> getPropertyNameElements(final Simulation simulation, final int columnIndex) {
+        return  simulation.getSimulationDescriptor().getFactMappingByIndex(columnIndex).getExpressionElementsWithoutClass()
                 .stream()
                 .map(ExpressionElement::getStep)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
@@ -22,6 +24,7 @@ import org.drools.workbench.screens.scenariosimulation.client.factories.Scenario
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
+import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 
 import static org.drools.workbench.screens.scenariosimulation.client.editor.strategies.DataManagementStrategy.SIMPLE_CLASSES_MAP;
@@ -39,6 +42,26 @@ public class ScenarioSimulationUtils {
                 .stream()
                 .map(Class::getCanonicalName)
                 .anyMatch(className::equals);
+    }
+
+    /**
+     * Method to retrieve a <b>new</b> <code>List</code> of <b>property name elements</b> where the first one is the
+     * the <b>actual</b> class name (i.e. an eventual <i>alias</i> get replaced)
+     * @param propertyNameElements
+     * @param factIdentifier
+     * @return
+     */
+    public static List<String> getPropertyNameElementsWithoutAlias(List<String> propertyNameElements, FactIdentifier factIdentifier) {
+        String actualClassName = factIdentifier.getClassName();
+        if (actualClassName.contains(".")) {
+            actualClassName = actualClassName.substring(actualClassName.lastIndexOf(".") + 1);
+        }
+        List<String> toReturn = new ArrayList<>(); // We have to keep the original List unmodified
+        toReturn.addAll(propertyNameElements);
+        if (toReturn.size() > 1) {
+            toReturn.set(0, actualClassName);
+        }
+        return toReturn;
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -163,8 +163,6 @@ public abstract class AbstractScenarioSimulationTest {
     protected ScenarioCellTextAreaSingletonDOMElementFactory scenarioCellTextAreaSingletonDOMElementFactoryTest;
     protected ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryTest;
 
-
-
     protected final Set<FactIdentifier> factIdentifierSet = new HashSet<>();
     protected final List<FactMapping> factMappingLocal = new ArrayList<>();
     protected final FactMappingType factMappingType = FactMappingType.valueOf(COLUMN_GROUP);
@@ -269,13 +267,13 @@ public abstract class AbstractScenarioSimulationTest {
             }
 
             @Override
-            public boolean validateInstanceHeaderUpdate(String instanceHeaderCellValue, int columnIndex, boolean isADataType) {
-                return true;
+            public void validateInstanceHeaderUpdate(String instanceHeaderCellValue, int columnIndex, boolean isADataType) throws Exception {
+                //
             }
 
             @Override
-            public boolean validatePropertyHeaderUpdate(String propertyHeaderCellValue, int columnIndex, boolean isPropertyType) {
-                return true;
+            public void validatePropertyHeaderUpdate(String propertyHeaderCellValue, int columnIndex, boolean isPropertyType) throws Exception {
+                //
             }
         });
         when(scenarioGridMock.getEventBus()).thenReturn(eventBusMock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -16,7 +16,6 @@
 package org.drools.workbench.screens.scenariosimulation.client;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -69,6 +68,18 @@ import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.events.NotificationEvent;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_NUMBER;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_ALIAS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_IDENTIFIER_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIRST_INDEX_LEFT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIRST_INDEX_RIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_PROPERTY_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -152,44 +163,7 @@ public abstract class AbstractScenarioSimulationTest {
     protected ScenarioCellTextAreaSingletonDOMElementFactory scenarioCellTextAreaSingletonDOMElementFactoryTest;
     protected ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryTest;
 
-    protected final int ROW_INDEX = 2;
-    protected final int COLUMN_INDEX = 3;
-    protected final int COLUMN_NUMBER = COLUMN_INDEX + 1;
 
-    protected final int FIRST_INDEX_LEFT = 2;
-    protected final int FIRST_INDEX_RIGHT = 4;
-    protected final String COLUMN_ID = "COLUMN ID";
-
-    protected final String COLUMN_GROUP = FactMappingType.EXPECT.name();
-
-    protected final String FULL_PACKAGE = "test.scesim";
-
-    protected final String VALUE = "value";
-
-    protected final List<String> VALUE_ELEMENTS = Collections.singletonList(VALUE);
-
-    protected final String CLASS_NAME = "TestClass";
-
-    protected final String PROPERTY_NAME = "testProperty";
-
-    protected final String FULL_CLASS_NAME = FULL_PACKAGE + "." + CLASS_NAME;
-
-    protected final String FULL_PROPERTY_NAME = CLASS_NAME + "." + PROPERTY_NAME;
-
-    protected final List<String> FULL_PROPERTY_NAME_ELEMENTS = Arrays.asList(CLASS_NAME, PROPERTY_NAME);
-
-    protected final String VALUE_CLASS_NAME = String.class.getName();
-
-    protected final String LIST_CLASS_NAME = List.class.getName();
-    protected final String MAP_CLASS_NAME = Map.class.getName();
-
-    protected final String FACT_IDENTIFIER_NAME = "FACT_IDENTIFIER_NAME";
-
-    protected static final String FACT_ALIAS = "FACT_ALIAS";
-
-    protected final String GRID_PROPERTY_TITLE = "GRID_PROPERTY_TITLE";
-    protected final String GRID_COLUMN_GROUP = "GIVEN";
-    protected final String GRID_COLUMN_ID = "GRID_COLUMN_ID";
 
     protected final Set<FactIdentifier> factIdentifierSet = new HashSet<>();
     protected final List<FactMapping> factMappingLocal = new ArrayList<>();
@@ -295,7 +269,7 @@ public abstract class AbstractScenarioSimulationTest {
             }
 
             @Override
-            public boolean validateInstanceHeaderUpdate(List<String> instanceNameElements, int columnIndex, boolean isADataType) {
+            public boolean validateInstanceHeaderUpdate(String instanceHeaderCellValue, int columnIndex, boolean isADataType) {
                 return true;
             }
 
@@ -350,7 +324,7 @@ public abstract class AbstractScenarioSimulationTest {
                 return CommandResultBuilder.SUCCESS;
             }
         });
-        when(informationHeaderMetaDataMock.getTitle()).thenReturn(VALUE);
+        when(informationHeaderMetaDataMock.getTitle()).thenReturn(MULTIPART_VALUE);
         when(informationHeaderMetaDataMock.getColumnGroup()).thenReturn(COLUMN_GROUP);
         when(propertyHeaderMetaDataMock.getMetadataType()).thenReturn(ScenarioHeaderMetaData.MetadataType.PROPERTY);
         when(propertyHeaderMetaDataMock.getTitle()).thenReturn(GRID_PROPERTY_TITLE);
@@ -369,6 +343,7 @@ public abstract class AbstractScenarioSimulationTest {
             factMappingLocal.add(factMappingMock);
             when(simulationDescriptorMock.getFactMappingByIndex(columnIndex)).thenReturn(factMappingMock);
         });
+        when(factIdentifierMock.getClassNameWithoutPackage()).thenReturn(CLASS_NAME);
         when(factIdentifierMock.getClassName()).thenReturn(FULL_CLASS_NAME);
         when(factIdentifierMock.getName()).thenReturn(FACT_IDENTIFIER_NAME);
         when(simulationDescriptorMock.getFactIdentifiers()).thenReturn(factIdentifierSet);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -274,7 +274,7 @@ public abstract class AbstractScenarioSimulationTest {
             }
 
             @Override
-            public boolean validatePropertyHeaderUpdate(List<String> propertyNameElements, int columnIndex, boolean isPropertyType) {
+            public boolean validatePropertyHeaderUpdate(String propertyHeaderCellValue, int columnIndex, boolean isPropertyType) {
                 return true;
             }
         });

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.scenariosimulation.client;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -165,7 +166,7 @@ public abstract class AbstractScenarioSimulationTest {
 
     protected final String VALUE = "value";
 
-    protected final List<String> VALUE_LIST = Collections.singletonList(VALUE);
+    protected final List<String> VALUE_ELEMENTS = Collections.singletonList(VALUE);
 
     protected final String CLASS_NAME = "TestClass";
 
@@ -174,6 +175,8 @@ public abstract class AbstractScenarioSimulationTest {
     protected final String FULL_CLASS_NAME = FULL_PACKAGE + "." + CLASS_NAME;
 
     protected final String FULL_PROPERTY_NAME = CLASS_NAME + "." + PROPERTY_NAME;
+
+    protected final List<String> FULL_PROPERTY_NAME_ELEMENTS = Arrays.asList(CLASS_NAME, PROPERTY_NAME);
 
     protected final String VALUE_CLASS_NAME = String.class.getName();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/AbstractScenarioSimulationTest.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.scenariosimulation.client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +165,15 @@ public abstract class AbstractScenarioSimulationTest {
 
     protected final String VALUE = "value";
 
-    protected final String FULL_CLASS_NAME = FULL_PACKAGE + ".testclass";
+    protected final List<String> VALUE_LIST = Collections.singletonList(VALUE);
+
+    protected final String CLASS_NAME = "TestClass";
+
+    protected final String PROPERTY_NAME = "testProperty";
+
+    protected final String FULL_CLASS_NAME = FULL_PACKAGE + "." + CLASS_NAME;
+
+    protected final String FULL_PROPERTY_NAME = CLASS_NAME + "." + PROPERTY_NAME;
 
     protected final String VALUE_CLASS_NAME = String.class.getName();
 
@@ -283,12 +292,12 @@ public abstract class AbstractScenarioSimulationTest {
             }
 
             @Override
-            public boolean validateInstanceHeaderUpdate(String value, int columnIndex, boolean isADataType) {
+            public boolean validateInstanceHeaderUpdate(List<String> instanceNameElements, int columnIndex, boolean isADataType) {
                 return true;
             }
 
             @Override
-            public boolean validatePropertyHeaderUpdate(String value, int columnIndex, boolean isPropertyType) {
+            public boolean validatePropertyHeaderUpdate(List<String> propertyNameElements, int columnIndex, boolean isPropertyType) {
                 return true;
             }
         });
@@ -398,10 +407,13 @@ public abstract class AbstractScenarioSimulationTest {
         when(factMapping.getFactAlias()).thenReturn(factAlias);
         when(factMapping.getClassName()).thenReturn(valueClassName);
 
+        final ExpressionElement factAliasExpressionElement = new ExpressionElement(factAlias);
+        final ExpressionElement propertyAliasExpressionElement = new ExpressionElement(propertyAlias);
         List<ExpressionElement> expressionElements = new ArrayList<>();
-        expressionElements.add(new ExpressionElement(factAlias));
-        expressionElements.add(new ExpressionElement(propertyAlias));
+        expressionElements.add(factAliasExpressionElement);
+        expressionElements.add(propertyAliasExpressionElement);
         when(factMapping.getExpressionElements()).thenReturn(expressionElements);
+        when(factMapping.getExpressionElementsWithoutClass()).thenReturn(Collections.singletonList(propertyAliasExpressionElement));
 
         when(factIdentifier.getClassName()).thenReturn(fullClassName);
         when(factIdentifier.getName()).thenReturn(factIdentfierName);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+
+/**
+ * Put all statically defined properties here
+ */
+public class TestProperties {
+
+    public static final int ROW_INDEX = 2;
+    public static final int ROW_COUNT = 3;
+    public static final int COLUMN_INDEX = 3;
+    public static final int COLUMN_NUMBER = COLUMN_INDEX + 1;
+
+    public static final int FIRST_INDEX_LEFT = 2;
+    public static final int FIRST_INDEX_RIGHT = 4;
+    public static final String COLUMN_ID = "COLUMN ID";
+
+    public static final String COLUMN_GROUP = FactMappingType.EXPECT.name();
+
+    public static final String FULL_PACKAGE = "test.scesim";
+
+    public static final String LOWER_CASE_VALUE = "value";
+
+    public static final String MULTIPART_VALUE = "MULTIPART.VALUE";
+
+    public static final List<String> MULTIPART_VALUE_ELEMENTS = Collections.unmodifiableList(Arrays.asList(MULTIPART_VALUE.split("\\.")));
+
+    public static final String CLASS_NAME = "TestClass";
+
+    public static final String PROPERTY_NAME = "testProperty";
+
+    public static final String FULL_CLASS_NAME = FULL_PACKAGE + "." + CLASS_NAME;
+
+    public static final String FULL_PROPERTY_NAME = CLASS_NAME + "." + PROPERTY_NAME;
+
+    public static final List<String> FULL_PROPERTY_NAME_ELEMENTS = Arrays.asList(CLASS_NAME, PROPERTY_NAME);
+
+    public static final String VALUE_CLASS_NAME = String.class.getName();
+
+    public static final String LIST_CLASS_NAME = List.class.getName();
+    public static final String MAP_CLASS_NAME = Map.class.getName();
+
+    public static final String FACT_IDENTIFIER_NAME = "FACT_IDENTIFIER_NAME";
+
+    public static final String FACT_ALIAS = "FACT_ALIAS";
+
+    public static final String GRID_PROPERTY_TITLE = "GRID_PROPERTY_TITLE";
+    public static final String GRID_COLUMN_GROUP = "GIVEN";
+    public static final String GRID_COLUMN_ID = "GRID_COLUMN_ID";
+
+    public static final String FULL_CLASSNAME_CREATED = FULL_PACKAGE + "." + CLASS_NAME;
+    public static final String LIST_PROPERTY_NAME = "listProperty";
+    public static final String FULL_PROPERTY_PATH = CLASS_NAME + "." + LIST_PROPERTY_NAME;
+    public static final List<String> FULL_PROPERTY_PATH_ELEMENTS = Arrays.asList(FULL_PROPERTY_PATH.split("\\."));
+
+    public static final String TEST_PROPERTYNAME = "TEST-PROPERTYNAME";
+
+    public static final String MAP_TEST_KEY = "TEST-KEY";
+    public static final String MAP_TEST_VALUE = "TEST-MULTIPART_VALUE";
+    public static final Map<String, String> TEST_INSTANCE_PROPERTY_MAP = Collections.singletonMap(MAP_TEST_KEY, MAP_TEST_VALUE);
+    public static final Map<String, String> TEST_KEY_PROPERTY_MAP = Collections.singletonMap("TEST-KEY1", "TEST-KEY2");
+    public static final Map<String, String> TEST_VALUE_PROPERTYY_MAP = Collections.singletonMap("TEST-VALUE1", "TEST-VALUE2");
+
+    public static final String TEST_JSON = "TEST-JSON";
+    public static final String TEST_CLASSNAME = "TEST-CLASSNAME";
+    public static final String TEST_KEY = TEST_CLASSNAME + "#" + TEST_PROPERTYNAME;
+    public static final int CHILD_COUNT = 3;
+    public static final String ITEM_ID = String.valueOf(CHILD_COUNT - 1);
+    public static final String UPDATED_VALUE = "UPDATED_VALUE";
+    public static final int JSON_ARRAY_SIZE = 2;
+    public static final Set<String> KEY_SET = new HashSet<>(Arrays.asList("prop1", "prop2"));
+
+    public static final String ELEMENT1_ID = "ELEMENT1_ID";
+    public static final String ELEMENT2_ID = "ELEMENT2_ID";
+
+    public static final String TEST_ITEM_ID = "TEST-ITEM-ID";
+    public static final String EXPANDABLE_PROPERTY = "EXPANDABLE_PROPERTY";
+    public static final Map<String, String> TEST_PROPERTIES_MAP = Collections.singletonMap("TEST-KEY", "TEST-MULTIPART_VALUE");
+    public static final Map<String, String> EXPANDABLE_PROPERTIES_MAP = Collections.singletonMap("EXPANDABLE-KEY", "EXPANDABLE-MULTIPART_VALUE");
+    public static final Map<String, Map<String, String>> EXPANDABLE_PROPERTIES_VALUES = Collections.singletonMap(EXPANDABLE_PROPERTY, EXPANDABLE_PROPERTIES_MAP);
+    public static final Map<String, List<String>> ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL = new HashMap<>();
+    public static final List<String> EXPANDABLE_PROPERTIES = Collections.singletonList(EXPANDABLE_PROPERTY);
+
+    public static final String INNER_TEXT = "INNER_TEXT";
+    public static final String TEST_PROPERTYVALUE = "TEST-PROPERTYVALUE";
+    public static final String TEST_NEWVALUE = "TEST_NEWVALUE";
+
+    public static final String GRID_COLUMN_ID_1 = GRID_COLUMN_ID + "_1";
+    public static final String GRID_PROPERTY_TITLE_1 = GRID_PROPERTY_TITLE + "_1";
+    public static final String FACT_ALIAS_1 = FACT_ALIAS + "_1";
+    public static final String FULL_CLASS_NAME_1 = FULL_CLASS_NAME + "_1";
+    public static final String FACT_IDENTIFIER_NAME_1 = FACT_IDENTIFIER_NAME + "_1";
+    public static final String VALUE_1 = MULTIPART_VALUE + "_1";
+
+    public static final String FACT_NAME = "FACT_NAME";
+    public static final String FIELD_NAME = "FIELD_NAME";
+
+    public static final String FILE_CONTENT = "FILE_CONTENT";
+
+    public static final String FULL_FACT_CLASSNAME = "FULL_FACT_CLASSNAME";
+
+    public static final String STRING_CLASS_NAME = String.class.getCanonicalName();
+    public static final String NUMBER_CLASS_NAME = Number.class.getCanonicalName();
+    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE = new HashMap<>();
+    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1 = new HashMap<>();
+    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2 = new HashMap<>();
+
+    public static final Double GRID_WIDTH = 100.0;
+    public static final Double HEADER_HEIGHT = 10.0;
+    public static final Double HEADER_ROW_HEIGHT = 10.0;
+    public static final int UI_COLUMN_INDEX = 0;
+    public static final int UI_ROW_INDEX = 1;
+    public static final double CLICK_POINT_X = 5;
+    public static final double CLICK_POINT_Y = 5;
+    public static final int OFFSET_X = 0;
+
+    public static final int MOUSE_EVENT_X = 32;
+    public static final int MOUSE_EVENT_Y = 64;
+    public static final double GRID_COMPUTED_LOCATION_X = 100.0;
+    public static final double GRID_COMPUTED_LOCATION_Y = 200.0;
+
+    public static final List<GridColumn.HeaderMetaData> HEADER_META_DATA = new ArrayList<>();
+    public static final List<GridRow> GRID_ROWS = new ArrayList<>();
+
+    public static final String MAIN_TITLE_TEXT = "MAIN_TITLE_TEXT";
+    public static final String MAIN_QUESTION_TEXT = "MAIN_QUESTION_TEXT";
+    public static final String TEXT1_TEXT = "TEXT1_TEXT";
+    public static final String TEXT_QUESTION_TEXT = "TEXT_QUESTION_TEXT";
+    public static final String TEXT_WARNING_TEXT = "TEXT_WARNING_TEXT";
+    public static final String OKDELETE_BUTTON_TEXT = "OKDELETE_BUTTON_TEXT";
+    public static final String OPTION1_TEXT = "OPTION1_TEXT";
+    public static final String OPTION2_TEXT = "OPTION2_TEXT";
+    public static final String OKPRESERVE_BUTTON_TEXT = "OKPRESERVE_BUTTON_TEXT";
+
+    public static final String OK_BUTTON_TEXT = "OK_BUTTON_TEXT";
+
+    public static final String TITLE = "TITLE";
+    public static final String YES_BUTTON_TEXT = "YES_BUTTON_TEXT";
+    public static final String NO_BUTTON_TEXT = "NO_BUTTON_TEXT";
+    public static final String CONFIRM_MESSAGE = "CONFIRM_MESSAGE";
+    public static final String INLINE_NOTIFICATION_MESSAGE = "INLINE_NOTIFICATION_MESSAGE";
+
+    public static final String MAIN_TEXT = "MAIN_TEXT";
+
+    public static final String TEXT_DANGER_TEXT = "TEXT_DANGER_TEXT";
+
+    public static final String PLACEHOLDER = "PLACEHOLDER";
+    public static final String LIST_VALUE = "[ \"Ford\", \"BMW\", \"Fiat\" ]";
+    public static final String MAP_VALUE = "{\"name\":\"myname\",\"age\":29}";
+
+    public static final String SCENARIO_TYPE = "SCENARIO_TYPE";
+    public static final String FILE_NAME = "FILE_NAME";
+    public static final String KIE_SESSION = "KIE_SESSION";
+    public static final String KIE_BASE = "KIE_BASE";
+    public static final String RULE_FLOW_GROUP = "RULE_FLOW_GROUP";
+    public static final String DMO_SESSION = "DMO_SESSION";
+    public static final String DMN_FILE_PATH = "DMN_FILE_PATH";
+    public static final String DMN_NAMESPACE = "DMN_NAMESPACE";
+    public static final String DMN_NAME = "DMN_NAME";
+
+    public static final String FACT_PACKAGE = "test.scesim.package";
+    public static final String GRID_COLUMN_TITLE = "GRID_COLUMN_TITLE";
+    public static final String GRID_CELL_TEXT = "GRID_CELL_TEXT";
+
+    public static final String LIST_GROUP_ITEM = "list-group-item";
+
+    public static final String COLUMN_INSTANCE_TITLE_FIRST = "COLUMN_INSTANCE_TITLE_FIRST";
+    public static final String COLUMN_PROPERTY_TITLE_FIRST = "COLUMN_PROPERTY_TITLE_FIRST";
+    public static final String COLUMN_GROUP_FIRST = "OTHER";
+
+    public static final int HEADER_ROWS = 2;
+    public static final String COLUMN_ONE_TITLE = "column one";
+    public static final String COLUMN_TWO_TITLE = "column two";
+
+    public static final String TEST = "test";
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionPresenterTest.java
@@ -15,11 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.collectioneditor;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import com.google.gwt.dom.client.ButtonElement;
 import com.google.gwt.dom.client.HeadingElement;
@@ -43,6 +40,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CHILD_COUNT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ITEM_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.JSON_ARRAY_SIZE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.KEY_SET;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_JSON;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_KEY;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTYNAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UPDATED_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -61,15 +66,7 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class CollectionPresenterTest extends AbstractCollectionEditorTest {
 
-    private static final String TEST_JSON = "TEST-JSON";
-    private final static String TEST_CLASSNAME = "TEST-CLASSNAME";
-    private final static String TEST_PROPERTYNAME = "TEST-PROPERTYNAME";
-    private final static String TEST_KEY = TEST_CLASSNAME + "#" + TEST_PROPERTYNAME;
-    private final static int CHILD_COUNT = 3;
-    private final static String ITEM_ID = String.valueOf(CHILD_COUNT - 1);
-    private final static String UPDATED_VALUE = "UPDATED_VALUE";
-    private final static int JSON_ARRAY_SIZE = 2;
-    private final static Set<String> KEY_SET = new HashSet<>(Arrays.asList("prop1", "prop2"));
+
 
     @Mock
     private ItemElementPresenter listElementPresenterMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementPresenterTest.java
@@ -25,6 +25,8 @@ import com.google.gwt.dom.client.ButtonElement;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ELEMENT1_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ELEMENT2_ID;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -35,8 +37,7 @@ import static org.mockito.Mockito.when;
 
 public abstract class ElementPresenterTest<E extends ElementView, T extends ElementView.Presenter<E>> extends AbstractCollectionEditorTest {
 
-    protected final static String ELEMENT1_ID = "ELEMENT1_ID";
-    protected final static String ELEMENT2_ID = "ELEMENT2_ID";
+
 
     protected T elementPresenter;
 
@@ -75,7 +76,7 @@ public abstract class ElementPresenterTest<E extends ElementView, T extends Elem
         elementViewListLocal.add(elementView2Mock);
         for (String el : Arrays.asList(ELEMENT1_ID, ELEMENT2_ID)) {
             when(propertyPresenterMock.getSimpleProperties(eq(el + "#KEY"))).thenReturn(new HashMap<>());
-            when(propertyPresenterMock.getSimpleProperties(eq(el + "#VALUE"))).thenReturn(new HashMap<>());
+            when(propertyPresenterMock.getSimpleProperties(eq(el + "#MULTIPART_VALUE"))).thenReturn(new HashMap<>());
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
@@ -15,9 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.collectioneditor;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.google.gwt.dom.client.LIElement;
@@ -28,6 +25,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ELEMENT1_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPANDABLE_PROPERTIES;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPANDABLE_PROPERTIES_VALUES;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_ITEM_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTIES_MAP;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -45,19 +48,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementView, ItemElementView.Presenter> {
 
-    private static final String TEST_ITEM_ID = "TEST-ITEM-ID";
-
-    private static final String EXPANDABLE_PROPERTY = "EXPANDABLE_PROPERTY";
-
-    private Map<String, String> testPropertiesMap = Collections.singletonMap("TEST-KEY", "TEST-VALUE");
-
-    private Map<String, String> expandablePropertiesMap = Collections.singletonMap("EXPANDABLE-KEY", "EXPANDABLE-VALUE");
-
-    private Map<String, Map<String, String>> expandablePropertiesValues = Collections.singletonMap(EXPANDABLE_PROPERTY, expandablePropertiesMap);
-
-    private Map<String, List<String>> itemIdExpandablePropertiesMapLocal = new HashMap<>();
-
-    private List<String> expandableProperties = Collections.singletonList(EXPANDABLE_PROPERTY);
 
     @Mock
     private LIElement propertyFieldsMock;
@@ -75,31 +65,31 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
                 this.propertyPresenter = propertyPresenterMock;
                 this.elementViewList = elementViewListLocal;
                 this.collectionEditorPresenter = collectionPresenterMock;
-                this.itemIdExpandablePropertiesMap = itemIdExpandablePropertiesMapLocal;
+                this.itemIdExpandablePropertiesMap = ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL;
             }
         });
-        itemIdExpandablePropertiesMapLocal.put(elementView1Mock.getItemId(), expandableProperties);
-        itemIdExpandablePropertiesMapLocal.put(elementView2Mock.getItemId(), expandableProperties);
+        ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL.put(elementView1Mock.getItemId(), EXPANDABLE_PROPERTIES);
+        ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL.put(elementView2Mock.getItemId(), EXPANDABLE_PROPERTIES);
     }
 
     @Test
     public void getItemContainer() {
         elementViewListLocal.clear();
-        itemIdExpandablePropertiesMapLocal.clear();
-        LIElement itemContainer = elementPresenter.getItemContainer(TEST_ITEM_ID, testPropertiesMap, expandablePropertiesValues);
-        verify(elementView1Mock, times(1 + expandablePropertiesValues.size())).init(elementPresenter); // Add invocation inside expandablePropertiesValues loop
+        ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL.clear();
+        LIElement itemContainer = elementPresenter.getItemContainer(TEST_ITEM_ID, TEST_PROPERTIES_MAP, EXPANDABLE_PROPERTIES_VALUES);
+        verify(elementView1Mock, times(1 + EXPANDABLE_PROPERTIES_VALUES.size())).init(elementPresenter); // Add invocation inside EXPANDABLE_PROPERTIES_VALUES loop
         verify(elementView1Mock, times(1)).setItemId(TEST_ITEM_ID);
-        verify(elementView1Mock, times(1 + expandablePropertiesValues.size())).getItemContainer(); // Add invocation inside expandablePropertiesValues loop
-        verify(elementView1Mock, times(3)).getSaveChange(); // Three times because invoked also inside expandablePropertiesValues loop
-        testPropertiesMap.forEach((propertyName, propertyValue) -> {
+        verify(elementView1Mock, times(1 + EXPANDABLE_PROPERTIES_VALUES.size())).getItemContainer(); // Add invocation inside EXPANDABLE_PROPERTIES_VALUES loop
+        verify(elementView1Mock, times(3)).getSaveChange(); // Three times because invoked also inside EXPANDABLE_PROPERTIES_VALUES loop
+        TEST_PROPERTIES_MAP.forEach((propertyName, propertyValue) -> {
             verify(propertyPresenterMock, times(1))
                     .getPropertyFields(eq(TEST_ITEM_ID), eq(propertyName), eq(propertyValue));
             verify(innerItemContainerMock, times(1)).insertBefore(propertyFieldsMock, saveChangeMock);
             reset(innerItemContainerMock);
         });
-        assertTrue(itemIdExpandablePropertiesMapLocal.containsKey(TEST_ITEM_ID));
-        expandablePropertiesValues.forEach((nestedPropertyName, nestedPropertiesValues) -> {
-            assertTrue(itemIdExpandablePropertiesMapLocal.get(TEST_ITEM_ID).contains(nestedPropertyName));
+        assertTrue(ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL.containsKey(TEST_ITEM_ID));
+        EXPANDABLE_PROPERTIES_VALUES.forEach((nestedPropertyName, nestedPropertiesValues) -> {
+            assertTrue(ITEM_ID_EXPANDABLE_PROPERTIES_MAP_LOCAL.get(TEST_ITEM_ID).contains(nestedPropertyName));
             verify((ItemElementPresenter) elementPresenter, times(1)).addExpandableItemElementView(eq(elementView1Mock), eq(nestedPropertiesValues), eq(nestedPropertyName));
         });
         assertNotNull(itemContainer);
@@ -112,7 +102,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
         elementPresenter.onEditItem(elementView1Mock);
         verify(elementPresenter, never()).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).editProperties(eq(elementView1Mock.getItemId()));
-        for (String expandableProperty : expandableProperties) {
+        for (String expandableProperty : EXPANDABLE_PROPERTIES) {
             verify(propertyPresenterMock, times(1)).editProperties(eq(expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
@@ -125,7 +115,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
         elementPresenter.onEditItem(elementView1Mock);
         verify(elementPresenter, times(1)).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).editProperties(eq(elementView1Mock.getItemId()));
-        for (String expandableProperty : expandableProperties) {
+        for (String expandableProperty : EXPANDABLE_PROPERTIES) {
             verify(propertyPresenterMock, times(1)).editProperties(eq(expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
@@ -154,7 +144,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
     public void updateItem() {
         elementPresenter.updateItem(elementView1Mock);
         verify(propertyPresenterMock, times(1)).updateProperties(eq(elementView1Mock.getItemId()));
-        for (String expandableProperty : expandableProperties) {
+        for (String expandableProperty : EXPANDABLE_PROPERTIES) {
             verify(propertyPresenterMock, times(1)).updateProperties(eq(expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.NONE);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementPresenterTest.java
@@ -15,9 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.collectioneditor;
 
-import java.util.Collections;
-import java.util.Map;
-
 import com.google.gwt.dom.client.LIElement;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.UListElement;
@@ -27,6 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ELEMENT1_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ELEMENT2_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_ITEM_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_KEY_PROPERTY_MAP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_VALUE_PROPERTYY_MAP;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -43,10 +45,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class KeyValueElementPresenterTest extends ElementPresenterTest<KeyValueElementView, KeyValueElementView.Presenter> {
 
-    private static final String TEST_ITEM_ID = "TEST-ITEM-ID";
-
-    private Map<String, String> testKeyPropertyMap = Collections.singletonMap("TEST-KEY1", "TEST-KEY2");
-    private Map<String, String> testValuePropertyyMap = Collections.singletonMap("TEST-VALUE1", "TEST-VALUE2");
 
     @Mock
     private LIElement propertyFieldsMock;
@@ -95,7 +93,7 @@ public class KeyValueElementPresenterTest extends ElementPresenterTest<KeyValueE
     @Test
     public void getKeyValueContainer() {
         elementViewListLocal.clear();
-        LIElement keyValueContainer = elementPresenter.getKeyValueContainer(TEST_ITEM_ID, testKeyPropertyMap, testValuePropertyyMap);
+        LIElement keyValueContainer = elementPresenter.getKeyValueContainer(TEST_ITEM_ID, TEST_KEY_PROPERTY_MAP, TEST_VALUE_PROPERTYY_MAP);
         verify(elementView1Mock, times(1)).init(elementPresenter);
         verify(elementView1Mock, times(1)).setItemId(TEST_ITEM_ID);
         verify(elementView1Mock, times(1)).getKeyContainer();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenterTest.java
@@ -30,6 +30,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.INNER_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ITEM_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_NEWVALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTYNAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTYVALUE;
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.NODE_HIDDEN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,11 +50,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class PropertyPresenterTest extends AbstractCollectionEditorTest {
 
-    private static final String INNER_TEXT = "INNER_TEXT";
-    private static final String ITEM_ID = "ITEM_ID";
-    private static final String TEST_PROPERTYNAME = "TEST-PROPERTYNAME";
-    private static final String TEST_PROPERTYVALUE = "TEST-PROPERTYVALUE";
-    private static final String TEST_NEWVALUE = "TEST_NEWVALUE";
 
     @Mock
     private PropertyView propertyViewMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/ItemEditingBoxPresenterTest.java
@@ -16,10 +16,8 @@
 package org.drools.workbench.screens.scenariosimulation.client.collectioneditor.editingbox;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.google.gwt.dom.client.UListElement;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -28,6 +26,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAP_TEST_KEY;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_INSTANCE_PROPERTY_MAP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_KEY;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTYNAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -43,12 +46,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class ItemEditingBoxPresenterTest extends AbstractEditingBoxPresenterTest {
 
-    private static final String TEST_KEY = "TEST-CLASSNAME#TEST-PROPERTYNAME";
-    private static final String TEST_PROPERTYNAME = "TEST-PROPERTYNAME";
-
-    private static final String MAP_TEST_KEY = "TEST-KEY";
-    private static final String MAP_TEST_VALUE = "TEST-VALUE";
-    private Map<String, String> testInstancePropertyMap = Collections.singletonMap(MAP_TEST_KEY, MAP_TEST_VALUE);
 
     @Mock
     private ItemEditingBox listEditingBoxMock;
@@ -75,7 +72,7 @@ public class ItemEditingBoxPresenterTest extends AbstractEditingBoxPresenterTest
 
     @Test
     public void getEditingBox() {
-        ((ItemEditingBoxPresenter)editingBoxPresenter).getEditingBox(TEST_KEY, testInstancePropertyMap, new HashMap<>());
+        ((ItemEditingBoxPresenter)editingBoxPresenter).getEditingBox(TEST_KEY, TEST_INSTANCE_PROPERTY_MAP, new HashMap<>());
         verify(viewsProviderMock, times(1)).getItemEditingBox();
         verify(listEditingBoxMock, times(1)).init(((ItemEditingBoxPresenter)editingBoxPresenter));
         verify(listEditingBoxMock, times(1)).setKey(TEST_KEY);
@@ -86,7 +83,7 @@ public class ItemEditingBoxPresenterTest extends AbstractEditingBoxPresenterTest
     @Test
     public void save() {
         editingBoxPresenter.save();
-        verify(propertyPresenterMock, times(1)).updateProperties("value");
+        verify(propertyPresenterMock, times(1)).updateProperties(LOWER_CASE_VALUE);
         verify(collectionPresenterMock, times(1)).addListItem(anyMap(), anyMap());
     }
 
@@ -98,7 +95,7 @@ public class ItemEditingBoxPresenterTest extends AbstractEditingBoxPresenterTest
         ItemEditingBox containerItemEditingBoxMock = mock(ItemEditingBox.class);
         UListElement containerPropertiesContainerMock = mock(UListElement.class);
         when(containerItemEditingBoxMock.getPropertiesContainer()).thenReturn(containerPropertiesContainerMock);
-        ((ItemEditingBoxPresenter)editingBoxPresenter).addExpandableItemEditingBox(containerItemEditingBoxMock, testInstancePropertyMap, TEST_KEY, TEST_PROPERTYNAME);
+        ((ItemEditingBoxPresenter)editingBoxPresenter).addExpandableItemEditingBox(containerItemEditingBoxMock, TEST_INSTANCE_PROPERTY_MAP, TEST_KEY, TEST_PROPERTYNAME);
         verify(viewsProviderMock, times(1)).getItemEditingBox();
         verify(listEditingBoxMock, times(1)).init(((ItemEditingBoxPresenter)editingBoxPresenter));
         verify(listEditingBoxMock, times(1)).setKey(TEST_KEY);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/editingbox/KeyValueEditingBoxPresenterTest.java
@@ -15,9 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.collectioneditor.editingbox;
 
-import java.util.Collections;
-import java.util.Map;
-
 import com.google.gwt.dom.client.UListElement;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
@@ -25,6 +22,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_KEY;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_KEY_PROPERTY_MAP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_PROPERTYNAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST_VALUE_PROPERTYY_MAP;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.spy;
@@ -35,11 +37,6 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class KeyValueEditingBoxPresenterTest extends AbstractEditingBoxPresenterTest {
 
-    private static final String TEST_KEY = "TEST-CLASSNAME#TEST-PROPERTYNAME";
-    private static final String TEST_PROPERTYNAME = "TEST-PROPERTYNAME";
-
-    private Map<String, String> testKeyPropertyMap = Collections.singletonMap("TEST-KEY1", "TEST-KEY2");
-    private Map<String, String> testValuePropertyyMap = Collections.singletonMap("TEST-VALUE1", "TEST-VALUE2");
 
 
     @Mock
@@ -70,7 +67,7 @@ public class KeyValueEditingBoxPresenterTest extends AbstractEditingBoxPresenter
 
     @Test
     public void getEditingBox() {
-        editingBoxMock =  ((KeyValueEditingBoxPresenter)editingBoxPresenter).getEditingBox(TEST_KEY, testKeyPropertyMap, testValuePropertyyMap);
+        editingBoxMock =  ((KeyValueEditingBoxPresenter)editingBoxPresenter).getEditingBox(TEST_KEY, TEST_KEY_PROPERTY_MAP, TEST_VALUE_PROPERTYY_MAP);
         verify(viewsProviderMock, times(1)).getKeyValueEditingBox();
         verify(keyValueEditingBoxMock, times(1)).init((KeyValueEditingBoxPresenter)editingBoxPresenter);
         verify(keyValueEditingBoxMock, times(1)).setKey(TEST_KEY);
@@ -85,7 +82,7 @@ public class KeyValueEditingBoxPresenterTest extends AbstractEditingBoxPresenter
     public void save() {
         editingBoxPresenter.save();
         verify(propertyPresenterMock, times(1)).updateProperties("key");
-        verify(propertyPresenterMock, times(1)).updateProperties("value");
+        verify(propertyPresenterMock, times(1)).updateProperties(LOWER_CASE_VALUE);
         verify(collectionPresenterMock, times(1)).addMapItem(anyMap(), anyMap());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -85,6 +85,14 @@ import org.kie.workbench.common.command.client.CommandResultBuilder;
 import org.kie.workbench.common.command.client.impl.CommandResultImpl;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyObject;
@@ -345,21 +353,21 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetGridCellValueEvent() {
-        SetGridCellValueEvent event = new SetGridCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE);
+        SetGridCellValueEvent event = new SetGridCellValueEvent(ROW_INDEX, COLUMN_INDEX, MULTIPART_VALUE);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetGridCellValueCommand.class));
     }
 
     @Test
     public void onSetHeaderCellValueEventInstanceHeader() {
-        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE_ELEMENTS, true, false);
+        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, MULTIPART_VALUE, true, false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetHeaderCellValueCommand.class));
     }
 
     @Test
     public void onSetHeaderCellValueEventPropertyHeader() {
-        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, Collections.singletonList(VALUE), false, true);
+        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, MULTIPART_VALUE, false, true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetHeaderCellValueCommand.class));
     }
@@ -397,19 +405,19 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetPropertyHeaderEvent() {
-        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, VALUE_ELEMENTS, VALUE_CLASS_NAME);
+        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME);
         when(scenarioGridModelMock.getSelectedColumn()).thenReturn(null);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         doReturn(gridColumnMock).when(scenarioGridModelMock).getSelectedColumn();
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_ELEMENTS)).thenReturn(true);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).onEvent(isA(ScenarioNotificationEvent.class));
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         reset(scenarioSimulationEventHandler);
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_ELEMENTS)).thenReturn(false);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -86,6 +86,7 @@ import org.kie.workbench.common.command.client.impl.CommandResultImpl;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -280,7 +281,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         ImportEvent event = new ImportEvent();
         scenarioSimulationEventHandler.onEvent(event);
         verify(fileUploadPopupPresenterMock, times(1))
-                .show(any(),
+                .show(anyListOf(String.class),
                       eq(ScenarioSimulationEditorConstants.INSTANCE.selectImportFile()),
                       eq(ScenarioSimulationEditorConstants.INSTANCE.importLabel()),
                       isA(org.uberfire.mvp.Command.class));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -352,7 +352,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetHeaderCellValueEventInstanceHeader() {
-        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE_LIST, true, false);
+        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE_ELEMENTS, true, false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetHeaderCellValueCommand.class));
     }
@@ -397,19 +397,19 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetPropertyHeaderEvent() {
-        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, VALUE_LIST, VALUE_CLASS_NAME);
+        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, VALUE_ELEMENTS, VALUE_CLASS_NAME);
         when(scenarioGridModelMock.getSelectedColumn()).thenReturn(null);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         doReturn(gridColumnMock).when(scenarioGridModelMock).getSelectedColumn();
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_LIST)).thenReturn(true);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_ELEMENTS)).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).onEvent(isA(ScenarioNotificationEvent.class));
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         reset(scenarioSimulationEventHandler);
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_LIST)).thenReturn(false);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -84,6 +84,7 @@ import org.kie.workbench.common.command.client.impl.CommandResultImpl;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -332,14 +333,14 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetHeaderCellValueEventInstanceHeader() {
-        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE, true, false);
+        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE_LIST, true, false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetHeaderCellValueCommand.class));
     }
 
     @Test
     public void onSetHeaderCellValueEventPropertyHeader() {
-        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, VALUE, false, true);
+        SetHeaderCellValueEvent event = new SetHeaderCellValueEvent(ROW_INDEX, COLUMN_INDEX, Collections.singletonList(VALUE), false, true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal), isA(SetHeaderCellValueCommand.class));
     }
@@ -377,19 +378,19 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
 
     @Test
     public void onSetPropertyHeaderEvent() {
-        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, VALUE, VALUE_CLASS_NAME);
+        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(FULL_PACKAGE, VALUE_LIST, VALUE_CLASS_NAME);
         when(scenarioGridModelMock.getSelectedColumn()).thenReturn(null);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         doReturn(gridColumnMock).when(scenarioGridModelMock).getSelectedColumn();
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE)).thenReturn(true);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_LIST)).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).onEvent(isA(ScenarioNotificationEvent.class));
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
         reset(scenarioSimulationEventHandler);
-        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE)).thenReturn(false);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(VALUE_LIST)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -397,11 +398,11 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         //
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyString())).thenReturn(true);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyListOf(String.class))).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal), isA(SetPropertyHeaderCommand.class));
         //
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyString())).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyListOf(String.class))).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(preserveDeletePopupPresenterMock, times(1))

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
@@ -36,6 +36,21 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_IDENTIFIER_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASSNAME_CREATED;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PROPERTY_NAME_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PROPERTY_PATH;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PROPERTY_PATH_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_PROPERTY_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.PROPERTY_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -53,11 +68,6 @@ import static org.mockito.Mockito.when;
 
 public abstract class AbstractSelectedColumnCommandTest extends AbstractScenarioSimulationCommandTest {
 
-    final private String CLASS_NAME = "ClassName";
-    final private String FULL_CLASSNAME_CREATED = FULL_PACKAGE + "." + CLASS_NAME;
-    final private String LIST_PROPERTY_NAME = "listProperty";
-    final private String FULL_PROPERTY_PATH = CLASS_NAME + "." + LIST_PROPERTY_NAME;
-    final private List<String> FULL_PROPERTY_PATH_ELEMENTS = Arrays.asList(FULL_PROPERTY_PATH.split("\\."));
 
     @Mock
     protected List<GridColumn<?>> gridColumnsMock;
@@ -73,11 +83,11 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         when(dataObjectFieldsMapMock.get(anyString())).thenReturn(factModelTreeMock);
 
         scenarioSimulationContextLocal.getStatus().setFullPackage(FULL_PACKAGE);
-        scenarioSimulationContextLocal.getStatus().setValue(VALUE);
+        scenarioSimulationContextLocal.getStatus().setValue(MULTIPART_VALUE);
         scenarioSimulationContextLocal.getStatus().setValueClassName(VALUE_CLASS_NAME);
         scenarioSimulationContextLocal.getStatus().setColumnId(COLUMN_ID);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(VALUE_ELEMENTS);
+        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(MULTIPART_VALUE_ELEMENTS);
     }
 
     @Test
@@ -136,20 +146,20 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     public void executeKeepDataFalseDMN() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.DMN);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, VALUE_ELEMENTS, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataFalseRule() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, VALUE_ELEMENTS, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataTrue() {
         scenarioSimulationContextLocal.getStatus().setKeepData(true);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, VALUE_ELEMENTS, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
@@ -182,7 +192,7 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         ((AbstractSelectedColumnCommand) command).setPropertyHeader(scenarioSimulationContextLocal, gridColumnMock, propertyNameElements, propertyClass, Optional.empty());
         verify(gridColumnMock, times(1)).setEditableHeaders(eq(!type.equals(ScenarioSimulationModel.Type.DMN)));
         verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
-        verify(propertyHeaderMetaDataMock, times(1)).setTitle(propertyNameElements.get(0));
+        verify(propertyHeaderMetaDataMock, times(1)).setTitle(String.join(".", propertyNameElements.subList(1, propertyNameElements.size())));
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
         verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), isA(ScenarioGridColumn.class), eq(propertyNameElements), eq(propertyClass), eq(keepData));
         verify(scenarioSimulationContextLocal.getScenarioSimulationEditorPresenter(), times(1)).reloadTestTools(false);
@@ -205,10 +215,14 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     /* This test is usable ONLY by <code>SetPropertyCommandTest</code> subclass */
     protected void getPropertyHeaderTitle() {
         Optional<String> emptyMatching = Optional.empty();
-        doReturn(emptyMatching).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(factIdentifierMock));
-        String retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, VALUE_ELEMENTS, factIdentifierMock);
-        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(factIdentifierMock));
-        assertEquals(VALUE, retrieved);
+        doReturn(emptyMatching).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE_ELEMENTS), eq(factIdentifierMock));
+        String retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, MULTIPART_VALUE_ELEMENTS, factIdentifierMock);
+        List<String> propertyNameElements = new ArrayList<>();
+        propertyNameElements.add(CLASS_NAME);
+        propertyNameElements.addAll(MULTIPART_VALUE_ELEMENTS.subList(1, MULTIPART_VALUE_ELEMENTS.size()));
+        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(propertyNameElements), eq(factIdentifierMock));
+        String expected = String.join(".", MULTIPART_VALUE_ELEMENTS.subList(1, MULTIPART_VALUE_ELEMENTS.size()));
+        assertEquals(expected, retrieved);
         String EXPECTED_VALUE_STRING = "EXPECTED_VALUE_STRING";
         Optional<String> expectedValue = Optional.of("EXPECTED_VALUE_STRING");
         doReturn(expectedValue).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME_ELEMENTS), eq(factIdentifierMock));
@@ -223,7 +237,7 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
 
     /* This test is usable ONLY by <code>SetPropertyCommandTest</code> subclass */
     protected void getMatchingExpressionAlias() {
-        Optional<String> retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, VALUE_ELEMENTS, factIdentifierMock);
+        Optional<String> retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, MULTIPART_VALUE_ELEMENTS, factIdentifierMock);
         verify(simulationDescriptorMock, times(1)).getFactMappingsByFactName(eq(factIdentifierMock.getName()));
         assertEquals(Optional.empty(), retrieved);
         List<FactMapping> factMappingList = new ArrayList<>();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.drools.workbench.screens.scenariosimulation.model.ExpressionElement;
 import org.drools.workbench.screens.scenariosimulation.model.FactMapping;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModel;
@@ -75,7 +77,7 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         scenarioSimulationContextLocal.getStatus().setValueClassName(VALUE_CLASS_NAME);
         scenarioSimulationContextLocal.getStatus().setColumnId(COLUMN_ID);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(VALUE_LIST);
+        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(VALUE_ELEMENTS);
     }
 
     @Test
@@ -134,20 +136,20 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     public void executeKeepDataFalseDMN() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.DMN);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, VALUE_LIST, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataFalseRule() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, VALUE_LIST, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataTrue() {
         scenarioSimulationContextLocal.getStatus().setKeepData(true);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, VALUE_LIST, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, VALUE_ELEMENTS, VALUE_CLASS_NAME);
     }
 
     @Test
@@ -203,25 +205,25 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     /* This test is usable ONLY by <code>SetPropertyCommandTest</code> subclass */
     protected void getPropertyHeaderTitle() {
         Optional<String> emptyMatching = Optional.empty();
-        doReturn(emptyMatching).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE), eq(factIdentifierMock));
-        String retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, VALUE, factIdentifierMock);
-        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE), eq(factIdentifierMock));
+        doReturn(emptyMatching).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(factIdentifierMock));
+        String retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, VALUE_ELEMENTS, factIdentifierMock);
+        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(factIdentifierMock));
         assertEquals(VALUE, retrieved);
         String EXPECTED_VALUE_STRING = "EXPECTED_VALUE_STRING";
         Optional<String> expectedValue = Optional.of("EXPECTED_VALUE_STRING");
-        doReturn(expectedValue).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME), eq(factIdentifierMock));
-        retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, FULL_PROPERTY_NAME, factIdentifierMock);
-        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME), eq(factIdentifierMock));
+        doReturn(expectedValue).when((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME_ELEMENTS), eq(factIdentifierMock));
+        retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, FULL_PROPERTY_NAME_ELEMENTS, factIdentifierMock);
+        verify((AbstractSelectedColumnCommand) command, times(1)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME_ELEMENTS), eq(factIdentifierMock));
         assertEquals(EXPECTED_VALUE_STRING, retrieved);
-        String aliasedPropertyName = CLASS_NAME + "_ALIAS." + PROPERTY_NAME;
-        retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, aliasedPropertyName, factIdentifierMock);
-        verify((AbstractSelectedColumnCommand) command, times(2)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME), eq(factIdentifierMock));
+        List<String> aliasedPropertyNameElements = Arrays.asList(CLASS_NAME + "_ALIAS", PROPERTY_NAME);
+        retrieved = ((AbstractSelectedColumnCommand) command).getPropertyHeaderTitle(scenarioSimulationContextLocal, aliasedPropertyNameElements, factIdentifierMock);
+        verify((AbstractSelectedColumnCommand) command, times(2)).getMatchingExpressionAlias(eq(scenarioSimulationContextLocal), eq(FULL_PROPERTY_NAME_ELEMENTS), eq(factIdentifierMock));
         assertEquals(EXPECTED_VALUE_STRING, retrieved);
     }
 
     /* This test is usable ONLY by <code>SetPropertyCommandTest</code> subclass */
     protected void getMatchingExpressionAlias() {
-        Optional<String> retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, VALUE, factIdentifierMock);
+        Optional<String> retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, VALUE_ELEMENTS, factIdentifierMock);
         verify(simulationDescriptorMock, times(1)).getFactMappingsByFactName(eq(factIdentifierMock.getName()));
         assertEquals(Optional.empty(), retrieved);
         List<FactMapping> factMappingList = new ArrayList<>();
@@ -229,10 +231,11 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         factMappingList.add(factMappingMock);
         String EXPRESSION_ALIAS = "EXPRESSION_ALIAS";
         when(factMappingMock.getExpressionAlias()).thenReturn(EXPRESSION_ALIAS);
-        retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, FULL_PROPERTY_NAME, factIdentifierMock);
+        retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, FULL_PROPERTY_NAME_ELEMENTS, factIdentifierMock);
         assertEquals(Optional.empty(), retrieved);
-        when(factMappingMock.getFullExpression()).thenReturn(FULL_PROPERTY_NAME);
-        retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, FULL_PROPERTY_NAME, factIdentifierMock);
+        List<ExpressionElement> expressionElements = FULL_PROPERTY_NAME_ELEMENTS.stream().map(ExpressionElement::new).collect(Collectors.toList());
+        when(factMappingMock.getExpressionElements()).thenReturn(expressionElements);
+        retrieved = ((AbstractSelectedColumnCommand) command).getMatchingExpressionAlias(scenarioSimulationContextLocal, FULL_PROPERTY_NAME_ELEMENTS, factIdentifierMock);
         assertEquals(Optional.of(EXPRESSION_ALIAS), retrieved);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommandTest.java
@@ -54,6 +54,7 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     final private String FULL_CLASSNAME_CREATED = FULL_PACKAGE + "." + CLASS_NAME;
     final private String LIST_PROPERTY_NAME = "listProperty";
     final private String FULL_PROPERTY_PATH = CLASS_NAME + "." + LIST_PROPERTY_NAME;
+    final private List<String> FULL_PROPERTY_PATH_ELEMENTS = Arrays.asList(FULL_PROPERTY_PATH.split("\\."));
 
     @Mock
     protected List<GridColumn<?>> gridColumnsMock;
@@ -73,6 +74,7 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         scenarioSimulationContextLocal.getStatus().setValueClassName(VALUE_CLASS_NAME);
         scenarioSimulationContextLocal.getStatus().setColumnId(COLUMN_ID);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
+        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(VALUE_LIST);
     }
 
     @Test
@@ -127,25 +129,24 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
     }
 
     /* Tests related to setPropertyHeader method */
-
     @Test
     public void executeKeepDataFalseDMN() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.DMN);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, VALUE, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.DMN, false, VALUE_LIST, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataFalseRule() {
         scenarioSimulationContextLocal.getStatus().setKeepData(false);
         when(simulationDescriptorMock.getType()).thenReturn(ScenarioSimulationModel.Type.RULE);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, VALUE, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, false, VALUE_LIST, VALUE_CLASS_NAME);
     }
 
     @Test
     public void executeKeepDataTrue() {
         scenarioSimulationContextLocal.getStatus().setKeepData(true);
-        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, VALUE, VALUE_CLASS_NAME);
+        commonSetPropertyHeader(ScenarioSimulationModel.Type.RULE, true, VALUE_LIST, VALUE_CLASS_NAME);
     }
 
     @Test
@@ -153,22 +154,22 @@ public abstract class AbstractSelectedColumnCommandTest extends AbstractScenario
         scenarioSimulationContextLocal.getStatus().setValueClassName(LIST_CLASS_NAME);
         scenarioSimulationContextLocal.getStatus().setValue(FULL_PROPERTY_PATH);
         final List<String> fullPropertyPathElements = Arrays.asList(FULL_PROPERTY_PATH.split("\\."));
-        ((AbstractSelectedColumnCommand) command).setPropertyHeader(scenarioSimulationContextLocal, gridColumnMock, FULL_PROPERTY_PATH, LIST_CLASS_NAME, Optional.empty());
+        ((AbstractSelectedColumnCommand) command).setPropertyHeader(scenarioSimulationContextLocal, gridColumnMock, FULL_PROPERTY_PATH_ELEMENTS, LIST_CLASS_NAME, Optional.empty());
         verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
         verify(propertyHeaderMetaDataMock, times(1)).setTitle(LIST_PROPERTY_NAME);
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
-        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), eq(gridColumnMock), eq(FULL_PROPERTY_PATH), eq(LIST_CLASS_NAME), anyBoolean());
+        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), eq(gridColumnMock), eq(FULL_PROPERTY_PATH_ELEMENTS), eq(LIST_CLASS_NAME), anyBoolean());
         verify((AbstractSelectedColumnCommand) command, times(1)).manageCollectionProperty(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(FULL_CLASSNAME_CREATED), eq(0), eq(fullPropertyPathElements));
         verify((AbstractSelectedColumnCommand) command, times(1)).navigateComplexObject(eq(factModelTreeMock), eq(fullPropertyPathElements), eq(scenarioSimulationContextLocal.getDataObjectFieldsMap()));
     }
 
-    protected void commonSetPropertyHeader(ScenarioSimulationModel.Type type, boolean keepData, String value, String propertyClass) {
-        ((AbstractSelectedColumnCommand) command).setPropertyHeader(scenarioSimulationContextLocal, gridColumnMock, value, propertyClass, Optional.empty());
+    protected void commonSetPropertyHeader(ScenarioSimulationModel.Type type, boolean keepData, List<String> propertyNameElements, String propertyClass) {
+        ((AbstractSelectedColumnCommand) command).setPropertyHeader(scenarioSimulationContextLocal, gridColumnMock, propertyNameElements, propertyClass, Optional.empty());
         verify(gridColumnMock, times(1)).setEditableHeaders(eq(!type.equals(ScenarioSimulationModel.Type.DMN)));
         verify(propertyHeaderMetaDataMock, times(1)).setColumnGroup(anyString());
-        verify(propertyHeaderMetaDataMock, times(1)).setTitle(value);
+        verify(propertyHeaderMetaDataMock, times(1)).setTitle(propertyNameElements.get(0));
         verify(propertyHeaderMetaDataMock, times(1)).setReadOnly(false);
-        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), isA(ScenarioGridColumn.class), eq(value), eq(propertyClass), eq(keepData));
+        verify(scenarioGridModelMock, times(1)).updateColumnProperty(anyInt(), isA(ScenarioGridColumn.class), eq(propertyNameElements), eq(propertyClass), eq(keepData));
         verify(scenarioSimulationContextLocal.getScenarioSimulationEditorPresenter(), times(1)).reloadTestTools(false);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AppendColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AppendColumnCommandTest.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIRST_INDEX_RIGHT;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommandTest.java
@@ -26,6 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteRowCommandTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommandTest.java
@@ -36,6 +36,20 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_NUMBER;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_ALIAS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_ALIAS_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_IDENTIFIER_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_IDENTIFIER_NAME_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_ID_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_PROPERTY_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_PROPERTY_TITLE_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -49,12 +63,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 @RunWith(GwtMockitoTestRunner.class)
 public class DuplicateInstanceCommandTest extends AbstractSelectedColumnCommandTest {
 
-    protected String GRID_COLUMN_ID_1 = GRID_COLUMN_ID + "_1";
-    protected String GRID_PROPERTY_TITLE_1 = GRID_PROPERTY_TITLE + "_1";
-    protected String FACT_ALIAS_1 = FACT_ALIAS + "_1";
-    protected String FULL_CLASS_NAME_1 = FULL_CLASS_NAME + "_1";
-    protected String FACT_IDENTIFIER_NAME_1 = FACT_IDENTIFIER_NAME + "_1";
-    protected String VALUE_1 = VALUE + "_1";
+
 
     @Mock
     protected ScenarioGridColumn scenarioGridColumnMock1;
@@ -155,17 +164,17 @@ public class DuplicateInstanceCommandTest extends AbstractSelectedColumnCommandT
     public void executeIfSelectedColumn_WithInstanceAndPropertyAndThreeColumns() {
         final String SECOND = "SECOND";
         addNewColumn(scenarioGridColumnMock2, headerMetaDatasMock2, informationHeaderMetaDataMock2, propertyHeaderMetaDataMock2, factIdentifierMock2, factMappingMock2,
-                     factMappingValueMock2, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 1, VALUE + "_2", GRID_PROPERTY_TITLE + "_2", GRID_COLUMN_ID + "_2", FACT_ALIAS + "_2", VALUE_CLASS_NAME,
+                     factMappingValueMock2, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 1, MULTIPART_VALUE + "_2", GRID_PROPERTY_TITLE + "_2", GRID_COLUMN_ID + "_2", FACT_ALIAS + "_2", VALUE_CLASS_NAME,
                      SECOND, FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_2");
         final String THIRD = "THIRD";
         addNewColumn(scenarioGridColumnMock3, headerMetaDatasMock3, informationHeaderMetaDataMock2, propertyHeaderMetaDataMock3, factIdentifierMock2, factMappingMock3,
-                     factMappingValueMock3, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 2, VALUE + "_2", GRID_PROPERTY_TITLE + "_3", GRID_COLUMN_ID + "_3", FACT_ALIAS + "_3", VALUE_CLASS_NAME,
+                     factMappingValueMock3, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 2, MULTIPART_VALUE + "_2", GRID_PROPERTY_TITLE + "_3", GRID_COLUMN_ID + "_3", FACT_ALIAS + "_3", VALUE_CLASS_NAME,
                      THIRD, FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_3");
         ((DuplicateInstanceCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, scenarioGridColumnMock2);
         verify(scenarioGridModelMock, times(1)).getInstancesCount(eq(scenarioGridColumnMock2.getFactIdentifier().getClassName()));
         verify((DuplicateInstanceCommand) command, times(1)).insertNewColumn(eq(scenarioSimulationContextLocal), eq(scenarioGridColumnMock2), eq(7), eq(Boolean.FALSE));
         verify((DuplicateInstanceCommand) command, times(1)).insertNewColumn(eq(scenarioSimulationContextLocal), eq(scenarioGridColumnMock3), eq(8), eq(Boolean.FALSE));
-        String expectedDuplicatedLabelSecond = VALUE + "_2" + DuplicateInstanceCommand.COPY_LABEL + "2";
+        String expectedDuplicatedLabelSecond = MULTIPART_VALUE + "_2" + DuplicateInstanceCommand.COPY_LABEL + "2";
         verify((DuplicateInstanceCommand) command, times(2)).setInstanceHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedDuplicatedLabelSecond), eq(FULL_CLASS_NAME + "_2"));
         List<String> expectedPropertyNameElementsSecond = Arrays.asList(expectedDuplicatedLabelSecond, SECOND);
         List<String> expectedPropertyNameElementsThird = Arrays.asList(expectedDuplicatedLabelSecond, THIRD);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateInstanceCommandTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -143,26 +144,33 @@ public class DuplicateInstanceCommandTest extends AbstractSelectedColumnCommandT
         ((DuplicateInstanceCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, scenarioGridColumnMock1);
         verify(scenarioGridModelMock, times(1)).getInstancesCount(eq(scenarioGridColumnMock1.getFactIdentifier().getClassName()));
         verify((DuplicateInstanceCommand) command, times(1)).insertNewColumn(eq(scenarioSimulationContextLocal), eq(scenarioGridColumnMock1), eq(COLUMN_NUMBER + 1), eq(Boolean.FALSE));
-        verify((DuplicateInstanceCommand) command, times(1)).setInstanceHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE_1 + DuplicateInstanceCommand.COPY_LABEL + "1"), eq(FULL_CLASS_NAME_1));
-        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq("value_1_copy_1.test"), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE_1)));
+        String expectedDuplicatedLabel = VALUE_1 + DuplicateInstanceCommand.COPY_LABEL + "1";
+        verify((DuplicateInstanceCommand) command, times(1)).setInstanceHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedDuplicatedLabel), eq(FULL_CLASS_NAME_1));
+        List<String> expectedPropertyNameElements = Arrays.asList(expectedDuplicatedLabel, "test");
+        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedPropertyNameElements), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE_1)));
         verify(scenarioGridModelMock, times(1)).duplicateColumnValues(eq(COLUMN_NUMBER), eq(0)); // The created column is mocked as gridColumnMock, with position 0
     }
 
     @Test
     public void executeIfSelectedColumn_WithInstanceAndPropertyAndThreeColumns() {
+        final String SECOND = "SECOND";
         addNewColumn(scenarioGridColumnMock2, headerMetaDatasMock2, informationHeaderMetaDataMock2, propertyHeaderMetaDataMock2, factIdentifierMock2, factMappingMock2,
                      factMappingValueMock2, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 1, VALUE + "_2", GRID_PROPERTY_TITLE + "_2", GRID_COLUMN_ID + "_2", FACT_ALIAS + "_2", VALUE_CLASS_NAME,
-                     "second", FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_2");
+                     SECOND, FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_2");
+        final String THIRD = "THIRD";
         addNewColumn(scenarioGridColumnMock3, headerMetaDatasMock3, informationHeaderMetaDataMock2, propertyHeaderMetaDataMock3, factIdentifierMock2, factMappingMock3,
                      factMappingValueMock3, COLUMN_NUMBER + 1, COLUMN_NUMBER + 2, COLUMN_NUMBER + 2, VALUE + "_2", GRID_PROPERTY_TITLE + "_3", GRID_COLUMN_ID + "_3", FACT_ALIAS + "_3", VALUE_CLASS_NAME,
-                     "third", FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_3");
+                     THIRD, FULL_CLASS_NAME + "_2", FACT_IDENTIFIER_NAME + "_3");
         ((DuplicateInstanceCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, scenarioGridColumnMock2);
         verify(scenarioGridModelMock, times(1)).getInstancesCount(eq(scenarioGridColumnMock2.getFactIdentifier().getClassName()));
         verify((DuplicateInstanceCommand) command, times(1)).insertNewColumn(eq(scenarioSimulationContextLocal), eq(scenarioGridColumnMock2), eq(7), eq(Boolean.FALSE));
         verify((DuplicateInstanceCommand) command, times(1)).insertNewColumn(eq(scenarioSimulationContextLocal), eq(scenarioGridColumnMock3), eq(8), eq(Boolean.FALSE));
-        verify((DuplicateInstanceCommand) command, times(2)).setInstanceHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE + "_2" + DuplicateInstanceCommand.COPY_LABEL + "2"), eq(FULL_CLASS_NAME + "_2"));
-        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq("value_2_copy_2.second"), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE + "_2")));
-        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq("value_2_copy_2.third"), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE + "_3")));
+        String expectedDuplicatedLabelSecond = VALUE + "_2" + DuplicateInstanceCommand.COPY_LABEL + "2";
+        verify((DuplicateInstanceCommand) command, times(2)).setInstanceHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedDuplicatedLabelSecond), eq(FULL_CLASS_NAME + "_2"));
+        List<String> expectedPropertyNameElementsSecond = Arrays.asList(expectedDuplicatedLabelSecond, SECOND);
+        List<String> expectedPropertyNameElementsThird = Arrays.asList(expectedDuplicatedLabelSecond, THIRD);
+        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedPropertyNameElementsSecond), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE + "_2")));
+        verify((DuplicateInstanceCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(expectedPropertyNameElementsThird), eq(VALUE_CLASS_NAME), eq(Optional.of(GRID_PROPERTY_TITLE + "_3")));
         verify(scenarioGridModelMock, times(1)).duplicateColumnValues(eq(COLUMN_NUMBER + 1), eq(0)); // The created column is mocked as gridColumnMock, with position 0
         verify(scenarioGridModelMock, times(1)).duplicateColumnValues(eq(COLUMN_NUMBER + 2), eq(0)); // The created column is mocked as gridColumnMock, with position 0
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DuplicateRowCommandTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.verify;
 @RunWith(GwtMockitoTestRunner.class)
 public class EnableTestToolsCommandTest extends AbstractScenarioSimulationCommandTest {
 
-    private static final String FACT_NAME = "FACT_NAME";
+
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/EnableTestToolsCommandTest.java
@@ -45,7 +45,7 @@ public class EnableTestToolsCommandTest extends AbstractScenarioSimulationComman
     public void executeWithFactName() {
         scenarioSimulationContextLocal.setTestToolsPresenter(testToolsPresenterMock);
         scenarioSimulationContextLocal.getStatus().setFilterTerm(FACT_NAME);
-        scenarioSimulationContextLocal.getStatus().setPropertyName(null);
+        scenarioSimulationContextLocal.getStatus().setPropertyNameElements(null);
         scenarioSimulationContextLocal.getStatus().setNotEqualsSearch(true);
         command.execute(scenarioSimulationContextLocal);
         verify(testToolsPresenterMock, times(1)).onEnableEditorTab(eq(FACT_NAME), eq(null), eq(true));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/ImportCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/ImportCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_CONTENT;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.verify;
 @RunWith(GwtMockitoTestRunner.class)
 public class ImportCommandTest extends AbstractScenarioSimulationCommandTest {
 
-    private static final String FILE_CONTENT = "FILE_CONTENT";
+
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/InsertColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/InsertColumnCommandTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/InsertRowCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/InsertRowCommandTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/PrependColumnCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/PrependColumnCommandTest.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIRST_INDEX_LEFT;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/RunSingleScenarioCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/RunSingleScenarioCommandTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommandTest.java
@@ -22,6 +22,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -43,7 +46,7 @@ public class SetGridCellValueCommandTest extends AbstractScenarioSimulationComma
     public void execute() {
         scenarioSimulationContextLocal.getStatus().setRowIndex(ROW_INDEX);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setGridCellValue(VALUE);
+        scenarioSimulationContextLocal.getStatus().setGridCellValue(MULTIPART_VALUE);
         command.execute(scenarioSimulationContextLocal);
         verify(scenarioGridModelMock, times(1)).setCellValue(eq(ROW_INDEX), eq(COLUMN_INDEX), isA(ScenarioGridCellValue.class));
         verify(scenarioGridModelMock, times(1)).resetErrors(eq(ROW_INDEX));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommandTest.java
@@ -43,7 +43,7 @@ public class SetGridCellValueCommandTest extends AbstractScenarioSimulationComma
     public void execute() {
         scenarioSimulationContextLocal.getStatus().setRowIndex(ROW_INDEX);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setCellValue(VALUE);
+        scenarioSimulationContextLocal.getStatus().setGridCellValue(VALUE);
         command.execute(scenarioSimulationContextLocal);
         verify(scenarioGridModelMock, times(1)).setCellValue(eq(ROW_INDEX), eq(COLUMN_INDEX), isA(ScenarioGridCellValue.class));
         verify(scenarioGridModelMock, times(1)).resetErrors(eq(ROW_INDEX));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
@@ -111,10 +113,10 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         FactModelTree authorFactModelTreeMock = getMockedFactModelTree(authorSimpleProperties, authorExpandableProperties);
         when(dataObjectFieldsMapMock.get("Author")).thenReturn(authorFactModelTreeMock);
         when(dataObjectFieldsMapMock.get("Book")).thenReturn(bookFactModelTreeMock);
-        assertFalse(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, "not-existing"));
-        assertTrue(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, "name"));
-        assertFalse(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, "author.not-existing"));
-        assertTrue(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, "author.books"));
+        assertFalse(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, Collections.singletonList("not-existing")));
+        assertTrue(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, Collections.singletonList("name")));
+        assertFalse(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, Arrays.asList("author", "not-existing")));
+        assertTrue(((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, Arrays.asList("author", "books")));
     }
 
     private FactModelTree getMockedFactModelTree(Map<String, String> simpleProperties, Map<String, String> expandableProperties) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -28,6 +28,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
@@ -50,7 +55,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         command = spy(new SetHeaderCellValueCommand());
         scenarioSimulationContextLocal.getStatus().setRowIndex(ROW_INDEX);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setGridCellValue(VALUE);
+        scenarioSimulationContextLocal.getStatus().setGridCellValue(MULTIPART_VALUE);
         assertTrue(command.isUndoable());
     }
 
@@ -129,47 +134,50 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
     private void commonExecute(boolean isInstanceHeader, boolean isPropertyHeader, boolean isValid) {
         ((SetHeaderCellValueCommand) command).isInstanceHeader = isInstanceHeader;
         ((SetHeaderCellValueCommand) command).isPropertyHeader = isPropertyHeader;
-        scenarioSimulationContextLocal.getStatus().setHeaderCellElements(VALUE_ELEMENTS);
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+        scenarioSimulationContextLocal.getStatus().setHeaderCellValue(MULTIPART_VALUE);
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX));
         command.execute(scenarioSimulationContextLocal);
         if (isInstanceHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         } else if (isPropertyHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX));
         } else {
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         }
         if (isValid) {
-            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_ELEMENTS));
+            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(MULTIPART_VALUE));
         }
     }
 
     private void commonValidateInstanceHeader(boolean isADataType) {
-        doReturn(isADataType).when(dataObjectFieldsMapMock).containsKey(VALUE);
-        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, VALUE_ELEMENTS, COLUMN_INDEX);
-        verify(dataObjectFieldsMapMock, times(1)).containsKey(eq(VALUE));
-        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isADataType));
+        doReturn(isADataType).when(dataObjectFieldsMapMock).containsKey(LOWER_CASE_VALUE);
+        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, LOWER_CASE_VALUE, COLUMN_INDEX);
+        verify(dataObjectFieldsMapMock, times(1)).containsKey(eq(LOWER_CASE_VALUE));
+        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(LOWER_CASE_VALUE), eq(COLUMN_INDEX), eq(isADataType));
         reset(dataObjectFieldsMapMock);
         reset(scenarioGridModelMock);
     }
 
     private void commonValidatePropertyHeader(boolean factModelPresent, boolean simplePropertyPresent) {
         FactModelTree factModelTreeMock = mock(FactModelTree.class);
+        doReturn(simplePropertyPresent).when((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(eq(scenarioSimulationContextLocal), eq(factModelTreeMock), eq(MULTIPART_VALUE_ELEMENTS));
         if (factModelPresent) {
             Map<String, String> simplePropertiesMock = mock(SortedMap.class);
             when(factModelTreeMock.getSimpleProperties()).thenReturn(simplePropertiesMock);
-            when(factModelTreeMock.getExpandableProperties()).thenReturn(mock(SortedMap.class));
+            Map<String, String> expandablePropertiesMock = mock(SortedMap.class);
+            when(factModelTreeMock.getExpandableProperties()).thenReturn(expandablePropertiesMock);
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(factModelTreeMock);
-            doReturn(simplePropertyPresent).when(simplePropertiesMock).containsKey(eq(VALUE));
+            doReturn(simplePropertyPresent).when(simplePropertiesMock).containsKey(eq(MULTIPART_VALUE_ELEMENTS.get(0)));
+            doReturn(simplePropertyPresent).when(expandablePropertiesMock).containsKey(eq(MULTIPART_VALUE_ELEMENTS.get(0)));
         } else {
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(null);
         }
         boolean isPropertyType = factModelPresent && simplePropertyPresent;
-        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, VALUE_ELEMENTS, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, MULTIPART_VALUE_ELEMENTS, COLUMN_INDEX);
         verify(simulationDescriptorMock, times(1)).getFactMappingByIndex(eq(COLUMN_INDEX));
-        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isPropertyType));
+        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isPropertyType));
         reset(simulationDescriptorMock);
         reset(scenarioGridModelMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -136,12 +136,12 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         ((SetHeaderCellValueCommand) command).isPropertyHeader = isPropertyHeader;
         scenarioSimulationContextLocal.getStatus().setHeaderCellValue(MULTIPART_VALUE);
         doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX));
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         command.execute(scenarioSimulationContextLocal);
         if (isInstanceHeader) {
             verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         } else if (isPropertyHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         } else {
             verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
             verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
@@ -175,9 +175,9 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(null);
         }
         boolean isPropertyType = factModelPresent && simplePropertyPresent;
-        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, MULTIPART_VALUE_ELEMENTS, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, MULTIPART_VALUE, COLUMN_INDEX);
         verify(simulationDescriptorMock, times(1)).getFactMappingByIndex(eq(COLUMN_INDEX));
-        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(MULTIPART_VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isPropertyType));
+        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(MULTIPART_VALUE), eq(COLUMN_INDEX), eq(isPropertyType));
         reset(simulationDescriptorMock);
         reset(scenarioGridModelMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -129,28 +129,28 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
     private void commonExecute(boolean isInstanceHeader, boolean isPropertyHeader, boolean isValid) {
         ((SetHeaderCellValueCommand) command).isInstanceHeader = isInstanceHeader;
         ((SetHeaderCellValueCommand) command).isPropertyHeader = isPropertyHeader;
-        scenarioSimulationContextLocal.getStatus().setHeaderCellElements(VALUE_LIST);
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+        scenarioSimulationContextLocal.getStatus().setHeaderCellElements(VALUE_ELEMENTS);
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
         command.execute(scenarioSimulationContextLocal);
         if (isInstanceHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
         } else if (isPropertyHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
         } else {
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_ELEMENTS), eq(COLUMN_INDEX));
         }
         if (isValid) {
-            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_LIST));
+            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_ELEMENTS));
         }
     }
 
     private void commonValidateInstanceHeader(boolean isADataType) {
         doReturn(isADataType).when(dataObjectFieldsMapMock).containsKey(VALUE);
-        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, VALUE_LIST, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, VALUE_ELEMENTS, COLUMN_INDEX);
         verify(dataObjectFieldsMapMock, times(1)).containsKey(eq(VALUE));
-        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(VALUE_LIST), eq(COLUMN_INDEX), eq(isADataType));
+        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isADataType));
         reset(dataObjectFieldsMapMock);
         reset(scenarioGridModelMock);
     }
@@ -167,9 +167,9 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(null);
         }
         boolean isPropertyType = factModelPresent && simplePropertyPresent;
-        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, VALUE_LIST, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, VALUE_ELEMENTS, COLUMN_INDEX);
         verify(simulationDescriptorMock, times(1)).getFactMappingByIndex(eq(COLUMN_INDEX));
-        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(VALUE_LIST), eq(COLUMN_INDEX), eq(isPropertyType));
+        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(VALUE_ELEMENTS), eq(COLUMN_INDEX), eq(isPropertyType));
         reset(simulationDescriptorMock);
         reset(scenarioGridModelMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -60,48 +61,48 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
     }
 
     @Test
-    public void executeInstanceHeaderValid() {
+    public void executeInstanceHeaderValid() throws Exception {
         commonExecute(true, false, true);
     }
 
     @Test
-    public void executeInstanceHeaderInvalid() {
+    public void executeInstanceHeaderInvalid() throws Exception {
         commonExecute(true, false, false);
     }
 
     @Test
-    public void executePropertyHeaderValid() {
+    public void executePropertyHeaderValid() throws Exception {
         commonExecute(false, true, true);
     }
 
     @Test
-    public void executePropertyHeaderInvalid() {
+    public void executePropertyHeaderInvalid() throws Exception {
         commonExecute(false, true, false);
     }
 
     @Test
-    public void executeOtherHeader() {
+    public void executeOtherHeader() throws Exception {
         commonExecute(false, false, false);
     }
 
     @Test
-    public void validateInstanceHeader() {
+    public void validateInstanceHeader() throws Exception {
         commonValidateInstanceHeader(false);
         commonValidateInstanceHeader(true);
     }
 
     @Test
-    public void validatePropertyHeaderNoFactModelMapped() {
+    public void validatePropertyHeaderNoFactModelMapped() throws Exception {
         commonValidatePropertyHeader(false, false);
     }
 
     @Test
-    public void validatePropertyHeaderFactModelMappedNoProperty() {
-        commonValidatePropertyHeader(true, true);
+    public void validatePropertyHeaderFactModelMappedNoProperty() throws Exception {
+        commonValidatePropertyHeader(true, false);
     }
 
     @Test
-    public void validatePropertyHeaderFactModelMappedProperty() {
+    public void validatePropertyHeaderFactModelMappedProperty() throws Exception {
         commonValidatePropertyHeader(true, true);
     }
 
@@ -131,12 +132,12 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         return toReturn;
     }
 
-    private void commonExecute(boolean isInstanceHeader, boolean isPropertyHeader, boolean isValid) {
+    private void commonExecute(boolean isInstanceHeader, boolean isPropertyHeader, boolean isValid) throws Exception {
         ((SetHeaderCellValueCommand) command).isInstanceHeader = isInstanceHeader;
         ((SetHeaderCellValueCommand) command).isPropertyHeader = isPropertyHeader;
         scenarioSimulationContextLocal.getStatus().setHeaderCellValue(MULTIPART_VALUE);
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
+        doNothing().when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
+        doNothing().when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
         command.execute(scenarioSimulationContextLocal);
         if (isInstanceHeader) {
             verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(MULTIPART_VALUE), eq(COLUMN_INDEX));
@@ -151,8 +152,9 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         }
     }
 
-    private void commonValidateInstanceHeader(boolean isADataType) {
+    private void commonValidateInstanceHeader(boolean isADataType) throws Exception {
         doReturn(isADataType).when(dataObjectFieldsMapMock).containsKey(LOWER_CASE_VALUE);
+        doNothing().when(scenarioGridModelMock).validateInstanceHeaderUpdate(eq(LOWER_CASE_VALUE), eq(COLUMN_INDEX), eq(isADataType));
         ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, LOWER_CASE_VALUE, COLUMN_INDEX);
         verify(dataObjectFieldsMapMock, times(1)).containsKey(eq(LOWER_CASE_VALUE));
         verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(LOWER_CASE_VALUE), eq(COLUMN_INDEX), eq(isADataType));
@@ -160,7 +162,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         reset(scenarioGridModelMock);
     }
 
-    private void commonValidatePropertyHeader(boolean factModelPresent, boolean simplePropertyPresent) {
+    private void commonValidatePropertyHeader(boolean factModelPresent, boolean simplePropertyPresent) throws Exception {
         FactModelTree factModelTreeMock = mock(FactModelTree.class);
         doReturn(simplePropertyPresent).when((SetHeaderCellValueCommand) command).recursivelyFindIsPropertyType(eq(scenarioSimulationContextLocal), eq(factModelTreeMock), eq(MULTIPART_VALUE_ELEMENTS));
         if (factModelPresent) {
@@ -175,6 +177,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(null);
         }
         boolean isPropertyType = factModelPresent && simplePropertyPresent;
+        doNothing().when(scenarioGridModelMock).validatePropertyHeaderUpdate(eq(MULTIPART_VALUE), eq(COLUMN_INDEX), eq(isPropertyType));
         ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, MULTIPART_VALUE, COLUMN_INDEX);
         verify(simulationDescriptorMock, times(1)).getFactMappingByIndex(eq(COLUMN_INDEX));
         verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(MULTIPART_VALUE), eq(COLUMN_INDEX), eq(isPropertyType));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -46,7 +46,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
         command = spy(new SetHeaderCellValueCommand());
         scenarioSimulationContextLocal.getStatus().setRowIndex(ROW_INDEX);
         scenarioSimulationContextLocal.getStatus().setColumnIndex(COLUMN_INDEX);
-        scenarioSimulationContextLocal.getStatus().setCellValue(VALUE);
+        scenarioSimulationContextLocal.getStatus().setGridCellValue(VALUE);
         assertTrue(command.isUndoable());
     }
 
@@ -99,27 +99,28 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
     private void commonExecute(boolean isInstanceHeader, boolean isPropertyHeader, boolean isValid) {
         ((SetHeaderCellValueCommand) command).isInstanceHeader = isInstanceHeader;
         ((SetHeaderCellValueCommand) command).isPropertyHeader = isPropertyHeader;
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
-        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
+        scenarioSimulationContextLocal.getStatus().setHeaderCellElements(VALUE_LIST);
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+        doReturn(isValid).when(((SetHeaderCellValueCommand) command)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
         command.execute(scenarioSimulationContextLocal);
         if (isInstanceHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
         } else if (isPropertyHeader) {
-            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), times(1)).validatePropertyHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
         } else {
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
-            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
+            verify(((SetHeaderCellValueCommand) command), never()).validateInstanceHeader(eq(scenarioSimulationContextLocal), eq(VALUE_LIST), eq(COLUMN_INDEX));
         }
         if (isValid) {
-            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE));
+            verify(scenarioGridModelMock, times(1)).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_LIST));
         }
     }
 
     private void commonValidateInstanceHeader(boolean isADataType) {
         doReturn(isADataType).when(dataObjectFieldsMapMock).containsKey(VALUE);
-        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, VALUE, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validateInstanceHeader(scenarioSimulationContextLocal, VALUE_LIST, COLUMN_INDEX);
         verify(dataObjectFieldsMapMock, times(1)).containsKey(eq(VALUE));
-        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(VALUE), eq(COLUMN_INDEX), eq(isADataType));
+        verify(scenarioGridModelMock, times(1)).validateInstanceHeaderUpdate(eq(VALUE_LIST), eq(COLUMN_INDEX), eq(isADataType));
         reset(dataObjectFieldsMapMock);
         reset(scenarioGridModelMock);
     }
@@ -136,9 +137,9 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioSimulationCom
             when(dataObjectFieldsMapMock.get(anyString())).thenReturn(null);
         }
         boolean isPropertyType = factModelPresent && simplePropertyPresent;
-        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, VALUE, COLUMN_INDEX);
+        ((SetHeaderCellValueCommand) command).validatePropertyHeader(scenarioSimulationContextLocal, VALUE_LIST, COLUMN_INDEX);
         verify(simulationDescriptorMock, times(1)).getFactMappingByIndex(eq(COLUMN_INDEX));
-        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(VALUE), eq(COLUMN_INDEX), eq(isPropertyType));
+        verify(scenarioGridModelMock, times(1)).validatePropertyHeaderUpdate(eq(VALUE_LIST), eq(COLUMN_INDEX), eq(isPropertyType));
         reset(simulationDescriptorMock);
         reset(scenarioGridModelMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
@@ -31,6 +31,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -27,6 +27,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
@@ -55,7 +57,7 @@ public class SetPropertyHeaderCommandTest extends AbstractSelectedColumnCommandT
     @Test
     public void executeIfSelected() {
         ((SetPropertyHeaderCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, gridColumnMock);
-        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE_ELEMENTS), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
+        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(MULTIPART_VALUE_ELEMENTS), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -55,7 +55,7 @@ public class SetPropertyHeaderCommandTest extends AbstractSelectedColumnCommandT
     @Test
     public void executeIfSelected() {
         ((SetPropertyHeaderCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, gridColumnMock);
-        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE_LIST), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
+        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE_ELEMENTS), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetPropertyHeaderCommandTest.java
@@ -55,7 +55,7 @@ public class SetPropertyHeaderCommandTest extends AbstractSelectedColumnCommandT
     @Test
     public void executeIfSelected() {
         ((SetPropertyHeaderCommand) command).executeIfSelectedColumn(scenarioSimulationContextLocal, gridColumnMock);
-        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
+        verify((SetPropertyHeaderCommand) command, times(1)).setPropertyHeader(eq(scenarioSimulationContextLocal), eq(gridColumnMock), eq(VALUE_LIST), eq(VALUE_CLASS_NAME), eq(Optional.empty()));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioCellTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioCellTextAreaDOMElementTest.java
@@ -27,6 +27,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -62,18 +64,18 @@ public class ScenarioCellTextAreaDOMElementTest extends AbstractFactoriesTest {
 
     @Test
     public void flushSameValue() {
-        when(gridCellValueMock.getValue()).thenReturn(VALUE);
-        scenarioCellTextAreaDOMElement.flush(VALUE);
+        when(gridCellValueMock.getValue()).thenReturn(MULTIPART_VALUE);
+        scenarioCellTextAreaDOMElement.flush(MULTIPART_VALUE);
         verify(scenarioGridCellMock, times(1)).setEditingMode(eq(false));
         verify(scenarioCellTextAreaDOMElement, never()).internalFlush(anyString());
     }
 
     @Test
     public void flushDifferentValue() {
-        when(gridCellValueMock.getValue()).thenReturn("TEST");
-        scenarioCellTextAreaDOMElement.flush(VALUE);
+        when(gridCellValueMock.getValue()).thenReturn(TEST);
+        scenarioCellTextAreaDOMElement.flush(MULTIPART_VALUE);
         verify(scenarioGridCellMock, times(1)).setEditingMode(eq(false));
-        verify(scenarioCellTextAreaDOMElement, times(1)).internalFlush(eq(VALUE));
+        verify(scenarioCellTextAreaDOMElement, times(1)).internalFlush(eq(MULTIPART_VALUE));
     }
 
     @Test
@@ -95,7 +97,7 @@ public class ScenarioCellTextAreaDOMElementTest extends AbstractFactoriesTest {
 
     @Test
     public void internalFlush() {
-        scenarioCellTextAreaDOMElement.internalFlush(VALUE);
+        scenarioCellTextAreaDOMElement.internalFlush(MULTIPART_VALUE);
         verify(eventBusMock, times(1)).fireEvent(isA(SetGridCellValueEvent.class));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -81,7 +81,7 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
     @Test
     public void internalFlushInvalidHeader() {
         scenarioHeaderTextAreaDOMElement.internalFlush(VALUE);
-        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_LIST));
+        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_ELEMENTS));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
@@ -42,8 +45,6 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
     @Mock
     private ScenarioHeaderMetaData scenarioHeaderMetaDataMock;
 
-    private final String VALUE = "VALUE";
-
     @Before
     public void setup() {
         super.setup();
@@ -57,36 +58,36 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
 
     @Test
     public void flushMetadataEqualsValue() {
-        when(scenarioHeaderMetaDataMock.getTitle()).thenReturn(VALUE);
+        when(scenarioHeaderMetaDataMock.getTitle()).thenReturn(MULTIPART_VALUE);
         scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(scenarioHeaderMetaDataMock);
-        scenarioHeaderTextAreaDOMElement.flush(VALUE);
-        verify(scenarioHeaderTextAreaDOMElement, never()).internalFlush(eq(VALUE));
+        scenarioHeaderTextAreaDOMElement.flush(MULTIPART_VALUE);
+        verify(scenarioHeaderTextAreaDOMElement, never()).internalFlush(eq(MULTIPART_VALUE));
     }
 
     @Test
     public void flushMetadataNotEqualsValue() {
         when(scenarioHeaderMetaDataMock.getTitle()).thenReturn("NOT_VALUE");
         scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(scenarioHeaderMetaDataMock);
-        scenarioHeaderTextAreaDOMElement.flush(VALUE);
-        verify(scenarioHeaderTextAreaDOMElement, times(1)).internalFlush(eq(VALUE));
+        scenarioHeaderTextAreaDOMElement.flush(MULTIPART_VALUE);
+        verify(scenarioHeaderTextAreaDOMElement, times(1)).internalFlush(eq(MULTIPART_VALUE));
     }
 
     @Test
     public void flushNullMetadata() {
         scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(null);
-        scenarioHeaderTextAreaDOMElement.flush(VALUE);
-        verify(scenarioHeaderTextAreaDOMElement, times(1)).internalFlush(eq(VALUE));
+        scenarioHeaderTextAreaDOMElement.flush(MULTIPART_VALUE);
+        verify(scenarioHeaderTextAreaDOMElement, times(1)).internalFlush(eq(MULTIPART_VALUE));
     }
 
     @Test
     public void internalFlushInvalidHeader() {
-        scenarioHeaderTextAreaDOMElement.internalFlush(VALUE);
-        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_ELEMENTS));
+        scenarioHeaderTextAreaDOMElement.internalFlush(MULTIPART_VALUE);
+        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(MULTIPART_VALUE));
     }
 
     @Test
     public void internalFlushValidHeader() {
-        scenarioHeaderTextAreaDOMElement.internalFlush(VALUE);
+        scenarioHeaderTextAreaDOMElement.internalFlush(MULTIPART_VALUE);
         verify(eventBusMock, times(1)).fireEvent(isA(SetHeaderCellValueEvent.class));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -81,7 +81,7 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
     @Test
     public void internalFlushInvalidHeader() {
         scenarioHeaderTextAreaDOMElement.internalFlush(VALUE);
-        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE));
+        verify(scenarioGridModelMock, never()).updateHeader(eq(COLUMN_INDEX), eq(ROW_INDEX), eq(VALUE_LIST));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -86,6 +86,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
 import static org.drools.workbench.screens.scenariosimulation.client.handlers.ScenarioSimulationDocksHandler.SCESIMEDITOR_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -655,8 +656,8 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
 
         test1.addExpressionElement("test", String.class.getCanonicalName());
         Scenario scenario = simulation.addScenario();
-        scenario.addMappingValue(test1.getFactIdentifier(), test1.getExpressionIdentifier(), "value");
-        scenario.addMappingValue(test2.getFactIdentifier(), test2.getExpressionIdentifier(), "value");
+        scenario.addMappingValue(test1.getFactIdentifier(), test1.getExpressionIdentifier(), LOWER_CASE_VALUE);
+        scenario.addMappingValue(test2.getFactIdentifier(), test2.getExpressionIdentifier(), LOWER_CASE_VALUE);
 
         presenter.cleanReadOnlyColumn(simulation);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractDataManagementStrategyTest extends AbstractScenari
                 doReturn(new ArrayList<>()).when(abstractDataManagementStrategySpy).getPropertiesToHide(eq(gridColumnMock), eq(scenarioGridModelMock));
             }
         }
-        final Map<String, List<String>> retrieved = abstractDataManagementStrategySpy.getPropertiesToHide(scenarioGridModelMock);
+        final Map<String, List<List<String>>> retrieved = abstractDataManagementStrategySpy.getPropertiesToHide(scenarioGridModelMock);
         if (selectedColumnNull) {
             assertTrue(retrieved.isEmpty());
             verify(abstractDataManagementStrategySpy, never()).getPropertiesToHide(isA(ScenarioGridColumn.class), eq(scenarioGridModelMock));
@@ -96,7 +96,7 @@ public abstract class AbstractDataManagementStrategyTest extends AbstractScenari
 
     private void commonGetPropertiesToHideList(boolean isPropertyAssigned) {
         doReturn(isPropertyAssigned).when(gridColumnMock).isPropertyAssigned();
-        List<String> retrieved = abstractDataManagementStrategySpy.getPropertiesToHide(gridColumnMock, scenarioGridModelMock);
+        List<List<String>> retrieved = abstractDataManagementStrategySpy.getPropertiesToHide(gridColumnMock, scenarioGridModelMock);
         if (isPropertyAssigned) {
             assertTrue(retrieved.isEmpty());
             verify(scenarioGridModelMock, never()).getSimulation();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategyTest.java
@@ -40,6 +40,9 @@ import org.mockito.Mock;
 import org.uberfire.client.callbacks.Callback;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_FACT_CLASSNAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -66,9 +69,7 @@ public class DMODataManagementStrategyTest extends AbstractDataManagementStrateg
     @Mock
     private AsyncPackageDataModelOracle oracleMock;
 
-    private final String FACT_NAME = "FACT_NAME";
 
-    private final String FULL_FACT_CLASSNAME = "FULL_FACT_CLASSNAME";
 
     @Before
     public void setup() {
@@ -150,8 +151,8 @@ public class DMODataManagementStrategyTest extends AbstractDataManagementStrateg
             Map<String, String> simpleProperties = retrieved.getSimpleProperties();
             assertNotNull(simpleProperties);
             assertEquals(1, simpleProperties.size());
-            Util.assertTrue(simpleProperties.containsKey("value"));
-            String simplePropertyValue = simpleProperties.get("value");
+            Util.assertTrue(simpleProperties.containsKey(LOWER_CASE_VALUE));
+            String simplePropertyValue = simpleProperties.get(LOWER_CASE_VALUE);
             assertNotNull(simplePropertyValue);
             assertEquals(fullName, simplePropertyValue);
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/AbstractFactoriesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/AbstractFactoriesTest.java
@@ -28,6 +28,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractFactoriesTest extends AbstractScenarioSimulationTest {
@@ -43,8 +45,7 @@ public abstract class AbstractFactoriesTest extends AbstractScenarioSimulationTe
     @Captor
     protected ArgumentCaptor<KeyDownHandler> keyDownHandlerArgumentCaptor;
 
-    protected final static int ROW_INDEX = 1;
-    protected final static int COLUMN_INDEX = 2;
+
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
@@ -30,6 +30,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAP_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.NUMBER_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.STRING_CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.isSimpleJavaType;
 import static org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModel.Type.DMN;
 import static org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModel.Type.RULE;
@@ -45,11 +54,6 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFactoriesTest {
 
-    protected final String STRING_CLASS_NAME = String.class.getCanonicalName();
-    protected final String NUMBER_CLASS_NAME = Number.class.getCanonicalName();
-    protected final Map<String, String> expectedMapForNotSimpleType = new HashMap<>();
-    protected final Map<String, String> expectedMapForNotSimpleType1 = new HashMap<>();
-    protected final Map<String, String> expectedMapForNotSimpleType2 = new HashMap<>();
 
     protected CollectionEditorSingletonDOMElementFactory collectionEditorSingletonDOMElementFactoryMock;
     protected CollectionViewImpl collectionEditorViewImpl;
@@ -92,15 +96,15 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
         when(factModelTreeMock.getSimpleProperties()).thenReturn(new HashMap<>());
         when(factModelTreeMock.getExpandableProperties()).thenReturn(new HashMap<>());
         /* This FactModelTree is used to test manageList and manageMap methods*/
-        when(factModelTreeMock1.getSimpleProperties()).thenReturn(expectedMapForNotSimpleType);
-        when(factModelTreeMock1.getExpandableProperties()).thenReturn(expectedMapForNotSimpleType1);
+        when(factModelTreeMock1.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE);
+        when(factModelTreeMock1.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1);
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get(FULL_CLASS_NAME)).thenReturn(factModelTreeMock1);
-        expectedMapForNotSimpleType.put("x", "y");
-        expectedMapForNotSimpleType1.put("a", "b");
+        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE.put("x", "y");
+        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1.put("a", "b");
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get("testclass")).thenReturn(factModelTreeMock2);
-        when(factModelTreeMock2.getSimpleProperties()).thenReturn(expectedMapForNotSimpleType2);
-        when(factModelTreeMock2.getExpandableProperties()).thenReturn(expectedMapForNotSimpleType1);
-        expectedMapForNotSimpleType2.put("z", "w");
+        when(factModelTreeMock2.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2);
+        when(factModelTreeMock2.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1);
+        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2.put("z", "w");
     }
 
     @Test
@@ -109,7 +113,7 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
         collectionEditorSingletonDOMElementFactoryMock.manageList(collectionEditorViewImpl, key, STRING_CLASS_NAME);
         verify(collectionEditorViewImpl, times(1)).setListWidget(true);
         Map<String, String> expectedMap1 = new HashMap<>();
-        expectedMap1.put("value", STRING_CLASS_NAME);
+        expectedMap1.put(LOWER_CASE_VALUE, STRING_CLASS_NAME);
         verify(collectionEditorViewImpl, times(1)).initListStructure(eq(key), eq(expectedMap1), isA(Map.class));
         verify(collectionEditorSingletonDOMElementFactoryMock, times(1)).getExpandablePropertiesMap(eq(STRING_CLASS_NAME));
     }
@@ -117,20 +121,20 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
     @Test
     public void manageMap_RuleSimpleType() {
         Map<String, String> expectedMap1 = new HashMap<>();
-        expectedMap1.put("value", NUMBER_CLASS_NAME);
+        expectedMap1.put(LOWER_CASE_VALUE, NUMBER_CLASS_NAME);
         manageMap(NUMBER_CLASS_NAME, true, expectedMap1);
     }
 
     @Test
     public void manageMap_NotRuleSimpleType() {
         Map<String, String> expectedMap1 = new HashMap<>();
-        expectedMap1.put("value", NUMBER_CLASS_NAME);
+        expectedMap1.put(LOWER_CASE_VALUE, NUMBER_CLASS_NAME);
         manageMap(NUMBER_CLASS_NAME, false, expectedMap1);
     }
 
     @Test
     public void manageMap_NotRuleNotSimpleType() {
-        manageMap(FULL_CLASS_NAME, false, expectedMapForNotSimpleType);
+        manageMap(FULL_CLASS_NAME, false, EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE);
     }
 
     private void manageMap(String genericType1, boolean isRule, Map<String, String> expectedMap1) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationGridHandlerTest.java
@@ -31,20 +31,18 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLICK_POINT_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_WIDTH;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_ROW_HEIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OFFSET_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_ROW_INDEX;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractScenarioSimulationGridHandlerTest extends AbstractScenarioSimulationTest {
-
-    protected final Double GRID_WIDTH = 100.0;
-    protected final Double HEADER_HEIGHT = 10.0;
-    protected final Double HEADER_ROW_HEIGHT = 10.0;
-    protected final int UI_COLUMN_INDEX = 0;
-    protected final int UI_ROW_INDEX = 1;
-    protected final double CLICK_POINT_X = 5;
-    protected final double CLICK_POINT_Y = 5;
-    protected final int OFFSET_X = 0;
 
     @Mock
     protected Point2D point2DMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
@@ -26,6 +26,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLICK_POINT_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLICK_POINT_Y;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_WIDTH;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_ROW_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandlerTest.java
@@ -33,6 +33,10 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COMPUTED_LOCATION_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COMPUTED_LOCATION_Y;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MOUSE_EVENT_X;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MOUSE_EVENT_Y;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -49,13 +53,7 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioSimulationGridWidgetMouseEventHandlerTest extends AbstractScenarioSimulationGridHandlerTest {
 
-    private static final int MOUSE_EVENT_X = 32;
 
-    private static final int MOUSE_EVENT_Y = 64;
-
-    private static final double GRID_COMPUTED_LOCATION_X = 100.0;
-
-    private static final double GRID_COMPUTED_LOCATION_Y = 200.0;
 
     @Mock
     private MouseEvent nativeClickEvent;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/menu/ScenarioContextMenuRegistryTest.java
@@ -37,6 +37,8 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -532,8 +532,8 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     private void commonValidatePropertyUpdate(int columnIndex, boolean isPropertyType, boolean isSamePropertyHeader, boolean isUnique, boolean expectedValid) {
         doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, MULTIPART_VALUE_ELEMENTS);
-        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(MULTIPART_VALUE_ELEMENTS, columnIndex);
-        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(MULTIPART_VALUE_ELEMENTS, columnIndex, isPropertyType);
+        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(MULTIPART_VALUE, columnIndex);
+        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(MULTIPART_VALUE, columnIndex, isPropertyType);
         assertEquals(retrieved, expectedValid);
         reset(eventBusMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -16,8 +16,6 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.models;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -43,9 +41,23 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_NUMBER;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_CELL_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_ROWS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_META_DATA;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_COUNT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -91,25 +103,14 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     @Mock
     private Scenario scenarioMock;
 
-    private List<GridColumn.HeaderMetaData> headerMetaDataList = new ArrayList<>();
-
-    private List<GridRow> gridRows = new ArrayList<>();
-
     private Supplier<GridCell<?>> gridCellSupplier;
-
-    private final String GRID_COLUMN_TITLE = "GRID_COLUMN_TITLE";
-    private final String GRID_CELL_TEXT = "GRID_CELL_TEXT";
-    private final String VALUE = "VALUE";
-    private final String VALUE_CLASS_NAME = String.class.getName();
-    private final int ROW_COUNT = 4;
-    private final int ROW_INDEX = 3;
 
     @Before
     public void setup() {
         super.setup();
-        headerMetaDataList.add(groupHeaderMetaDataMock);
-        headerMetaDataList.add(informationHeaderMetaDataMock);
-        headerMetaDataList.add(propertyHeaderMetaDataMock);
+        HEADER_META_DATA.add(groupHeaderMetaDataMock);
+        HEADER_META_DATA.add(informationHeaderMetaDataMock);
+        HEADER_META_DATA.add(propertyHeaderMetaDataMock);
 
         doReturn(gridCellValueMock).when(gridCellMock).getValue();
 
@@ -120,18 +121,18 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         when(indexHeaderMetaDataMock.getTitle()).thenReturn(ExpressionIdentifier.INDEX.getName());
         when(scenarioIndexGridColumnMock.getInformationHeaderMetaData()).thenReturn(indexHeaderMetaDataMock);
 
-        when(gridColumnMock.getHeaderMetaData()).thenReturn(headerMetaDataList);
+        when(gridColumnMock.getHeaderMetaData()).thenReturn(HEADER_META_DATA);
 
         when(gridCellMock.getValue()).thenReturn(gridCellValueMock);
         when(gridCellValueMock.getValue()).thenReturn(GRID_CELL_TEXT);
 
         when(scenarioMock.getUnmodifiableFactMappingValues()).thenReturn(factMappingValuesLocal);
-
+        GRID_ROWS.clear();
         IntStream.range(0, ROW_COUNT).forEach(rowIndex -> {
             when(simulationMock.addScenario(rowIndex)).thenReturn(scenarioMock);
             when(simulationMock.getScenarioByIndex(rowIndex)).thenReturn(scenarioMock);
             when(simulationMock.cloneScenario(rowIndex, rowIndex + 1)).thenReturn(scenarioMock);
-            gridRows.add(gridRowMock);
+            GRID_ROWS.add(gridRowMock);
         });
         when(simulationMock.addScenario(ROW_COUNT)).thenReturn(scenarioMock);
         when(simulationMock.getScenarioByIndex(ROW_COUNT)).thenReturn(scenarioMock);
@@ -145,7 +146,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
             {
                 this.simulation = simulationMock;
                 this.eventBus = eventBusMock;
-                this.rows = gridRows;
+                this.rows = GRID_ROWS;
                 this.columns = gridColumns;
             }
 
@@ -258,7 +259,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeFalse() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_ELEMENTS, VALUE_CLASS_NAME, false);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME, false);
         verify(scenarioGridModel, times(2)).checkSimulation();
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(gridColumnMock), isA(ExpressionIdentifier.class));
@@ -266,7 +267,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeTrue() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_ELEMENTS, VALUE_CLASS_NAME, true);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, MULTIPART_VALUE_ELEMENTS, VALUE_CLASS_NAME, true);
         verify(scenarioGridModel, atLeast(2)).checkSimulation();
         verify(scenarioGridModel, atLeast(ROW_COUNT - 1)).getCell(anyInt(), eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
@@ -318,23 +319,22 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateHeader() {
-        List<String> newValueElements = Collections.singletonList("NEW_VALUE");
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, newValueElements); // This is instance header
+        String newValue = "NEW_VALUE";
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, newValue); // This is instance header
         verify(eventBusMock, times(1)).fireEvent(isA(ReloadTestToolsEvent.class));
         reset(eventBusMock);
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 2, newValueElements); // This is property header
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 2, newValue); // This is property header
         verify(eventBusMock, never()).fireEvent(any());
         reset(eventBusMock);
         // if update with same value, no event should be raised
-        List<String> titleElements = Collections.singletonList(scenarioGridModel.getColumns().get(COLUMN_INDEX).getHeaderMetaData().get(1).getTitle());
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, titleElements);
+        String title = scenarioGridModel.getColumns().get(COLUMN_INDEX).getHeaderMetaData().get(1).getTitle();
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, title);
         verify(eventBusMock, never()).fireEvent(any());
     }
 
     @Test
     public void updateFactMappingInstance() {
         final int INDEX = 0;
-        final String VALUE = "VALUE";
         final String ALIAS_1 = "ALIAS_1";
         final String ALIAS_2 = "ALIAS_2";
         FactMapping factMappingReference = mock(FactMapping.class);
@@ -347,38 +347,38 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         when(factMappingReference.getFactAlias()).thenReturn(ALIAS_1);
         when(factMappingToCheck.getFactAlias()).thenReturn(ALIAS_1);
         when(simulationDescriptorMock.getFactMappingByIndex(INDEX)).thenReturn(factMappingToCheck);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
-        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(VALUE));
-        verify(factMappingToCheck, times(1)).setFactAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
+        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, times(1)).setFactAlias(eq(MULTIPART_VALUE));
         reset(informationHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should not execute the if in the first if
         when(factMappingToCheck.getFactAlias()).thenReturn(ALIAS_2);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
-        verify(informationHeaderMetaDataMock, never()).setTitle(eq(VALUE));
-        verify(factMappingToCheck, never()).setFactAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
+        verify(informationHeaderMetaDataMock, never()).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, never()).setFactAlias(eq(MULTIPART_VALUE));
         reset(informationHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should not execute the if in the first if
         when(factMappingReference.getFactIdentifier()).thenReturn(factIdentifier1);
         when(factMappingToCheck.getFactAlias()).thenReturn(ALIAS_1);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
-        verify(informationHeaderMetaDataMock, never()).setTitle(eq(VALUE));
-        verify(factMappingToCheck, never()).setFactAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
+        verify(informationHeaderMetaDataMock, never()).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, never()).setFactAlias(eq(MULTIPART_VALUE));
         reset(informationHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should execute the second if
         when(factMappingToCheck.getFactIdentifier()).thenReturn(factIdentifier1);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
-        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(VALUE));
-        verify(factMappingToCheck, times(1)).setFactAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
+        verify(informationHeaderMetaDataMock, times(1)).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, times(1)).setFactAlias(eq(MULTIPART_VALUE));
         reset(informationHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should not execute the second if
         when(factMappingToCheck.getFactIdentifier()).thenReturn(factIdentifier2);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
-        verify(informationHeaderMetaDataMock, never()).setTitle(eq(VALUE));
-        verify(factMappingToCheck, never()).setFactAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.INSTANCE);
+        verify(informationHeaderMetaDataMock, never()).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, never()).setFactAlias(eq(MULTIPART_VALUE));
     }
 
     @Test
@@ -397,25 +397,25 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         when(factMappingReference.getFullExpression()).thenReturn(ALIAS_1);
         when(factMappingToCheck.getFullExpression()).thenReturn(ALIAS_1);
         when(simulationDescriptorMock.getFactMappingByIndex(INDEX)).thenReturn(factMappingToCheck);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
-        verify(propertyHeaderMetaDataMock, times(1)).setTitle(eq(VALUE));
-        verify(factMappingToCheck, times(1)).setExpressionAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
+        verify(propertyHeaderMetaDataMock, times(1)).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, times(1)).setExpressionAlias(eq(MULTIPART_VALUE));
         reset(propertyHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should not execute
         when(factMappingToCheck.getFactAlias()).thenReturn(ALIAS_2);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
-        verify(propertyHeaderMetaDataMock, never()).setTitle(eq(VALUE));
-        verify(factMappingToCheck, never()).setExpressionAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
+        verify(propertyHeaderMetaDataMock, never()).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, never()).setExpressionAlias(eq(MULTIPART_VALUE));
         reset(propertyHeaderMetaDataMock);
         reset(factMappingToCheck);
         // Should not execute
         when(factMappingReference.getFactIdentifier()).thenReturn(factIdentifier1);
         when(factMappingToCheck.getFactAlias()).thenReturn(ALIAS_1);
         when(factMappingToCheck.getFullExpression()).thenReturn(ALIAS_2);
-        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
-        verify(propertyHeaderMetaDataMock, never()).setTitle(eq(VALUE));
-        verify(factMappingToCheck, never()).setExpressionAlias(eq(VALUE));
+        scenarioGridModel.updateFactMapping(simulationDescriptorMock, factMappingReference, INDEX, MULTIPART_VALUE, ScenarioHeaderMetaData.MetadataType.PROPERTY);
+        verify(propertyHeaderMetaDataMock, never()).setTitle(eq(MULTIPART_VALUE));
+        verify(factMappingToCheck, never()).setExpressionAlias(eq(MULTIPART_VALUE));
     }
 
     @Test
@@ -434,7 +434,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         scenarioGridModel.updateIndexColumn();
         verify(scenarioGridModel, never()).setCellValue(anyInt(), anyInt(), isA(ScenarioGridCellValue.class));
         reset(scenarioGridModel);
-        when(scenarioGridModel.getRowCount()).thenReturn(3);
+        when(scenarioGridModel.getRowCount()).thenReturn(ROW_COUNT);
         int indexColumnPosition = 0;
         gridColumns.add(indexColumnPosition, scenarioIndexGridColumnMock);
         when(scenarioGridModel.getColumns()).thenReturn(gridColumns);
@@ -462,7 +462,6 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         scenarioGridModel.refreshErrors();
         verify(gridCellMock, times(expectedCalls)).setErrorMode(eq(true));
 
-        reset(gridCellMock);
         when(factMappingValueMock.isError()).thenReturn(false);
         scenarioGridModel.refreshErrors();
         verify(gridCellMock, times(expectedCalls)).setErrorMode(eq(false));
@@ -524,17 +523,17 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     }
 
     private void commonValidateInstanceHeaderUpdate(int columnIndex, boolean isADataType, boolean isSameInstanceHeader, boolean isUnique, boolean expectedValid) {
-        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, VALUE_ELEMENTS.get(VALUE_ELEMENTS.size() -1));
-        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(VALUE_ELEMENTS, columnIndex);
-        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(VALUE_ELEMENTS, columnIndex, isADataType);
+        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, MULTIPART_VALUE_ELEMENTS.get(MULTIPART_VALUE_ELEMENTS.size() -1));
+        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(MULTIPART_VALUE, columnIndex);
+        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(MULTIPART_VALUE, columnIndex, isADataType);
         assertEquals(expectedValid, retrieved);
         reset(eventBusMock);
     }
 
     private void commonValidatePropertyUpdate(int columnIndex, boolean isPropertyType, boolean isSamePropertyHeader, boolean isUnique, boolean expectedValid) {
-        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, VALUE_ELEMENTS);
-        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(VALUE_ELEMENTS, columnIndex);
-        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(VALUE_ELEMENTS, columnIndex, isPropertyType);
+        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, MULTIPART_VALUE_ELEMENTS);
+        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(MULTIPART_VALUE_ELEMENTS, columnIndex);
+        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(MULTIPART_VALUE_ELEMENTS, columnIndex, isPropertyType);
         assertEquals(retrieved, expectedValid);
         reset(eventBusMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -258,7 +258,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeFalse() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_LIST, VALUE_CLASS_NAME, false);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_ELEMENTS, VALUE_CLASS_NAME, false);
         verify(scenarioGridModel, times(2)).checkSimulation();
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(gridColumnMock), isA(ExpressionIdentifier.class));
@@ -266,7 +266,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeTrue() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_LIST, VALUE_CLASS_NAME, true);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_ELEMENTS, VALUE_CLASS_NAME, true);
         verify(scenarioGridModel, atLeast(2)).checkSimulation();
         verify(scenarioGridModel, atLeast(ROW_COUNT - 1)).getCell(anyInt(), eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
@@ -524,17 +524,17 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     }
 
     private void commonValidateInstanceHeaderUpdate(int columnIndex, boolean isADataType, boolean isSameInstanceHeader, boolean isUnique, boolean expectedValid) {
-        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, VALUE_LIST.get(VALUE_LIST.size() -1));
-        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(VALUE_LIST, columnIndex);
-        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(VALUE_LIST, columnIndex, isADataType);
+        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, VALUE_ELEMENTS.get(VALUE_ELEMENTS.size() -1));
+        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(VALUE_ELEMENTS, columnIndex);
+        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(VALUE_ELEMENTS, columnIndex, isADataType);
         assertEquals(expectedValid, retrieved);
         reset(eventBusMock);
     }
 
     private void commonValidatePropertyUpdate(int columnIndex, boolean isPropertyType, boolean isSamePropertyHeader, boolean isUnique, boolean expectedValid) {
-        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, VALUE_LIST);
-        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(VALUE_LIST, columnIndex);
-        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(VALUE_LIST, columnIndex, isPropertyType);
+        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, VALUE_ELEMENTS);
+        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(VALUE_ELEMENTS, columnIndex);
+        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(VALUE_ELEMENTS, columnIndex, isPropertyType);
         assertEquals(retrieved, expectedValid);
         reset(eventBusMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.models;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -257,7 +258,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeFalse() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE, VALUE_CLASS_NAME, false);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_LIST, VALUE_CLASS_NAME, false);
         verify(scenarioGridModel, times(2)).checkSimulation();
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).commonAddColumn(eq(COLUMN_INDEX), eq(gridColumnMock), isA(ExpressionIdentifier.class));
@@ -265,7 +266,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateColumnTypeTrue() {
-        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE, VALUE_CLASS_NAME, true);
+        scenarioGridModel.updateColumnProperty(COLUMN_INDEX, gridColumnMock, VALUE_LIST, VALUE_CLASS_NAME, true);
         verify(scenarioGridModel, atLeast(2)).checkSimulation();
         verify(scenarioGridModel, atLeast(ROW_COUNT - 1)).getCell(anyInt(), eq(COLUMN_INDEX));
         verify(scenarioGridModel, times(1)).deleteColumn(eq(COLUMN_INDEX));
@@ -317,16 +318,16 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void updateHeader() {
-        String newValue = "NEW_VALUE";
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, newValue); // This is instance header
+        List<String> newValueElements = Collections.singletonList("NEW_VALUE");
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, newValueElements); // This is instance header
         verify(eventBusMock, times(1)).fireEvent(isA(ReloadTestToolsEvent.class));
         reset(eventBusMock);
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 2, newValue); // This is property header
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 2, newValueElements); // This is property header
         verify(eventBusMock, never()).fireEvent(any());
         reset(eventBusMock);
         // if update with same value, no event should be raised
-        String title = scenarioGridModel.getColumns().get(COLUMN_INDEX).getHeaderMetaData().get(1).getTitle();
-        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, title);
+        List<String> titleElements = Collections.singletonList(scenarioGridModel.getColumns().get(COLUMN_INDEX).getHeaderMetaData().get(1).getTitle());
+        scenarioGridModel.updateHeader(COLUMN_INDEX, 1, titleElements);
         verify(eventBusMock, never()).fireEvent(any());
     }
 
@@ -383,7 +384,6 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     @Test
     public void updateFactMappingProperty() {
         final int INDEX = 0;
-        final String VALUE = "VALUE";
         final String ALIAS_1 = "ALIAS_1";
         final String ALIAS_2 = "ALIAS_2";
         FactMapping factMappingReference = mock(FactMapping.class);
@@ -443,17 +443,17 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     @Test
     public void isSameInstanceHeaderDifferent() {
-        commonIsSameInstanceHeader("TEST", "TOAST", false);
+        commonIsSameInstanceHeader(CLASS_NAME, "TOAST", false);
     }
 
     @Test
     public void isSameInstanceHeaderEqualWithoutPackage() {
-        commonIsSameInstanceHeader("TEST", "TEST", true);
+        commonIsSameInstanceHeader(CLASS_NAME, CLASS_NAME, true);
     }
 
     @Test
     public void isSameInstanceHeaderEqualWithPackage() {
-        commonIsSameInstanceHeader("com.something.TEST", "TEST", true);
+        commonIsSameInstanceHeader(FULL_CLASS_NAME, CLASS_NAME, false);
     }
 
     @Test
@@ -509,7 +509,7 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     private void commonIsSameInstanceHeader(String columnClassName, String value, boolean expected) {
         FactIdentifier factIdentifierMock = mock(FactIdentifier.class);
-        when(factIdentifierMock.getClassName()).thenReturn(columnClassName);
+        when(factIdentifierMock.getClassNameWithoutPackage()).thenReturn(columnClassName);
         int colIndex = 3;
         when(factMappingMock.getFactIdentifier()).thenReturn(factIdentifierMock);
         when(simulationDescriptorMock.getFactMappingByIndex(colIndex)).thenReturn(factMappingMock);
@@ -524,19 +524,17 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     }
 
     private void commonValidateInstanceHeaderUpdate(int columnIndex, boolean isADataType, boolean isSameInstanceHeader, boolean isUnique, boolean expectedValid) {
-        String value = "VALUE";
-        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, value);
-        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(value, columnIndex);
-        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(value, columnIndex, isADataType);
-        assertEquals(retrieved, expectedValid);
+        doReturn(isSameInstanceHeader).when(scenarioGridModel).isSameInstanceHeader(columnIndex, VALUE_LIST.get(VALUE_LIST.size() -1));
+        doReturn(isUnique).when(scenarioGridModel).isUniqueInstanceHeaderTitle(VALUE_LIST, columnIndex);
+        boolean retrieved = scenarioGridModel.validateInstanceHeaderUpdate(VALUE_LIST, columnIndex, isADataType);
+        assertEquals(expectedValid, retrieved);
         reset(eventBusMock);
     }
 
     private void commonValidatePropertyUpdate(int columnIndex, boolean isPropertyType, boolean isSamePropertyHeader, boolean isUnique, boolean expectedValid) {
-        String value = "VALUE";
-        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, value);
-        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(value, columnIndex);
-        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(value, columnIndex, isPropertyType);
+        doReturn(isSamePropertyHeader).when(scenarioGridModel).isSamePropertyHeader(columnIndex, VALUE_LIST);
+        doReturn(isUnique).when(scenarioGridModel).isUniquePropertyHeaderTitle(VALUE_LIST, columnIndex);
+        boolean retrieved = scenarioGridModel.validatePropertyHeaderUpdate(VALUE_LIST, columnIndex, isPropertyType);
         assertEquals(retrieved, expectedValid);
         reset(eventBusMock);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractDeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractDeletePopupViewTest.java
@@ -53,15 +53,7 @@ public abstract class AbstractDeletePopupViewTest {
     @Mock
     protected HeadingElement mainQuestionMock;
 
-    protected final String MAIN_TITLE_TEXT = "MAIN_TITLE_TEXT";
-    protected final String MAIN_QUESTION_TEXT = "MAIN_QUESTION_TEXT";
-    protected final String TEXT1_TEXT = "TEXT1_TEXT";
-    protected final String TEXT_QUESTION_TEXT = "TEXT_QUESTION_TEXT";
-    protected final String TEXT_WARNING_TEXT = "TEXT_WARNING_TEXT";
-    protected final String OKDELETE_BUTTON_TEXT = "OKDELETE_BUTTON_TEXT";
-    protected final String OPTION1_TEXT = "OPTION1_TEXT";
-    protected final String OPTION2_TEXT = "OPTION2_TEXT";
-    protected final String OKPRESERVE_BUTTON_TEXT = "OKPRESERVE_BUTTON_TEXT";
+
 
     protected void commonSetup() {
         when(translationServiceMock.getTranslation(Constants.ConfirmPopup_Cancel)).thenReturn(Constants.ConfirmPopup_Cancel);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioConfirmationPopupViewTest.java
@@ -25,6 +25,11 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.uberfire.client.views.pfly.widgets.Button;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractScenarioPopupViewTest.java
@@ -28,6 +28,8 @@ import org.uberfire.client.views.pfly.widgets.Button;
 import org.uberfire.client.views.pfly.widgets.Modal;
 import org.uberfire.mvp.Command;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OK_BUTTON_TEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyString;
@@ -70,8 +72,7 @@ public abstract class AbstractScenarioPopupViewTest {
     @Mock
     protected HeadingElement mainTitleMock;
 
-    protected final String MAIN_TITLE_TEXT = "MAIN_TITLE_TEXT";
-    protected final String OK_BUTTON_TEXT = "OK_BUTTON_TEXT";
+
 
     @Test
     public void init() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractYesNoConfirmYesNoConfirmPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/AbstractYesNoConfirmYesNoConfirmPopupViewTest.java
@@ -25,7 +25,6 @@ import org.uberfire.mvp.Command;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public abstract class AbstractYesNoConfirmYesNoConfirmPopupViewTest {
-    
 
     @Mock
     protected Command okCommandMock;
@@ -36,14 +35,6 @@ public abstract class AbstractYesNoConfirmYesNoConfirmPopupViewTest {
     @Mock
     protected Command noCommandMock;
 
-    protected final String TITLE = "TITLE";
-    protected final String OK_BUTTON_TEXT = "OK_BUTTON_TEXT";
-    protected final String YES_BUTTON_TEXT = "YES_BUTTON_TEXT";
-    protected final String NO_BUTTON_TEXT = "NO_BUTTON_TEXT";
-    protected final String CONFIRM_MESSAGE = "CONFIRM_MESSAGE";
-    protected final String INLINE_NOTIFICATION_MESSAGE = "INLINE_NOTIFICATION_MESSAGE";
     protected final Button.ButtonStyleType BUTTON_STYLE_TYPE = Button.ButtonStyleType.SUCCESS;
     protected final InlineNotification.InlineNotificationType INLINE_NOTIFICATION_TYPE = InlineNotification.InlineNotificationType.SUCCESS;
-
-
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupPresenterTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -35,7 +37,7 @@ public class ConfirmPopupPresenterTest extends AbstractDeletePopupViewTest {
 
     private ConfirmPopupPresenter confirmPopupPresenter;
 
-    private final String MAIN_TEXT = "MAIN_TEXT";
+
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ConfirmPopupViewTest.java
@@ -21,13 +21,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
 import static org.mockito.Mockito.spy;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ConfirmPopupViewTest extends AbstractScenarioConfirmationPopupViewTest {
-
-
-    private final String MAIN_TEXT = "MAIN_TEXT";
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupPresenterTest.java
@@ -22,6 +22,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_DANGER_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -35,7 +41,7 @@ public class DeletePopupPresenterTest extends AbstractDeletePopupViewTest {
 
     private DeletePopupPresenter deletePopupPresenter;
 
-    private final String TEXT_DANGER_TEXT = "TEXT_DANGER_TEXT";
+
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/DeletePopupViewTest.java
@@ -23,6 +23,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_DANGER_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,8 +39,6 @@ public class DeletePopupViewTest extends AbstractScenarioConfirmationPopupViewTe
 
     @Mock
     private ParagraphElement textDangerMock;
-
-    private final String TEXT_DANGER_TEXT = "TEXT_DANGER_TEXT";
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupPresenterTest.java
@@ -22,6 +22,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKPRESERVE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OPTION1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OPTION2_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/PreserveDeletePopupViewTest.java
@@ -25,6 +25,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.client.views.pfly.widgets.Button;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKPRESERVE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OPTION1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OPTION2_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/ScenarioConfirmationPopupViewPresenterTest.java
@@ -22,6 +22,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAIN_TITLE_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OKDELETE_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT1_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_QUESTION_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEXT_WARNING_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmYesNoConfirmPopupViewPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmYesNoConfirmPopupViewPresenterTest.java
@@ -23,6 +23,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.client.views.pfly.widgets.Button;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CONFIRM_MESSAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.INLINE_NOTIFICATION_MESSAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.NO_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OK_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.YES_BUTTON_TEXT;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmYesNoConfirmPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/popup/YesNoConfirmYesNoConfirmPopupViewTest.java
@@ -30,6 +30,12 @@ import org.uberfire.client.views.pfly.widgets.InlineNotification;
 import org.uberfire.client.views.pfly.widgets.Modal;
 import org.uberfire.mvp.Command;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CONFIRM_MESSAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.INLINE_NOTIFICATION_MESSAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.NO_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.OK_BUTTON_TEXT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.YES_BUTTON_TEXT;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRendererTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/renderers/ScenarioGridColumnRendererTest.java
@@ -32,6 +32,10 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MAP_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.PLACEHOLDER;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
@@ -50,10 +54,6 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioGridColumnRendererTest {
 
-    private static final String PLACEHOLDER = "PLACEHOLDER";
-    private static final String VALUE = "VALUE";
-    private static final String LIST_VALUE = "[ \"Ford\", \"BMW\", \"Fiat\" ]";
-    private static final String MAP_VALUE = "{\"name\":\"myname\",\"age\":29}";
     @Mock
     private GridBodyCellRenderContext contextMock;
     @Mock
@@ -117,18 +117,18 @@ public class ScenarioGridColumnRendererTest {
         verify(scenarioGridColumnRenderer, never()).internalRenderCell(any(), eq(contextMock), eq(textMock), eq(null));
         reset(scenarioGridColumnRenderer);
 
-        cell = new ScenarioGridCell(new ScenarioGridCellValue(VALUE));
+        cell = new ScenarioGridCell(new ScenarioGridCellValue(MULTIPART_VALUE));
         retrieved = scenarioGridColumnRenderer.renderCell(cell, contextMock);
         assertNotNull(retrieved);
         verify(scenarioGridColumnRenderer, never()).getCollectionString(anyString(), anyBoolean());
-        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(textMock), eq(VALUE));
+        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(textMock), eq(MULTIPART_VALUE));
         reset(scenarioGridColumnRenderer);
 
-        ScenarioGridCell scenarioGridCell = new ScenarioGridCell(new ScenarioGridCellValue(VALUE, PLACEHOLDER));
+        ScenarioGridCell scenarioGridCell = new ScenarioGridCell(new ScenarioGridCellValue(MULTIPART_VALUE, PLACEHOLDER));
         retrieved = scenarioGridColumnRenderer.renderCell(scenarioGridCell, contextMock);
         assertNotNull(retrieved);
         verify(scenarioGridColumnRenderer, never()).getCollectionString(anyString(), anyBoolean());
-        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(textMock), eq(VALUE));
+        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(textMock), eq(MULTIPART_VALUE));
         reset(scenarioGridColumnRenderer);
 
         scenarioGridCell = new ScenarioGridCell(new ScenarioGridCellValue(null, PLACEHOLDER));
@@ -154,12 +154,12 @@ public class ScenarioGridColumnRendererTest {
         verify(scenarioGridColumnRenderer, times(1)).getCollectionString(eq(MAP_VALUE), eq(false));
         reset(scenarioGridColumnRenderer);
 
-        cell = new ScenarioGridCell(new ScenarioGridCellValue(VALUE));
+        cell = new ScenarioGridCell(new ScenarioGridCellValue(MULTIPART_VALUE));
         ((ScenarioGridCell) cell).setErrorMode(true);
         retrieved = scenarioGridColumnRenderer.renderCell(cell, contextMock);
         assertNotNull(retrieved);
         verify(scenarioGridColumnRenderer, never()).getCollectionString(anyString(), anyBoolean());
-        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(errorTextMock), eq(VALUE));
+        verify(scenarioGridColumnRenderer, times(1)).internalRenderCell(any(), eq(contextMock), eq(errorTextMock), eq(MULTIPART_VALUE));
         reset(scenarioGridColumnRenderer);
     }
 
@@ -193,7 +193,7 @@ public class ScenarioGridColumnRendererTest {
         commonGetValueToShow(cell, true, null, false);
         cell = new ScenarioGridCell(new ScenarioGridCellValue(null));
         commonGetValueToShow(cell, true, null, false);
-        cell = new ScenarioGridCell(new ScenarioGridCellValue(VALUE));
+        cell = new ScenarioGridCell(new ScenarioGridCellValue(MULTIPART_VALUE));
         commonGetValueToShow(cell, false, null, false);
         cell = new ScenarioGridCell(new ScenarioGridCellValue(LIST_VALUE));
         cell.setListMap(true);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
@@ -24,20 +24,20 @@ import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_FILE_PATH;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAMESPACE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMO_SESSION;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.KIE_BASE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.KIE_SESSION;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.RULE_FLOW_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.SCENARIO_TYPE;
 import static org.mockito.Mockito.when;
 
 abstract class AbstractSettingsTest {
 
-    protected final String SCENARIO_TYPE = "SCENARIO_TYPE";
 
-    protected static final String FILE_NAME = "FILE_NAME";
-    protected static final String KIE_SESSION = "KIE_SESSION";
-    protected static final String KIE_BASE = "KIE_BASE";
-    protected static final String RULE_FLOW_GROUP = "RULE_FLOW_GROUP";
-    protected static final String DMO_SESSION = "DMO_SESSION";
-    protected static final String DMN_FILE_PATH = "DMN_FILE_PATH";
-    protected static final String DMN_NAMESPACE = "DMN_NAMESPACE";
-    protected static final String DMN_NAME = "DMN_NAME";
 
     @Mock
     protected LabelElement nameLabelMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractTestToolsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractTestToolsTest.java
@@ -31,6 +31,9 @@ import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.Fact
 import org.junit.Before;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LOWER_CASE_VALUE;
+
 abstract class AbstractTestToolsTest {
 
     @Mock
@@ -43,19 +46,10 @@ abstract class AbstractTestToolsTest {
     protected SortedMap<String, FactModelTree> simpleJavaTypeTreeMap;
     protected SortedMap<String, FactModelTree> instanceFactTreeMap;
     protected SortedMap<String, FactModelTree> simpleJavaInstanceFactTreeMap;
-    protected String FACT_NAME;
-    protected String FACT_PACKAGE = "test.scesim.package";
-    protected final String GRID_COLUMN_TITLE = "GRID_COLUMN_TITLE";
-    protected final String GRID_COLUMN_GROUP = "GIVEN";
-    protected final String GRID_COLUMN_ID = "GRID_COLUMN_ID";
-    protected final String GRID_CELL_TEXT = "GRID_CELL_TEXT";
-    protected final String FULL_PACKAGE = "test.scesim";
-    protected final String VALUE = "VALUE";
-    protected final String VALUE_CLASS_NAME = String.class.getName();
-    protected final int ROW_COUNT = 4;
-    protected final int ROW_INDEX = 3;
-    protected final int COLUMN_INDEX = 5;
+
     protected FactModelTree FACT_MODEL_TREE;
+
+    protected String localFactName;
 
     @Before
     public void setup() {
@@ -64,8 +58,8 @@ abstract class AbstractTestToolsTest {
         instanceFactTreeMap = new TreeMap<>();
         dataObjectFactTreeMap.keySet().forEach(key -> instanceFactTreeMap.put(getRandomString(), dataObjectFactTreeMap.get(key)));
         simpleJavaInstanceFactTreeMap = new TreeMap<>();
-        FACT_NAME = new ArrayList<>(dataObjectFactTreeMap.keySet()).get(0);
-        FACT_MODEL_TREE = dataObjectFactTreeMap.get(FACT_NAME);
+        localFactName = new ArrayList<>(dataObjectFactTreeMap.keySet()).get(0);
+        FACT_MODEL_TREE = dataObjectFactTreeMap.get(localFactName);
     }
 
     protected String getRandomFactModelTree(Map<String, FactModelTree> source, int position) {
@@ -97,7 +91,7 @@ abstract class AbstractTestToolsTest {
         for (String key : DataManagementStrategy.SIMPLE_CLASSES_MAP.keySet()) {
             Map<String, String> simpleProperties = new HashMap<>();
             String fullName = DataManagementStrategy.SIMPLE_CLASSES_MAP.get(key).getCanonicalName();
-            simpleProperties.put("value", fullName);
+            simpleProperties.put(LOWER_CASE_VALUE, fullName);
             String packageName = fullName.substring(0, fullName.lastIndexOf("."));
             FactModelTree value = new FactModelTree(key, packageName, simpleProperties, new HashMap<>());
             toReturn.put(key, value);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenterTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewTest.java
@@ -21,6 +21,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIELD_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PROPERTY_PATH;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -37,8 +40,8 @@ public class FieldItemViewTest extends AbstractTestToolsTest {
     @Before
     public void setup() {
         super.setup();
-        INNER_HTML = "<a>" + FACT_NAME + "</a> [" + FACT_MODEL_TREE.getFactName() + "]";
-        ID_ATTRIBUTE = "fieldElement-" + FACT_NAME + "-" + FACT_MODEL_TREE.getFactName();
+        INNER_HTML = "<a>" + FIELD_NAME + "</a> [" + FACT_MODEL_TREE.getFactName() + "]";
+        ID_ATTRIBUTE = "fieldElement-" + FACT_NAME + "-" + FIELD_NAME;
         this.fieldItemView = spy(new FieldItemViewImpl() {
             {
                 this.fieldElement = lIElementMock;
@@ -48,8 +51,11 @@ public class FieldItemViewTest extends AbstractTestToolsTest {
 
     @Test
     public void setFieldData() {
-        fieldItemView.setFieldData("", FACT_NAME, FACT_NAME, FACT_MODEL_TREE.getFactName());
+        fieldItemView.setFieldData(FULL_PROPERTY_PATH, FACT_NAME, FIELD_NAME, FACT_MODEL_TREE.getFactName());
         verify(lIElementMock, times(1)).setInnerHTML(eq(INNER_HTML));
         verify(lIElementMock, times(1)).setAttribute(eq("id"), eq(ID_ATTRIBUTE));
+        verify(lIElementMock, times(1)).setAttribute(eq("fieldName"), eq(FIELD_NAME));
+        verify(lIElementMock, times(1)).setAttribute(eq("className"), eq(FACT_MODEL_TREE.getFactName()));
+        verify(lIElementMock, times(1)).setAttribute(eq("fullPath"), eq(FULL_PROPERTY_PATH));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenterTest.java
@@ -27,6 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyObject;
@@ -90,11 +94,11 @@ public class ListGroupItemPresenterTest extends AbstractTestToolsTest {
 
     @Test
     public void getDivElementByStrings() {
-        DivElement retrieved = listGroupItemPresenter.getDivElement(FULL_PACKAGE, VALUE, VALUE_CLASS_NAME);
+        DivElement retrieved = listGroupItemPresenter.getDivElement(FULL_PACKAGE, MULTIPART_VALUE, VALUE_CLASS_NAME);
         assertNotNull(retrieved);
         assertEquals(divElementMock, retrieved);
-        verify(listGroupItemPresenter, times(1)).commonGetListGroupItemView(eq(FULL_PACKAGE), eq(VALUE), eq(true));
-        verify(listGroupItemPresenter, times(1)).populateListGroupItemView(eq(listGroupItemViewMock), eq(VALUE), eq(VALUE_CLASS_NAME));
+        verify(listGroupItemPresenter, times(1)).commonGetListGroupItemView(eq(FULL_PACKAGE), eq(MULTIPART_VALUE), eq(true));
+        verify(listGroupItemPresenter, times(1)).populateListGroupItemView(eq(listGroupItemViewMock), eq(MULTIPART_VALUE), eq(VALUE_CLASS_NAME));
     }
 
     @Test
@@ -154,12 +158,12 @@ public class ListGroupItemPresenterTest extends AbstractTestToolsTest {
 
     @Test
     public void populateListGroupItemView() {
-        listGroupItemPresenter.populateListGroupItemView(listGroupItemViewMock, "", FACT_NAME, FACT_MODEL_TREE);
-        verify(listGroupItemViewMock, times(1)).setFactName(eq(FACT_NAME));
+        listGroupItemPresenter.populateListGroupItemView(listGroupItemViewMock, "", FACT_MODEL_TREE.getFactName(), FACT_MODEL_TREE);
+        verify(listGroupItemViewMock, times(1)).setFactName(eq(FACT_MODEL_TREE.getFactName()));
         Map<String, String> simpleProperties = FACT_MODEL_TREE.getSimpleProperties();
         for (String key : simpleProperties.keySet()) {
             String value = simpleProperties.get(key);
-            verify(fieldItemPresenterMock, times(1)).getLIElement(eq(FACT_NAME), eq(FACT_NAME), eq(key), eq(value));
+            verify(fieldItemPresenterMock, times(1)).getLIElement(eq(FACT_MODEL_TREE.getFactName()), eq(FACT_MODEL_TREE.getFactName()), eq(key), eq(value));
         }
         verify(listGroupItemViewMock, times(simpleProperties.size())).addFactField(anyObject());
         reset(listGroupItemViewMock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemViewImplTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_GROUP_ITEM;
 import static org.drools.workbench.screens.scenariosimulation.client.rightpanel.ListGroupItemViewImpl.LIST_VIEW_PF_EXPAND_ACTIVE;
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.FA_ANGLE_DOWN;
 import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.HIDDEN;
@@ -67,10 +69,6 @@ public class ListGroupItemViewImplTest extends AbstractTestToolsTest {
     private LIElement factFieldMock;
 
     private ListGroupItemViewImpl listGroupItemView;
-
-    private static final String LIST_GROUP_ITEM = "list-group-item";
-
-
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
@@ -27,6 +27,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.mvp.Command;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_FILE_PATH;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAMESPACE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMO_SESSION;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.KIE_BASE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.KIE_SESSION;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.RULE_FLOW_GROUP;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.reset;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.SCENARIO_TYPE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.drools.workbench.screens.scenariosimulation.client.TestProperties;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
@@ -27,6 +28,7 @@ import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -46,12 +48,8 @@ public abstract class AbstractUtilsTest {
 
     protected List<ScenarioHeaderMetaData> scenarioHeaderMetaDataList = new ArrayList<>();
 
-    protected final static String PLACEHOLDER = "PLACEHOLDER";
-    protected final static String COLUMN_ID = "COLUMN_ID";
-    protected final static String COLUMN_INSTANCE_TITLE_FIRST = "COLUMN_INSTANCE_TITLE_FIRST";
-    protected final static String COLUMN_PROPERTY_TITLE_FIRST = "COLUMN_PROPERTY_TITLE_FIRST";
-    protected final static String COLUMN_GROUP_FIRST = "OTHER";
-    protected final FactMappingType factMappingType = FactMappingType.valueOf(COLUMN_GROUP_FIRST);
+
+    protected final FactMappingType factMappingType = FactMappingType.valueOf(TestProperties.COLUMN_GROUP_FIRST);
 
     @Before
     public void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/AbstractUtilsTest.java
@@ -20,12 +20,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.drools.workbench.screens.scenariosimulation.client.factories.CollectionEditorSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
-import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridLayer;
-import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.model.FactMappingType;
 import org.junit.Before;
 import org.mockito.Mock;
@@ -40,15 +37,6 @@ public abstract class AbstractUtilsTest {
 
     @Mock
     protected ScenarioHeaderTextBoxSingletonDOMElementFactory scenarioHeaderTextBoxSingletonDOMElementFactoryMock;
-
-    @Mock
-    protected CollectionEditorSingletonDOMElementFactory collectionEditorSingletonDOMElementFactoryMock;
-
-    @Mock
-    protected ScenarioGridLayer mockScenarioGridLayer;
-
-    @Mock
-    protected ScenarioGridPanel mockScenarioGridPanel;
 
     @Mock
     protected ScenarioSimulationBuilders.HeaderBuilder headerBuilderMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuildersTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationBuildersTest.java
@@ -25,6 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP_FIRST;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INSTANCE_TITLE_FIRST;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.PLACEHOLDER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -39,6 +39,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ONE_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_TWO_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_HEIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_ROW_HEIGHT;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_COLUMN_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
@@ -48,13 +55,6 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioSimulationTest {
 
-    private static final int HEADER_ROWS = 2;
-    private static final double HEADER_HEIGHT = 50.0;
-    private static final double HEADER_ROW_HEIGHT = HEADER_HEIGHT / HEADER_ROWS;
-    private static final Integer uiColumnIndex = 0;
-    private static final String columnGroup = "col-group";
-    private static final String columnOneTitle = "column one";
-    private static final String columnTwoTitle = "column two";
     private ScenarioGridColumn scenarioGridColumnOne;
     private ScenarioGridColumn scenarioGridColumnTwo;
 
@@ -98,13 +98,13 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         scenarioGridColumnOne =
                 mockGridColumn(100.0,
                                Collections.singletonList(clickedScenarioHeaderMetadataMock),
-                               columnOneTitle,
-                               columnGroup);
+                               COLUMN_ONE_TITLE,
+                               COLUMN_GROUP);
         scenarioGridColumnTwo =
                 mockGridColumn(100.0,
                                Collections.singletonList(clickedScenarioHeaderMetadataMock),
-                               columnTwoTitle,
-                               columnGroup);
+                               COLUMN_TWO_TITLE,
+                               COLUMN_GROUP);
         gridColumns.add(scenarioGridColumnOne);
         gridColumns.add(scenarioGridColumnTwo);
     }
@@ -140,10 +140,10 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         final EnableTestToolsEvent event = ScenarioSimulationGridHeaderUtilities.getEnableTestToolsEvent(scenarioGridMock,
                                                                                                          scenarioGridColumnOne,
                                                                                                          clickedScenarioHeaderMetadataMock,
-                                                                                                         uiColumnIndex,
-                                                                                                         columnGroup);
+                                                                                                         UI_COLUMN_INDEX,
+                                                                                                         COLUMN_GROUP);
 
-        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
+        assertThat(event.getFilterTerm()).isEqualTo(COLUMN_ONE_TITLE + ";" + COLUMN_TWO_TITLE + ";" + MULTIPART_VALUE);
         assertThat(event.isNotEqualsSearch()).isTrue();
     }
 
@@ -154,10 +154,10 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         final EnableTestToolsEvent event = ScenarioSimulationGridHeaderUtilities.getEnableTestToolsEvent(scenarioGridMock,
                                                                                                          scenarioGridColumnOne,
                                                                                                          clickedScenarioHeaderMetadataMock,
-                                                                                                         uiColumnIndex,
-                                                                                                         columnGroup);
+                                                                                                         UI_COLUMN_INDEX,
+                                                                                                         COLUMN_GROUP);
 
-        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle + ";" + columnTwoTitle);
+        assertThat(event.getFilterTerm()).isEqualTo(COLUMN_ONE_TITLE + ";" + COLUMN_TWO_TITLE + ";" + MULTIPART_VALUE);
         assertThat(event.isNotEqualsSearch()).isTrue();
     }
 
@@ -169,10 +169,10 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
         final EnableTestToolsEvent event = ScenarioSimulationGridHeaderUtilities.getEnableTestToolsEvent(scenarioGridMock,
                                                                                                          scenarioGridColumnOne,
                                                                                                          clickedScenarioHeaderMetadataMock,
-                                                                                                         uiColumnIndex,
-                                                                                                         columnGroup);
+                                                                                                         UI_COLUMN_INDEX,
+                                                                                                         COLUMN_GROUP);
 
-        assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle);
+        assertThat(event.getFilterTerm()).isEqualTo(COLUMN_ONE_TITLE);
         assertThat(event.getPropertyNameElements()).isNull();
         assertThat(event.isNotEqualsSearch()).isFalse();
     }
@@ -263,14 +263,14 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
     private ScenarioGridColumn mockGridColumn(final double width,
                                               final List<GridColumn.HeaderMetaData> headerMetaData,
                                               final String columnTitle,
-                                              final String columnGroup) {
+                                              final String COLUMN_GROUP) {
         final ScenarioGridColumn uiColumn = mock(ScenarioGridColumn.class);
 
         doReturn(headerMetaData).when(uiColumn).getHeaderMetaData();
         doReturn(width).when(uiColumn).getWidth();
 
         final ScenarioHeaderMetaData informationHeader = mock(ScenarioHeaderMetaData.class);
-        when(informationHeader.getColumnGroup()).thenReturn(columnGroup);
+        when(informationHeader.getColumnGroup()).thenReturn(COLUMN_GROUP);
         when(informationHeader.getTitle()).thenReturn(columnTitle);
 
         when(uiColumn.getInformationHeaderMetaData()).thenReturn(informationHeader);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationGridHeaderUtilitiesTest.java
@@ -173,7 +173,7 @@ public class ScenarioSimulationGridHeaderUtilitiesTest extends AbstractScenarioS
                                                                                                          columnGroup);
 
         assertThat(event.getFilterTerm()).isEqualTo(columnOneTitle);
-        assertThat(event.getPropertyName()).isNull();
+        assertThat(event.getPropertyNameElements()).isNull();
         assertThat(event.isNotEqualsSearch()).isFalse();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -16,9 +16,14 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.ExpressionIdentifier;
+import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,6 +32,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
@@ -80,5 +87,26 @@ public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
     public void isSimpleJavaType() {
         SIMPLE_CLASSES_MAP.values().forEach(clazz -> assertTrue(ScenarioSimulationUtils.isSimpleJavaType(clazz.getName())));
         assertFalse(ScenarioSimulationUtils.isSimpleJavaType("com.TestBean"));
+    }
+
+    @Test
+    public void getPropertyNameElementsWithoutAlias() {
+        FactIdentifier factIdentifierMock = mock(FactIdentifier.class);
+        String packageName = "com.package";
+        String className = "ClassName";
+        String propertyName = "propertyName";
+        String aliasName = "AliasName";
+        when(factIdentifierMock.getClassName()).thenReturn(className);
+        List<String> retrieved = ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias(Collections.singletonList(propertyName), factIdentifierMock);
+        assertEquals(Collections.singletonList(propertyName), retrieved);
+        when(factIdentifierMock.getClassName()).thenReturn(packageName + "." + className);
+        retrieved = ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias(Collections.singletonList(propertyName), factIdentifierMock);
+        assertEquals(Collections.singletonList(propertyName), retrieved);
+        when(factIdentifierMock.getClassName()).thenReturn(className);
+        retrieved = ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias(Arrays.asList(className, propertyName), factIdentifierMock);
+        assertEquals(Arrays.asList(className, propertyName), retrieved);
+        when(factIdentifierMock.getClassName()).thenReturn(packageName + "." + className);
+        retrieved = ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias(Arrays.asList(aliasName, propertyName), factIdentifierMock);
+        assertEquals(Arrays.asList(className, propertyName), retrieved);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -27,6 +27,11 @@ import org.drools.workbench.screens.scenariosimulation.model.FactIdentifier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_GROUP_FIRST;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_ID;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INSTANCE_TITLE_FIRST;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_PROPERTY_TITLE_FIRST;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.PLACEHOLDER;
 import static org.drools.workbench.screens.scenariosimulation.client.editor.strategies.DataManagementStrategy.SIMPLE_CLASSES_MAP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -53,6 +53,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.DefaultGridWidg
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.SelectionExtension;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.TEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -71,7 +72,7 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioGridTest {
 
-    private static final String TEST = "test";
+
     @Mock
     private ScenarioGridModel scenarioGridModelMock;
     @Mock

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ScenarioGridTest {
 
+    private static final String TEST = "test";
     @Mock
     private ScenarioGridModel scenarioGridModelMock;
     @Mock
@@ -264,7 +265,7 @@ public class ScenarioGridTest {
         factMappingDescription.getExpressionElements().clear();
         assertTrue(scenarioGrid.isPropertyAssigned(false, factMappingDescription));
         assertTrue(scenarioGrid.isPropertyAssigned(true, factMappingDescription));
-        factMappingDescription.getExpressionElements().add(new ExpressionElement("test"));
+        factMappingDescription.getExpressionElements().add(new ExpressionElement(TEST));
         assertTrue(scenarioGrid.isPropertyAssigned(false, factMappingDescription));
         assertTrue(scenarioGrid.isPropertyAssigned(true, factMappingDescription));
         factMappingGiven.getExpressionElements().clear();


### PR DESCRIPTION
@kkufova @Rikkola @danielezonca

see https://issues.jboss.org/browse/DROOLS-3862