### PR TITLE
DROOLS-3957 : Make verifier panel use docks

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableDocksHandler.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableDocksHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.guided.dtable.client.editor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisDockPlaceHolder;
+import org.kie.workbench.common.services.verifier.reporting.client.resources.i18n.AnalysisConstants;
+import org.kie.workbench.common.widgets.client.docks.AbstractWorkbenchDocksHandler;
+import org.kie.workbench.common.widgets.client.docks.DockPlaceHolderPlace;
+import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
+import org.uberfire.client.workbench.docks.UberfireDock;
+import org.uberfire.client.workbench.docks.UberfireDockPosition;
+
+@ApplicationScoped
+public class GuidedDecisionTableDocksHandler
+        extends AbstractWorkbenchDocksHandler {
+
+    public static final String VERIFIER_DOCK = "VERIFIER_DOCK";
+
+    @Inject
+    private AuthoringWorkbenchDocks authoringWorkbenchDocks;
+
+    private UberfireDock verifierReportDock;
+
+    @Override
+    public Collection<UberfireDock> provideDocks(final String perspectiveIdentifier) {
+
+        final List<UberfireDock> result = new ArrayList<>();
+
+        verifierReportDock = new UberfireDock(UberfireDockPosition.EAST,
+                                              "PLAY_CIRCLE",
+                                              new DockPlaceHolderPlace(AnalysisDockPlaceHolder.IDENTIFIER,
+                                                                       VERIFIER_DOCK),
+                                              perspectiveIdentifier);
+        result.add(verifierReportDock.withSize(450).withLabel(AnalysisConstants.INSTANCE.Analysis()));
+
+        return result;
+    }
+
+    public void addDocks() {
+        refreshDocks(true,
+                     false);
+    }
+
+    public void removeDocks() {
+        refreshDocks(true,
+                     true);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
@@ -50,6 +50,7 @@ import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuIt
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
@@ -80,8 +81,10 @@ import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.ED
  * Guided Decision Table Editor Presenter
  */
 @Dependent
-@WorkbenchEditor(identifier = "GuidedDecisionTableEditor", supportedTypes = {GuidedDTableResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
+@WorkbenchEditor(identifier = GuidedDecisionTableEditorPresenter.IDENTIFIER, supportedTypes = {GuidedDTableResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
 public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableEditorPresenter {
+
+    public static final String IDENTIFIER = "GuidedDecisionTableEditor";
 
     private final SaveAndRenameCommandBuilder<GuidedDecisionTable52, Metadata> saveAndRenameCommandBuilder;
 
@@ -92,6 +95,8 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
                                               final PerspectiveManager perspectiveManager,
                                               final Event<NotificationEvent> notification,
                                               final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
+                                              final GuidedDecisionTableDocksHandler guidedDecisionTableDocksHandler,
+                                              final AnalysisReportScreen analysisReportScreen,
                                               final ValidationPopup validationPopup,
                                               final GuidedDTableResourceType resourceType,
                                               final EditMenuBuilder editMenuBuilder,
@@ -111,6 +116,8 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
               perspectiveManager,
               notification,
               decisionTableSelectedEvent,
+              guidedDecisionTableDocksHandler,
+              analysisReportScreen,
               validationPopup,
               resourceType,
               editMenuBuilder,
@@ -125,6 +132,8 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
               downloadMenuItem);
 
         this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilder;
+
+        this.modeller.addVerificationPanel(analysisReportScreen);
     }
 
     @Override
@@ -148,6 +157,11 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
     @OnFocus
     public void onFocus() {
         super.onFocus();
+    }
+
+    @Override
+    protected String getEditorIdentifier() {
+        return GuidedDecisionTableEditorPresenter.IDENTIFIER;
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
@@ -64,6 +64,7 @@ import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.soup.project.datamodel.imports.Imports;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.callbacks.CommandDrivenErrorCallback;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
@@ -115,8 +116,10 @@ import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopu
  * Guided Decision Table Graph Editor Presenter
  */
 @Dependent
-@WorkbenchEditor(identifier = "GuidedDecisionTableGraphEditor", supportedTypes = {GuidedDTableGraphResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
+@WorkbenchEditor(identifier = GuidedDecisionTableGraphEditorPresenter.IDENTIFIER, supportedTypes = {GuidedDTableGraphResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
 public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionTableEditorPresenter {
+
+    public static final String IDENTIFIER = "GuidedDecisionTableGraphEditor";
 
     private final Caller<GuidedDecisionTableGraphEditorService> graphService;
     private final Caller<KieModuleService> moduleService;
@@ -143,6 +146,8 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                                                    final Event<NotificationEvent> notification,
                                                    final Event<SaveInProgressEvent> saveInProgressEvent,
                                                    final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
+                                                   final GuidedDecisionTableDocksHandler guidedDecisionTableDocksHandler,
+                                                   final AnalysisReportScreen analysisReportScreen,
                                                    final ValidationPopup validationPopup,
                                                    final GuidedDTableGraphResourceType dtGraphResourceType,
                                                    final EditMenuBuilder editMenuBuilder,
@@ -164,6 +169,8 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
               perspectiveManager,
               notification,
               decisionTableSelectedEvent,
+              guidedDecisionTableDocksHandler,
+              analysisReportScreen,
               validationPopup,
               dtGraphResourceType,
               editMenuBuilder,
@@ -232,6 +239,11 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     @OnFocus
     public void onFocus() {
         super.onFocus();
+    }
+
+    @Override
+    protected String getEditorIdentifier() {
+        return GuidedDecisionTableGraphEditorPresenter.IDENTIFIER;
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerProvider.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerProvider.java
@@ -17,7 +17,6 @@
 package org.drools.workbench.screens.guided.dtable.client.widget.analysis;
 
 import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
 
 import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
@@ -27,24 +26,13 @@ import org.kie.workbench.common.services.verifier.reporting.client.controller.An
 import org.kie.workbench.common.services.verifier.reporting.client.controller.AnalyzerControllerImpl;
 import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.mvp.PlaceRequest;
 
 @Dependent
 public class DecisionTableAnalyzerProvider {
 
-    private final AnalysisReportScreen analysisReportScreen;
-    private PlaceManager placeManager;
-
-    @Inject
-    public DecisionTableAnalyzerProvider(
-            final AnalysisReportScreen analysisReportScreen,
-            final PlaceManager placeManager) {
-        this.analysisReportScreen = analysisReportScreen;
-        this.placeManager = placeManager;
-    }
-
-    public AnalyzerController newAnalyzer(final PlaceRequest placeRequest,
+    public AnalyzerController newAnalyzer(final AnalysisReportScreen analysisReportScreen,
+                                          final PlaceRequest placeRequest,
                                           final AsyncPackageDataModelOracle oracle,
                                           final GuidedDecisionTable52 model,
                                           final EventBus eventBus) {
@@ -55,7 +43,6 @@ public class DecisionTableAnalyzerProvider {
                                                       .withOracle(oracle)
                                                       .withModel(model)
                                                       .build(),
-                                              placeManager,
                                               eventBus);
         } else {
             return makePlaceHolder();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -49,6 +49,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.popovers.C
 import org.drools.workbench.screens.guided.dtable.client.wizard.column.NewGuidedDecisionTableColumnWizard;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -83,6 +84,7 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     private Set<GuidedDecisionTableView.Presenter> availableDecisionTables = new HashSet<>();
 
     private Set<HandlerRegistration> handlerRegistrations = new HashSet<>();
+    private AnalysisReportScreen analysisReportScreen;
 
     @Inject
     public GuidedDecisionTableModellerPresenter(final GuidedDecisionTableModellerView view,
@@ -361,7 +363,7 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
         //Bootstrap Decision Table analysis
         for (GuidedDecisionTableView.Presenter p : getAvailableDecisionTables()) {
             if (p.equals(dtPresenter)) {
-                p.initialiseAnalysis();
+                p.initialiseAnalysis(analysisReportScreen);
             }
         }
 
@@ -404,5 +406,10 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
             dtPresenter.link(getAvailableDecisionTables());
         }
         getView().getGridLayerView().refreshGridWidgetConnectors();
+    }
+
+    @Override
+    public void addVerificationPanel(AnalysisReportScreen analysisReportScreen) {
+        this.analysisReportScreen = analysisReportScreen;
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -32,6 +32,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBui
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableColumnSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
@@ -118,5 +119,8 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
         void refreshScrollPosition();
 
         void updateLinks();
+
+        void addVerificationPanel(AnalysisReportScreen analysisReportScreen);
+
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -97,6 +97,7 @@ import org.kie.soup.project.datamodel.oracle.DropDownData;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
 import org.kie.workbench.common.services.shared.rulename.RuleNamesService;
 import org.kie.workbench.common.services.verifier.reporting.client.controller.AnalyzerController;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.services.verifier.reporting.client.panel.IssueSelectedEvent;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
@@ -344,7 +345,6 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         initialiseLockManager();
         initialiseUtilities();
         initialiseModels();
-        initialiseValidationAndVerification();
         initialiseEventHandlers();
         initialiseAuditLog();
     }
@@ -506,8 +506,9 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
     }
 
     //Setup the Validation & Verification analyzer
-    void initialiseValidationAndVerification() {
-        this.analyzerController = decisionTableAnalyzerProvider.newAnalyzer(placeRequest,
+    void initialiseValidationAndVerification(AnalysisReportScreen analysisReportScreen) {
+        this.analyzerController = decisionTableAnalyzerProvider.newAnalyzer(analysisReportScreen,
+                                                                            placeRequest,
                                                                             oracle,
                                                                             model,
                                                                             eventBus);
@@ -596,10 +597,11 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
     }
 
     @Override
-    public void initialiseAnalysis() {
-        if (analyzerController != null) {
-            analyzerController.initialiseAnalysis();
+    public void initialiseAnalysis(final AnalysisReportScreen analysisReportScreen) {
+        if (analyzerController == null) {
+            initialiseValidationAndVerification(analysisReportScreen);
         }
+        analyzerController.initialiseAnalysis();
     }
 
     @Override
@@ -1438,13 +1440,13 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
     }
 
     @Override
-    public boolean hasEditableColumns() {
-        return getAccess().hasEditableColumns();
+    public void setReadOnly(final boolean isReadOnly) {
+        this.access.setReadOnly(isReadOnly);
     }
 
     @Override
-    public void setReadOnly(final boolean isReadOnly) {
-        this.access.setReadOnly(isReadOnly);
+    public boolean hasEditableColumns() {
+        return getAccess().hasEditableColumns();
     }
 
     @Override
@@ -1495,16 +1497,16 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             return isReadOnly;
         }
 
+        public void setReadOnly(final boolean isReadOnly) {
+            this.isReadOnly = isReadOnly;
+        }
+
         public boolean hasEditableColumns() {
             return hasEditableColumns;
         }
 
         public void setHasEditableColumns(final boolean hasEditableColumns) {
             this.hasEditableColumns = hasEditableColumns;
-        }
-
-        public void setReadOnly(final boolean isReadOnly) {
-            this.isReadOnly = isReadOnly;
         }
 
         public boolean isEditable() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
@@ -40,6 +40,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.model.sync
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.workitems.IBindingProvider;
 import org.kie.workbench.common.widgets.metadata.client.KieDocument;
@@ -114,7 +115,7 @@ public interface GuidedDecisionTableView extends GridWidget,
 
         void onClose();
 
-        void initialiseAnalysis();
+        void initialiseAnalysis(final AnalysisReportScreen analysisReportScreen);
 
         void terminateAnalysis();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -36,6 +36,7 @@ import org.guvnor.common.services.shared.validation.model.ValidationMessage;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Imports;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -88,6 +89,8 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                                                       perspectiveManager,
                                                       notification,
                                                       decisionTableSelectedEvent,
+                                                      mock(GuidedDecisionTableDocksHandler.class),
+                                                      mock(AnalysisReportScreen.class),
                                                       validationPopup,
                                                       resourceType,
                                                       editMenuBuilder,
@@ -210,7 +213,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         presenter.onFocus();
 
         verify(activeDtable,
-               times(1)).initialiseAnalysis();
+               times(1)).initialiseAnalysis(any());
 
         verify(decisionTableSelectedEvent,
                times(1)).fire(dtSelectedEventCaptor.capture());

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
@@ -48,6 +48,7 @@ import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilderImpl;
 import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
@@ -355,6 +356,8 @@ public class GuidedDecisionTableEditorMenusTest {
                                                                                                   perspectiveManager,
                                                                                                   notification,
                                                                                                   decisionTableSelectedEvent,
+                                                                                                  mock(GuidedDecisionTableDocksHandler.class),
+                                                                                                  mock(AnalysisReportScreen.class),
                                                                                                   validationPopup,
                                                                                                   resourceType,
                                                                                                   editMenuBuilder,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
@@ -33,6 +33,7 @@ import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Imports;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
 import org.mockito.ArgumentCaptor;
@@ -79,6 +80,8 @@ public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTa
                                                       mock(PerspectiveManager.class),
                                                       notification,
                                                       decisionTableSelectedEvent,
+                                                      mock(GuidedDecisionTableDocksHandler.class),
+                                                      mock(AnalysisReportScreen.class),
                                                       validationPopup,
                                                       resourceType,
                                                       editMenuBuilder,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.imports.Imports;
 import org.kie.workbench.common.services.shared.project.KieModuleService;
+import org.kie.workbench.common.services.verifier.reporting.client.panel.AnalysisReportScreen;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.source.ViewDRLSourceWidget;
 import org.kie.workbench.common.widgets.metadata.client.KieDocument;
@@ -216,6 +217,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
                                                            notification,
                                                            saveInProgressEvent,
                                                            decisionTableSelectedEvent,
+                                                           mock(GuidedDecisionTableDocksHandler.class),
+                                                           mock(AnalysisReportScreen.class),
                                                            validationPopup,
                                                            dtGraphResourceType,
                                                            editMenuBuilder,
@@ -1660,6 +1663,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
                                                            notification,
                                                            saveInProgressEvent,
                                                            decisionTableSelectedEvent,
+                                                           mock(GuidedDecisionTableDocksHandler.class),
+                                                           mock(AnalysisReportScreen.class),
                                                            validationPopup,
                                                            dtGraphResourceType,
                                                            editMenuBuilder,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerProviderTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerProviderTest.java
@@ -31,7 +31,6 @@ import org.kie.workbench.common.services.verifier.reporting.client.panel.Analysi
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.mvp.PlaceRequest;
 
 import static org.junit.Assert.assertFalse;
@@ -43,9 +42,6 @@ public class DecisionTableAnalyzerProviderTest {
 
     @Mock
     private AnalysisReportScreen analysisReportScreen;
-
-    @Mock
-    private PlaceManager placeManager;
 
     @Test
     public void defaultAnalyserSetting() throws
@@ -105,10 +101,10 @@ public class DecisionTableAnalyzerProviderTest {
     }
 
     private AnalyzerController constructAnalyzer() {
-        return new DecisionTableAnalyzerProvider(analysisReportScreen,
-                                                 placeManager).newAnalyzer(mock(PlaceRequest.class),
-                                                                           mock(AsyncPackageDataModelOracleImpl.class),
-                                                                           mock(GuidedDecisionTable52.class),
-                                                                           mock(EventBus.class));
+        return new DecisionTableAnalyzerProvider().newAnalyzer(mock(AnalysisReportScreen.class),
+                                                               mock(PlaceRequest.class),
+                                                               mock(AsyncPackageDataModelOracleImpl.class),
+                                                               mock(GuidedDecisionTable52.class),
+                                                               mock(EventBus.class));
     }
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/BaseGuidedDecisionTablePresenterTest.java
@@ -287,7 +287,8 @@ public abstract class BaseGuidedDecisionTablePresenterTest {
     }
 
     private void setupProviders() {
-        when(decisionTableAnalyzerProvider.newAnalyzer(eq(dtPlaceRequest),
+        when(decisionTableAnalyzerProvider.newAnalyzer(any(),
+                                                       eq(dtPlaceRequest),
                                                        eq(oracle),
                                                        any(GuidedDecisionTable52.class),
                                                        any(EventBus.class))).thenReturn(analyzerController);

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -441,7 +441,7 @@ public class GuidedDecisionTableModellerPresenterTest {
         presenter.onDecisionTableSelected(event);
 
         verify(dtPresenter1,
-               times(1)).initialiseAnalysis();
+               times(1)).initialiseAnalysis(any());
         verify(view,
                times(1)).select(dtPresenter1.getView());
         verify(gridLayer,
@@ -464,7 +464,7 @@ public class GuidedDecisionTableModellerPresenterTest {
         presenter.onDecisionTableSelected(event);
 
         verify(dtPresenter1,
-               times(1)).initialiseAnalysis();
+               times(1)).initialiseAnalysis(any());
         verify(view,
                times(1)).select(dtPresenter1.getView());
         verify(gridLayer,
@@ -488,7 +488,7 @@ public class GuidedDecisionTableModellerPresenterTest {
         presenter.onDecisionTableSelected(event);
 
         verify(dtPresenter1,
-               times(1)).initialiseAnalysis();
+               times(1)).initialiseAnalysis(any());
         verify(view,
                times(1)).select(dtPresenter1.getView());
     }
@@ -505,7 +505,7 @@ public class GuidedDecisionTableModellerPresenterTest {
 
         presenter.onDecisionTableSelected(event);
 
-        verify(dtPresenter, never()).initialiseAnalysis();
+        verify(dtPresenter, never()).initialiseAnalysis(any());
         verify(view, never()).select(any(GuidedDecisionTableView.class));
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -263,7 +263,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         verify(dtPresenter,
                times(1)).initialiseModels();
         verify(dtPresenter,
-               times(1)).initialiseValidationAndVerification();
+               times(1)).initialiseValidationAndVerification(any());
         verify(dtPresenter,
                times(1)).initialiseEventHandlers();
         verify(dtPresenter,
@@ -318,7 +318,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         verify(dtPresenter,
                times(2)).initialiseModels();
         verify(dtPresenter,
-               times(2)).initialiseValidationAndVerification();
+               times(2)).initialiseValidationAndVerification(any());
         verify(dtPresenter,
                times(2)).initialiseAuditLog();
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3957

@manstis @jomarko I'll split the work for DROOLS-1807 into two bits. First moving V&V to docks so I can couple reporting more closely with the editor and then adding the "set state" functionality in.

https://issues.jboss.org/browse/DROOLS-1807

PRs:
https://github.com/kiegroup/kie-wb-common/pull/2609
https://github.com/kiegroup/drools-wb/pull/1129