### PR TITLE
[DROOLS-3883] Add running indicator

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -296,6 +296,7 @@ public class ScenarioSimulationEditorPresenter
                         simulation::getScenarioByIndex
                 )
         );
+        view.showBusyIndicator(ScenarioSimulationEditorConstants.INSTANCE.running());
         service.call(getRefreshModelCallback(), new HasBusyIndicatorDefaultErrorCallback(view))
                 .runScenario(versionRecordManager.getCurrentPath(),
                              simulation.getSimulationDescriptor(),
@@ -349,6 +350,7 @@ public class ScenarioSimulationEditorPresenter
     }
 
     protected void refreshModelContent(TestRunResult testRunResult) {
+        view.hideBusyIndicator();
         if (this.model == null) {
             return;
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -248,4 +248,6 @@ public interface ScenarioSimulationEditorConstants
     String importFailedMessage();
 
     String importErrorTitle();
+
+    String running();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -130,6 +130,6 @@ settings=Settings
 uploadWarning=Make sure the headers in the selected CSV file have not been modified. Otherwise, the spreadsheet may not be successfully imported.
 importFailedMessage=A CSV file with an incorrect header layout has been imported. Make sure the imported CSV file has unmodified headers.
 importErrorTitle=Error during import
-running=Running
+running=Running...
 
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -130,5 +130,6 @@ settings=Settings
 uploadWarning=Make sure the headers in the selected CSV file have not been modified. Otherwise, the spreadsheet may not be successfully imported.
 importFailedMessage=A CSV file with an incorrect header layout has been imported. Make sure the imported CSV file has unmodified headers.
 importErrorTitle=Error during import
+running=Running
 
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -89,6 +89,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.drools.workbench.screens.scenariosimulation.client.handlers.ScenarioSimulationDocksHandler.SCESIMEDITOR_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyInt;
@@ -506,22 +507,23 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
                                                                                                           new TestResultMessage()));
         when(statusMock.getSimulation()).thenReturn(simulationMock);
         when(contextMock.getStatus()).thenReturn(statusMock);
-        assertFalse(modelLocal.getSimulation().equals(simulationMock));
+        assertNotEquals(simulationMock, modelLocal.getSimulation());
         presenter.onStartup(observablePathMock, placeRequestMock);
         presenter.onRunScenario();
         verify(scenarioSimulationServiceMock, times(1)).runScenario(any(), any(), any());
         verify(scenarioGridModelMock, times(1)).resetErrors();
         verify(scenarioSimulationViewMock, times(1)).refreshContent(any());
         verify(scenarioSimulationDocksHandlerMock).expandTestResultsDock();
-        assertTrue(modelLocal.getSimulation().equals(simulationMock));
+        assertEquals(simulationMock, modelLocal.getSimulation());
     }
 
     @Test
     public void onRunTestById() throws Exception {
-        when(scenarioSimulationServiceMock.runScenario(any(), any(), any())).thenReturn(new TestRunResult(Collections.EMPTY_MAP,
+        when(scenarioSimulationServiceMock.runScenario(any(), any(), any())).thenReturn(new TestRunResult(Collections.emptyMap(),
                                                                                                           new TestResultMessage()));
         when(simulationMock.getScenarioByIndex(anyInt())).thenReturn(mock(Scenario.class));
         presenter.onRunScenario(Collections.singletonList(0));
+        verify(scenarioSimulationViewMock, times(1)).showBusyIndicator(anyString());
         verify(scenarioSimulationServiceMock, times(1)).runScenario(any(), any(), any());
         verify(scenarioGridModelMock, times(1)).resetErrors();
         verify(scenarioSimulationViewMock, times(1)).refreshContent(any());
@@ -538,6 +540,7 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         when(scenarioMapMock.entrySet()).thenReturn(entries);
         presenter.refreshModelContent(new TestRunResult(scenarioMapMock,
                                                         new TestResultMessage()));
+        verify(scenarioSimulationViewMock, times(1)).hideBusyIndicator();
         verify(simulationMock, times(1)).replaceScenario(eq(scenarioIndex), any());
         assertEquals(scenarioSimulationModelMock, presenter.getModel());
         verify(scenarioSimulationViewMock, times(1)).refreshContent(eq(simulationMock));


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3883

NOTE: the indicator was already removed in case of exception by `HasBusyIndicatorDefaultErrorCallback` 

@kkufova @Rikkola @gitgabrio 