### PR TITLE
[DROOLS-4034] Add an Instance to a Scenario Column leads to an exception

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -223,6 +223,8 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(DeleteColumnEvent event) {
         context.getStatus().setColumnIndex(event.getColumnIndex());
         context.getStatus().setColumnGroup(event.getColumnGroup());
+        context.getStatus().setDisable(true);
+        context.getStatus().setOpenDock(false);
         commonExecution(context,
                         new DeleteColumnCommand(),
                         true);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommand.java
@@ -23,7 +23,6 @@ import javax.enterprise.context.Dependent;
 import org.drools.scenariosimulation.api.model.FactMappingType;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
-import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 /**
  * <code>Command</code> to <b>delete</b> a column. <b>Eventually</b> add a ne column if the deleted one is the last of its group.

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/DeleteColumnCommand.java
@@ -53,10 +53,6 @@ public class DeleteColumnCommand extends AbstractScenarioSimulationCommand {
                                                                                                 context.getScenarioCellTextAreaSingletonDOMElementFactory(),
                                                                                                 ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
         }
-        GridColumn<?> selectedColumn = context.getModel().getSelectedColumn();
-        boolean toDisable = selectedColumn == null || context.getModel().getColumns().indexOf(selectedColumn) == status.getColumnIndex();
-        if (context.getTestToolsPresenter() != null && toDisable) {
-            new DisableTestToolsCommand().execute(context);
-        }
+        new ReloadTestToolsCommand().execute(context);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -265,7 +265,6 @@ public class ScenarioGridModel extends BaseGridData {
         final GridColumn<?> toDelete = getColumns().get(columnIndex);
         deleteColumn(toDelete);
         simulation.removeFactMappingByIndex(columnIndex);
-        eventBus.fireEvent(new ReloadTestToolsEvent(true));
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -258,7 +258,6 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
         verify(scenarioGridModel, times(1)).checkSimulation();
         verify(scenarioGridModel, times(1)).deleteColumn(eq(gridColumnMock));
         verify(simulationMock, times(1)).removeFactMappingByIndex(eq(COLUMN_INDEX));
-        verify(eventBusMock, times(1)).fireEvent(isA(ReloadTestToolsEvent.class));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4034

Open a new TestScenario editor.
Try to assign an instance to a column. Instance only, without a property (eg. Author).
An exception is thown.

Issue introduced with fix of ticket DROOLS-3890, please retest this ticket too.

@jomarko  @gitgabrio @danielezonca can you please review it?
Thanks.