### PR TITLE
DROOLS-3432 : While using the same template key with difference objects/attributes causes an exception when switching to the Data tab in a Guided Rule Template

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/column/plugins/BRLConditionColumnPlugin.java
@@ -36,6 +36,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import org.drools.workbench.models.datamodel.rule.IPattern;
 import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.models.datamodel.rule.util.InterpolationVariableCollector;
 import org.drools.workbench.models.datamodel.rule.visitors.RuleModelVisitor;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
@@ -159,12 +160,15 @@ public class BRLConditionColumnPlugin extends BaseDecisionTableColumnPlugin impl
     }
 
     boolean getDefinedVariables(RuleModel ruleModel) {
-        Map<InterpolationVariable, Integer> ivs = new HashMap<InterpolationVariable, Integer>();
+        Map<InterpolationVariable, Integer> ivs = new HashMap<>();
         RuleModelVisitor rmv = new RuleModelVisitor(ivs);
         rmv.visit(ruleModel);
 
+        Map<InterpolationVariable, Integer> result = new InterpolationVariableCollector(ivs,
+                                                                                        DataType.TYPE_STRING).getMap();
+
         //Update column and UI
-        editingCol.setChildColumns(convertInterpolationVariables(ivs));
+        editingCol.setChildColumns(convertInterpolationVariables(result));
 
         return ivs.size() > 0;
     }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.Date;
 
 import com.google.gwt.event.shared.EventBus;
+import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.AbstractCellFactory;
@@ -62,6 +63,10 @@ public class TemplateDataCellFactory
      * @return A Cell
      */
     public DecoratedGridCellValueAdaptor<? extends Comparable<?>> getCell(TemplateDataColumn column) {
+
+        if(column.getDataType().equals(TemplateModel.DEFAULT_TYPE)){
+            return makeTextCell();
+        }
 
         //Check if the column has an enumeration
         final String dataType = column.getDataType();

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
@@ -20,6 +20,7 @@ import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +28,7 @@ import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -88,5 +90,22 @@ public class TemplateDataCellFactoryTest {
         testedFactory.getCell(column);
 
         verify(testedFactory).makeSelectionEnumCell(factType, factField, "==", dataType);
+    }
+
+    @Test
+    public void testDoNotGetCellWhenEnumPresentIfDataTypeIsDefault() throws Exception {
+        final String factType = "org.kiegroup.Car";
+        final String factField = "color";
+        final String dataType = TemplateModel.DEFAULT_TYPE;
+
+        doReturn(true).when(oracle).hasEnums(factType, factField);
+        doReturn(factType).when(column).getFactType();
+        doReturn(factField).when(column).getFactField();
+        doReturn(dataType).when(column).getDataType();
+        doReturn("==").when(column).getOperator();
+
+        testedFactory.getCell(column);
+
+        verify(testedFactory, never()).makeSelectionEnumCell(anyString(), anyString(), anyString(), anyString());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-3432
If the same variable is used for two fields the UI defaults to String cell editor.

PRs:
https://github.com/kiegroup/drools/pull/2332
https://github.com/kiegroup/drools-wb/pull/1134