### PR TITLE
[DROOLS-4018] Add support for LocalDate in Rule based test scenarios

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
@@ -165,11 +165,6 @@ public abstract class AbstractScenarioSimulationCommand extends AbstractCommand<
         return getScenarioGridColumn(headerBuilder, factoryCell, placeHolder);
     }
 
-//    protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, ScenarioSimulationContext context) {
-//        // indirection add for test
-//        return getScenarioGridColumn(headerBuilder, context.getScenarioCellTextAreaSingletonDOMElementFactory(), ScenarioSimulationEditorConstants.INSTANCE.insertValue());
-//    }
-
     protected Optional<FactIdentifier> getFactIdentifierByColumnTitle(String columnTitle, ScenarioSimulationContext context) {
 
         return context.getScenarioGridLayer().getScenarioGrid().getModel().getColumns().stream()

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractScenarioSimulationCommand.java
@@ -26,7 +26,6 @@ import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioS
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationViolation;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
-import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.kie.workbench.common.command.client.AbstractCommand;
@@ -166,10 +165,10 @@ public abstract class AbstractScenarioSimulationCommand extends AbstractCommand<
         return getScenarioGridColumn(headerBuilder, factoryCell, placeHolder);
     }
 
-    protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, ScenarioSimulationContext context) {
-        // indirection add for test
-        return getScenarioGridColumn(headerBuilder, context.getScenarioCellTextAreaSingletonDOMElementFactory(), ScenarioSimulationEditorConstants.INSTANCE.insertValue());
-    }
+//    protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, ScenarioSimulationContext context) {
+//        // indirection add for test
+//        return getScenarioGridColumn(headerBuilder, context.getScenarioCellTextAreaSingletonDOMElementFactory(), ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+//    }
 
     protected Optional<FactIdentifier> getFactIdentifierByColumnTitle(String columnTitle, ScenarioSimulationContext context) {
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
@@ -33,6 +33,7 @@ import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -162,7 +163,7 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioSimu
      * @param context It contains the <b>Context</b> inside which the commands will be executed
      * @param selectedColumn The selected <code>ScenarioGridColumn</code> where the command was launched
      * @param propertyNameElements The <code>List</code> with the path instance_name.property.name (eg. Author.isAlive)
-     * @param propertyClass it contains the full classname of the instance (eg. com.Author)
+     * @param propertyClass it contains the full classname of the property (eg. com.Author)
      * @param propertyHeaderTitle The title to assign to this property. Can be null, in this case it will be retrieved used <code>getPropertyHeaderTitle()</code> method
      */
     protected void setPropertyHeader(ScenarioSimulationContext context, ScenarioGridColumn selectedColumn, List<String> propertyNameElements, String propertyClass, Optional<String> propertyHeaderTitle) {
@@ -181,7 +182,9 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioSimu
                     }
                 });
         selectedColumn.getPropertyHeaderMetaData().setColumnGroup(getPropertyMetaDataGroup(selectedColumn.getInformationHeaderMetaData().getColumnGroup()));
-        setPropertyMetaData(selectedColumn.getPropertyHeaderMetaData(), propertyTitle, false, selectedColumn, ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
+                ScenarioSimulationUtils.isLocalDate(propertyClass));
+        setPropertyMetaData(selectedColumn.getPropertyHeaderMetaData(), propertyTitle, false, selectedColumn, editableCellPlaceholder);
         selectedColumn.setPropertyAssigned(true);
         context.getModel().updateColumnProperty(columnIndex,
                                                 selectedColumn,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
@@ -182,8 +182,7 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioSimu
                     }
                 });
         selectedColumn.getPropertyHeaderMetaData().setColumnGroup(getPropertyMetaDataGroup(selectedColumn.getInformationHeaderMetaData().getColumnGroup()));
-        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
-                ScenarioSimulationUtils.isLocalDate(propertyClass));
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(propertyClass);
         setPropertyMetaData(selectedColumn.getPropertyHeaderMetaData(), propertyTitle, false, selectedColumn, editableCellPlaceholder);
         selectedColumn.setPropertyAssigned(true);
         context.getModel().updateColumnProperty(columnIndex,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
@@ -17,8 +17,9 @@ package org.drools.workbench.screens.scenariosimulation.client.commands.actualco
 
 import javax.enterprise.context.Dependent;
 
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
-import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 
 /**
@@ -34,9 +35,15 @@ public class SetGridCellValueCommand extends AbstractScenarioSimulationCommand {
     @Override
     protected void internalExecute(ScenarioSimulationContext context) {
         final ScenarioSimulationContext.Status status = context.getStatus();
+        SimulationDescriptor simulationDescriptor = status.getSimulation().getSimulationDescriptor();
+        int columnIndex = status.getColumnIndex();
+        String className = simulationDescriptor.getFactMappingByIndex(columnIndex).getClassName();
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
+                ScenarioSimulationUtils.isLocalDate(className));
         context.getModel().setCellValue(status.getRowIndex(),
-                                        status.getColumnIndex(),
-                                        new ScenarioGridCellValue(status.getGridCellValue(), ScenarioSimulationEditorConstants.INSTANCE.insertValue()));
-        context.getModel().resetError(status.getRowIndex(), status.getColumnIndex());
+                                        columnIndex,
+                                        new ScenarioGridCellValue(status.getGridCellValue(),
+                                                                  editableCellPlaceholder));
+        context.getModel().resetError(status.getRowIndex(), columnIndex);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetGridCellValueCommand.java
@@ -38,8 +38,7 @@ public class SetGridCellValueCommand extends AbstractScenarioSimulationCommand {
         SimulationDescriptor simulationDescriptor = status.getSimulation().getSimulationDescriptor();
         int columnIndex = status.getColumnIndex();
         String className = simulationDescriptor.getFactMappingByIndex(columnIndex).getClassName();
-        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
-                ScenarioSimulationUtils.isLocalDate(className));
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(className);
         context.getModel().setCellValue(status.getRowIndex(),
                                         columnIndex,
                                         new ScenarioGridCellValue(status.getGridCellValue(),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -52,10 +52,10 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
         this.model = model;
     }
 
-    protected static FactModelTree getSimpleClassFactModelTree(Class clazz) {
-        String key = clazz.getSimpleName();
+    protected static FactModelTree getSimpleClassFactModelTree(String simpleClass, String canonicalName) {
+        String key = simpleClass;
         Map<String, String> simpleProperties = new HashMap<>();
-        String fullName = clazz.getCanonicalName();
+        String fullName = canonicalName;
         simpleProperties.put("value", fullName);
         String packageName = fullName.substring(0, fullName.lastIndexOf("."));
         FactModelTree toReturn = new FactModelTree(key, packageName, simpleProperties, new HashMap<>());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategy.java
@@ -200,12 +200,16 @@ public class DMODataManagementStrategy extends AbstractDataManagementStrategy {
         if (result != null) {
             factTypeFieldsMap.put(result.getFactName(), result);
         }
-        if (factTypeFieldsMap.size() == expectedElements) { // This is used to invoke this callback only once, when all the expected "compolex" objects has been managed
+        if (factTypeFieldsMap.size() == expectedElements) { // This is used to invoke this callback only once, when all the expected "complex" objects has been managed
             factTypeFieldsMap.values().forEach(factModelTree -> populateFactModelTree(factModelTree, factTypeFieldsMap));
-            SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap = new TreeMap<>(simpleJavaTypes.stream()
-                                                                                             .collect(Collectors.toMap(
-                                                                                                     factType -> factType,
-                                                                                                     factType -> getSimpleClassFactModelTree(SIMPLE_CLASSES_MAP.get(factType)))));
+            SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap =
+                    new TreeMap<>(simpleJavaTypes.stream()
+                                          .collect(Collectors.toMap(
+                                                  factType -> factType,
+                                                  factType -> {
+                                                      SimpleClassEntry classEntry = SIMPLE_CLASSES_MAP.get(factType);
+                                                      return getSimpleClassFactModelTree(classEntry.getSimpleName(), classEntry.getCanonicalName());
+                                                  })));
 
             SortedMap<String, FactModelTree> visibleFacts = new TreeMap<>(factTypeFieldsMap);
             visibleFacts.putAll(simpleJavaTypeFieldsMap);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -33,12 +33,14 @@ import org.uberfire.backend.vfs.ObservablePath;
  */
 public interface DataManagementStrategy {
 
-    Map<String, Class> SIMPLE_CLASSES_MAP = Collections.unmodifiableMap(Stream.of(
-            new AbstractMap.SimpleEntry<>(Boolean.class.getSimpleName(), Boolean.class),
-            new AbstractMap.SimpleEntry<>(Double.class.getSimpleName(), Double.class),
-            new AbstractMap.SimpleEntry<>(Integer.class.getSimpleName(), Integer.class),
-            new AbstractMap.SimpleEntry<>(Number.class.getSimpleName(), Number.class),
-            new AbstractMap.SimpleEntry<>(String.class.getSimpleName(), String.class)).
+    Map<String, SimpleClassEntry> SIMPLE_CLASSES_MAP = Collections.unmodifiableMap(Stream.of(
+            new AbstractMap.SimpleEntry<>(Boolean.class.getSimpleName(), new SimpleClassEntry(Boolean.class)),
+            new AbstractMap.SimpleEntry<>(Double.class.getSimpleName(), new SimpleClassEntry(Double.class)),
+            new AbstractMap.SimpleEntry<>(Integer.class.getSimpleName(), new SimpleClassEntry(Integer.class)),
+            new AbstractMap.SimpleEntry<>(Number.class.getSimpleName(), new SimpleClassEntry(Number.class)),
+            new AbstractMap.SimpleEntry<>(String.class.getSimpleName(), new SimpleClassEntry(String.class)),
+            // LocalDate is not supported by GWT
+            new AbstractMap.SimpleEntry<>("LocalDate", new SimpleClassEntry("LocalDate", "java.time.LocalDate"))).
             collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
     void populateTestTools(final TestToolsView.Presenter testToolsPresenter, final ScenarioGridModel scenarioGridModel);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -27,6 +27,9 @@ import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToo
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModelContent;
 import org.uberfire.backend.vfs.ObservablePath;
 
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.LOCALDATE_CANONICAL_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.LOCALDATE_SIMPLE_NAME;
+
 /**
  * The <b>Strategy</b> to use to manage/modify/save data inside the editor.
  * Every actual implementation should provide methods to manage a specific kind of data source (ex. RULE, DMN)
@@ -40,7 +43,7 @@ public interface DataManagementStrategy {
             new AbstractMap.SimpleEntry<>(Number.class.getSimpleName(), new SimpleClassEntry(Number.class)),
             new AbstractMap.SimpleEntry<>(String.class.getSimpleName(), new SimpleClassEntry(String.class)),
             // LocalDate is not supported by GWT
-            new AbstractMap.SimpleEntry<>("LocalDate", new SimpleClassEntry("LocalDate", "java.time.LocalDate"))).
+            new AbstractMap.SimpleEntry<>(LOCALDATE_SIMPLE_NAME, new SimpleClassEntry(LOCALDATE_SIMPLE_NAME, LOCALDATE_CANONICAL_NAME))).
             collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
     void populateTestTools(final TestToolsView.Presenter testToolsPresenter, final ScenarioGridModel scenarioGridModel);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/SimpleClassEntry.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/SimpleClassEntry.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.editor.strategies;
+
+public class SimpleClassEntry {
+
+    private final String simpleName;
+    private final String canonicalName;
+
+    public SimpleClassEntry(Class<?> clazz) {
+        this(clazz.getSimpleName(), clazz.getCanonicalName());
+    }
+
+    public SimpleClassEntry(String simpleName, String canonicalName) {
+        this.simpleName = simpleName;
+        this.canonicalName = canonicalName;
+    }
+
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    public String getCanonicalName() {
+        return canonicalName;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -49,6 +49,7 @@ import org.drools.workbench.screens.scenariosimulation.client.factories.Scenario
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.client.values.ScenarioGridCellValue;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridCell;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
@@ -882,7 +883,11 @@ public class ScenarioGridModel extends BaseGridData {
         IntStream.range(1, getColumnCount()).forEach(columnIndex -> {
             final FactMapping factMappingByIndex = simulationDescriptor.getFactMappingByIndex(columnIndex);
             scenario.addMappingValue(factMappingByIndex.getFactIdentifier(), factMappingByIndex.getExpressionIdentifier(), null);
-            String placeHolder = ((ScenarioGridColumn) columns.get(columnIndex)).isPropertyAssigned() ? ScenarioSimulationEditorConstants.INSTANCE.insertValue() : ScenarioSimulationEditorConstants.INSTANCE.defineValidType();
+            String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
+                    ScenarioSimulationUtils.isLocalDate(factMappingByIndex.getClassName()));
+            String placeHolder = ((ScenarioGridColumn) columns.get(columnIndex)).isPropertyAssigned() ?
+                    editableCellPlaceholder :
+                    ScenarioSimulationEditorConstants.INSTANCE.defineValidType();
             setCell(rowIndex, columnIndex, () -> {
                 ScenarioGridCell newCell = new ScenarioGridCell(new ScenarioGridCellValue(null, placeHolder));
                 if (ScenarioSimulationSharedUtils.isCollection((factMappingByIndex.getClassName()))) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -883,8 +883,7 @@ public class ScenarioGridModel extends BaseGridData {
         IntStream.range(1, getColumnCount()).forEach(columnIndex -> {
             final FactMapping factMappingByIndex = simulationDescriptor.getFactMappingByIndex(columnIndex);
             scenario.addMappingValue(factMappingByIndex.getFactIdentifier(), factMappingByIndex.getExpressionIdentifier(), null);
-            String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
-                    ScenarioSimulationUtils.isLocalDate(factMappingByIndex.getClassName()));
+            String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(factMappingByIndex.getClassName());
             String placeHolder = ((ScenarioGridColumn) columns.get(columnIndex)).isPropertyAssigned() ?
                     editableCellPlaceholder :
                     ScenarioSimulationEditorConstants.INSTANCE.defineValidType();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -176,6 +176,8 @@ public interface ScenarioSimulationEditorConstants
 
     String deleteValues();
 
+    String dateFormatPlaceholder();
+
     String deleteScenarioMainTitle();
 
     String deleteScenarioMainQuestion();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CheatSheetViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CheatSheetViewImpl.java
@@ -29,7 +29,6 @@ import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.Sce
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 
-// FIXME add LocalDate to cheatsheet
 @ApplicationScoped
 @Templated(stylesheet = "/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css")
 public class CheatSheetViewImpl

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CheatSheetViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CheatSheetViewImpl.java
@@ -29,6 +29,7 @@ import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.Sce
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 
+// FIXME add LocalDate to cheatsheet
 @ApplicationScoped
 @Templated(stylesheet = "/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css")
 public class CheatSheetViewImpl

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ConstantHolder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ConstantHolder.java
@@ -24,4 +24,8 @@ public class ConstantHolder {
     public static final String FA_ANGLE_RIGHT = "fa-angle-right";
     public static final String HIDDEN = "hidden";
     public static final String NODE_HIDDEN = "node-hidden";
+
+    // GWT doesn't support Java 8 LocalDate
+    public static final String LOCALDATE_SIMPLE_NAME = "LocalDate";
+    public static final String LOCALDATE_CANONICAL_NAME = "java.time.LocalDate";
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -98,17 +98,19 @@ public class ScenarioSimulationUtils {
      * @param factoryCell
      * @return
      */
-    public static ScenarioGridColumn getScenarioGridColumn(String instanceTitle,
-                                                           String propertyTitle,
-                                                           String columnId,
-                                                           String columnGroup,
-                                                           FactMappingType factMappingType,
-                                                           ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader,
-                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell
-    ) {
-        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(instanceTitle, propertyTitle, columnId, columnGroup, factMappingType, factoryHeader);
-        return getScenarioGridColumn(headerBuilder, factoryCell);
-    }
+
+    // FIXME to remove
+//    public static ScenarioGridColumn getScenarioGridColumn(String instanceTitle,
+//                                                           String propertyTitle,
+//                                                           String columnId,
+//                                                           String columnGroup,
+//                                                           FactMappingType factMappingType,
+//                                                           ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader,
+//                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell
+//    ) {
+//        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(instanceTitle, propertyTitle, columnId, columnGroup, factMappingType, factoryHeader);
+//        return getScenarioGridColumn(headerBuilder, factoryCell);
+//    }
 
     /**
      * Returns a <code>ScenarioGridColumn</code> with the following default values:
@@ -167,13 +169,15 @@ public class ScenarioSimulationUtils {
      * @param factoryCell
      * @return
      */
-    public static ScenarioGridColumn getScenarioGridColumn(ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
-                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell) {
-        ScenarioSimulationBuilders.ScenarioGridColumnBuilder scenarioGridColumnBuilder = getScenarioGridColumnBuilder(factoryCell,
-                                                                                                                      headerBuilder,
-                                                                                                                      ScenarioSimulationEditorConstants.INSTANCE.insertValue());
-        return scenarioGridColumnBuilder.build();
-    }
+
+    // FIXME to remove
+//    public static ScenarioGridColumn getScenarioGridColumn(ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
+//                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell) {
+//        ScenarioSimulationBuilders.ScenarioGridColumnBuilder scenarioGridColumnBuilder = getScenarioGridColumnBuilder(factoryCell,
+//                                                                                                                      headerBuilder,
+//                                                                                                                      ScenarioSimulationEditorConstants.INSTANCE.insertValue());
+//        return scenarioGridColumnBuilder.build();
+//    }
 
     /**
      * Returns a <code>ScenarioGridColumn</code> with the following default values:
@@ -316,6 +320,16 @@ public class ScenarioSimulationUtils {
                 context.getCellHeight() / 2 +
                 gridLayer.getDomElementContainer().getAbsoluteTop());
         return new Point2D(cellXMiddle, cellYMiddle);
+    }
+
+    public static boolean isLocalDate(String className) {
+        return "java.time.LocalDate".equals(className);
+    }
+
+    public static String getPlaceholder(boolean isLocalDate) {
+        return isLocalDate ?
+                ScenarioSimulationEditorConstants.INSTANCE.dateFormatPlaceholder() :
+                ScenarioSimulationEditorConstants.INSTANCE.insertValue();
     }
 
     protected static double getColumnWidth(String columnId) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -36,6 +36,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 import static org.drools.workbench.screens.scenariosimulation.client.editor.strategies.DataManagementStrategy.SIMPLE_CLASSES_MAP;
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.LOCALDATE_CANONICAL_NAME;
 
 public class ScenarioSimulationUtils {
 
@@ -84,46 +85,6 @@ public class ScenarioSimulationUtils {
      * isPropertyAssigned: <code>false</code>;
      * </p>
      * <p>
-     * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
-     * </p>
-     * <p>
-     * columnRenderer: new ScenarioGridColumnRenderer()
-     * </p>
-     * @param instanceTitle
-     * @param propertyTitle
-     * @param columnId
-     * @param columnGroup
-     * @param factMappingType
-     * @param factoryHeader
-     * @param factoryCell
-     * @return
-     */
-
-    // FIXME to remove
-//    public static ScenarioGridColumn getScenarioGridColumn(String instanceTitle,
-//                                                           String propertyTitle,
-//                                                           String columnId,
-//                                                           String columnGroup,
-//                                                           FactMappingType factMappingType,
-//                                                           ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader,
-//                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell
-//    ) {
-//        ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(instanceTitle, propertyTitle, columnId, columnGroup, factMappingType, factoryHeader);
-//        return getScenarioGridColumn(headerBuilder, factoryCell);
-//    }
-
-    /**
-     * Returns a <code>ScenarioGridColumn</code> with the following default values:
-     * <p>
-     * width: 150
-     * </p>
-     * <p>
-     * isMovable: <code>false</code>;
-     * </p>
-     * <p>
-     * isPropertyAssigned: <code>false</code>;
-     * </p>
-     * <p>
      * columnRenderer: new ScenarioGridColumnRenderer()
      * </p>
      * @param instanceTitle
@@ -147,37 +108,6 @@ public class ScenarioSimulationUtils {
         ScenarioSimulationBuilders.HeaderBuilder headerBuilder = getHeaderBuilder(instanceTitle, propertyTitle, columnId, columnGroup, factMappingType, factoryHeader);
         return getScenarioGridColumn(headerBuilder, factoryCell, placeHolder);
     }
-
-    /**
-     * Returns a <code>ScenarioGridColumn</code> with the following default values:
-     * <p>
-     * width: 150
-     * </p>
-     * <p>
-     * isMovable: <code>false</code>;
-     * </p>
-     * <p>
-     * isPropertyAssigned: <code>true</code>;
-     * </p>
-     * <p>
-     * placeHolder: <code>ScenarioSimulationEditorConstants.INSTANCE.insertValue()</code>;
-     * </p>
-     * <p>
-     * columnRenderer: new ScenarioGridColumnRenderer()
-     * </p>
-     * @param headerBuilder
-     * @param factoryCell
-     * @return
-     */
-
-    // FIXME to remove
-//    public static ScenarioGridColumn getScenarioGridColumn(ScenarioSimulationBuilders.HeaderBuilder headerBuilder,
-//                                                           ScenarioCellTextAreaSingletonDOMElementFactory factoryCell) {
-//        ScenarioSimulationBuilders.ScenarioGridColumnBuilder scenarioGridColumnBuilder = getScenarioGridColumnBuilder(factoryCell,
-//                                                                                                                      headerBuilder,
-//                                                                                                                      ScenarioSimulationEditorConstants.INSTANCE.insertValue());
-//        return scenarioGridColumnBuilder.build();
-//    }
 
     /**
      * Returns a <code>ScenarioGridColumn</code> with the following default values:
@@ -322,14 +252,14 @@ public class ScenarioSimulationUtils {
         return new Point2D(cellXMiddle, cellYMiddle);
     }
 
-    public static boolean isLocalDate(String className) {
-        return "java.time.LocalDate".equals(className);
-    }
-
-    public static String getPlaceholder(boolean isLocalDate) {
-        return isLocalDate ?
+    public static String getPlaceholder(String canonicalClassName) {
+        return isLocalDate(canonicalClassName) ?
                 ScenarioSimulationEditorConstants.INSTANCE.dateFormatPlaceholder() :
                 ScenarioSimulationEditorConstants.INSTANCE.insertValue();
+    }
+
+    public static boolean isLocalDate(String canonicalClassName) {
+        return LOCALDATE_CANONICAL_NAME.equals(canonicalClassName);
     }
 
     protected static double getColumnWidth(String columnId) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtils.java
@@ -23,6 +23,7 @@ import com.ait.lienzo.client.core.types.Point2D;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
 import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.workbench.screens.scenariosimulation.client.editor.strategies.SimpleClassEntry;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
@@ -47,7 +48,7 @@ public class ScenarioSimulationUtils {
     public static boolean isSimpleJavaType(String className) {
         return SIMPLE_CLASSES_MAP.values()
                 .stream()
-                .map(Class::getCanonicalName)
+                .map(SimpleClassEntry::getCanonicalName)
                 .anyMatch(className::equals);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -137,7 +137,7 @@ public class ScenarioGrid extends BaseGridWidget {
         String columnGroup = factMapping.getExpressionIdentifier().getType().name();
         boolean isInstanceAssigned = isInstanceAssigned(factIdentifier);
         boolean isPropertyAssigned = isPropertyAssigned(isInstanceAssigned, factMapping);
-        String placeHolder = getPlaceholder(isPropertyAssigned);
+        String placeHolder = getPlaceholder(isPropertyAssigned, factMapping);
         ScenarioGridColumn scenarioGridColumn = getScenarioGridColumnLocal(instanceTitle, propertyTitle, columnId, columnGroup, factMapping.getExpressionIdentifier().getType(), placeHolder);
         scenarioGridColumn.setInstanceAssigned(isInstanceAssigned);
         scenarioGridColumn.setPropertyAssigned(isPropertyAssigned);
@@ -214,8 +214,12 @@ public class ScenarioGrid extends BaseGridWidget {
      * @param isPropertyAssigned
      * @return
      */
-    protected String getPlaceholder(boolean isPropertyAssigned) {
-        return isPropertyAssigned ? ScenarioSimulationEditorConstants.INSTANCE.insertValue() : ScenarioSimulationEditorConstants.INSTANCE.defineValidType();
+    // FIXME to test
+    // FIXME verify all ScenarioSimulationEditorConstants.INSTANCE.insertValue() usages
+    protected String getPlaceholder(boolean isPropertyAssigned, FactMapping factMapping) {
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
+                ScenarioSimulationUtils.isLocalDate(factMapping.getClassName()));
+        return isPropertyAssigned ? editableCellPlaceholder : ScenarioSimulationEditorConstants.INSTANCE.defineValidType();
     }
 
     protected ScenarioGridColumn getScenarioGridColumnLocal(String instanceTitle, String propertyTitle, String

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -214,11 +214,8 @@ public class ScenarioGrid extends BaseGridWidget {
      * @param isPropertyAssigned
      * @return
      */
-    // FIXME to test
-    // FIXME verify all ScenarioSimulationEditorConstants.INSTANCE.insertValue() usages
     protected String getPlaceholder(boolean isPropertyAssigned, FactMapping factMapping) {
-        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(
-                ScenarioSimulationUtils.isLocalDate(factMapping.getClassName()));
+        String editableCellPlaceholder = ScenarioSimulationUtils.getPlaceholder(factMapping.getClassName());
         return isPropertyAssigned ? editableCellPlaceholder : ScenarioSimulationEditorConstants.INSTANCE.defineValidType();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -154,3 +154,4 @@ close=Close
 apply=Apply
 errorPopoverMessageFailedWithError=The expected value is ''{0}'' but the actual one is ''{1}''.
 errorPopoverMessageFailedWithException=Exception with detailed message: {0}
+dateFormatPlaceholder=Insert date as mm-dd-yyyy

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -154,4 +154,4 @@ close=Close
 apply=Apply
 errorPopoverMessageFailedWithError=The expected value is ''{0}'' but the actual one is ''{1}''.
 errorPopoverMessageFailedWithException=Exception with detailed message: {0}
-dateFormatPlaceholder=Insert date as mm-dd-yyyy
+dateFormatPlaceholder=Insert date as yyyy-mm-dd

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetInstanceHeaderCommandTest.java
@@ -21,9 +21,11 @@ import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMappingType;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
-import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationBuilders;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioCellTextAreaSingletonDOMElementFactory;
+import org.drools.workbench.screens.scenariosimulation.client.factories.ScenarioHeaderTextBoxSingletonDOMElementFactory;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +59,7 @@ public class SetInstanceHeaderCommandTest extends AbstractScenarioSimulationComm
         command = spy(new SetInstanceHeaderCommand() {
 
             @Override
-            protected ScenarioGridColumn getScenarioGridColumnLocal(ScenarioSimulationBuilders.HeaderBuilder headerBuilder, ScenarioSimulationContext context) {
+            protected ScenarioGridColumn getScenarioGridColumnLocal(String instanceTitle, String propertyTitle, String columnId, String columnGroup, FactMappingType factMappingType, ScenarioHeaderTextBoxSingletonDOMElementFactory factoryHeader, ScenarioCellTextAreaSingletonDOMElementFactory factoryCell, String placeHolder) {
                 return gridColumnMock;
             }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
@@ -46,9 +46,12 @@ public abstract class AbstractDataManagementStrategyTest extends AbstractScenari
 
     @Test
     public void getSimpleClassFactModelTree() {
-        final FactModelTree retrieved = AbstractDataManagementStrategy.getSimpleClassFactModelTree(String.class);
+        Class<String> clazz = String.class;
+        final FactModelTree retrieved = AbstractDataManagementStrategy.getSimpleClassFactModelTree(
+                clazz.getSimpleName(),
+                clazz.getCanonicalName());
         assertNotNull(retrieved);
-        assertEquals(String.class.getSimpleName(), retrieved.getFactName());
+        assertEquals(clazz.getSimpleName(), retrieved.getFactName());
         assertEquals("java.lang", retrieved.getFullPackage());
         assertNotNull(retrieved.getSimpleProperties());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DMODataManagementStrategyTest.java
@@ -72,8 +72,6 @@ public class DMODataManagementStrategyTest extends AbstractDataManagementStrateg
     @Mock
     private AsyncPackageDataModelOracle oracleMock;
 
-
-
     @Before
     public void setup() {
         super.setup();
@@ -189,7 +187,9 @@ public class DMODataManagementStrategyTest extends AbstractDataManagementStrateg
     public void getSimpleClassFactModelTree() {
         Class[] expectedClazzes = {String.class, Boolean.class, Integer.class, Double.class, Number.class};
         for (Class expectedClazz : expectedClazzes) {
-            final FactModelTree retrieved = dmoDataManagementStrategy.getSimpleClassFactModelTree(expectedClazz);
+            final FactModelTree retrieved = dmoDataManagementStrategy.getSimpleClassFactModelTree(
+                    expectedClazz.getSimpleName(),
+                    expectedClazz.getCanonicalName());
             assertNotNull(retrieved);
             String key = expectedClazz.getSimpleName();
             assertEquals(key, retrieved.getFactName());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -43,11 +43,12 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
 
-    @Test
-    public void getScenarioGridColumn1() {
-        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_INSTANCE_TITLE_FIRST, COLUMN_PROPERTY_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, scenarioHeaderTextBoxSingletonDOMElementFactoryMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
-        assertNotNull(retrieved);
-    }
+    // FIXME to remove
+//    @Test
+//    public void getScenarioGridColumn1() {
+//        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_INSTANCE_TITLE_FIRST, COLUMN_PROPERTY_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, scenarioHeaderTextBoxSingletonDOMElementFactoryMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
+//        assertNotNull(retrieved);
+//    }
 
     @Test
     public void getScenarioGridColumn2() {
@@ -55,11 +56,12 @@ public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
         assertNotNull(retrieved);
     }
 
-    @Test
-    public void getScenarioGridColumn3() {
-        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilderMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
-        assertNotNull(retrieved);
-    }
+    // FIXME to remove
+//    @Test
+//    public void getScenarioGridColumn3() {
+//        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilderMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
+//        assertNotNull(retrieved);
+//    }
 
     @Test
     public void getScenarioGridColumn4() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.utils;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.List;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,25 +45,11 @@ import static org.mockito.Mockito.when;
 @RunWith(GwtMockitoTestRunner.class)
 public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
 
-    // FIXME to remove
-//    @Test
-//    public void getScenarioGridColumn1() {
-//        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_INSTANCE_TITLE_FIRST, COLUMN_PROPERTY_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, scenarioHeaderTextBoxSingletonDOMElementFactoryMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
-//        assertNotNull(retrieved);
-//    }
-
     @Test
     public void getScenarioGridColumn2() {
         final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(COLUMN_INSTANCE_TITLE_FIRST, COLUMN_PROPERTY_TITLE_FIRST, COLUMN_ID, COLUMN_GROUP_FIRST, factMappingType, scenarioHeaderTextBoxSingletonDOMElementFactoryMock, scenarioCellTextAreaSingletonDOMElementFactoryMock, PLACEHOLDER);
         assertNotNull(retrieved);
     }
-
-    // FIXME to remove
-//    @Test
-//    public void getScenarioGridColumn3() {
-//        final ScenarioGridColumn retrieved = ScenarioSimulationUtils.getScenarioGridColumn(headerBuilderMock, scenarioCellTextAreaSingletonDOMElementFactoryMock);
-//        assertNotNull(retrieved);
-//    }
 
     @Test
     public void getScenarioGridColumn4() {
@@ -115,5 +103,14 @@ public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
         when(factIdentifierMock.getClassName()).thenReturn(packageName + "." + className);
         retrieved = ScenarioSimulationUtils.getPropertyNameElementsWithoutAlias(Arrays.asList(aliasName, propertyName), factIdentifierMock);
         assertEquals(Arrays.asList(className, propertyName), retrieved);
+    }
+
+    @Test
+    public void getPlaceholder() {
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.insertValue(),
+                     ScenarioSimulationUtils.getPlaceholder(String.class.getCanonicalName()));
+
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.dateFormatPlaceholder(),
+                     ScenarioSimulationUtils.getPlaceholder(LocalDate.class.getCanonicalName()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/utils/ScenarioSimulationUtilsTest.java
@@ -90,7 +90,7 @@ public class ScenarioSimulationUtilsTest extends AbstractUtilsTest {
 
     @Test
     public void isSimpleJavaType() {
-        SIMPLE_CLASSES_MAP.values().forEach(clazz -> assertTrue(ScenarioSimulationUtils.isSimpleJavaType(clazz.getName())));
+        SIMPLE_CLASSES_MAP.values().forEach(clazz -> assertTrue(ScenarioSimulationUtils.isSimpleJavaType(clazz.getCanonicalName())));
         assertFalse(ScenarioSimulationUtils.isSimpleJavaType("com.TestBean"));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -15,6 +15,7 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.widgets;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -281,12 +282,24 @@ public class ScenarioGridTest {
         assertTrue(scenarioGrid.isPropertyAssigned(true, factMappingInteger));
     }
 
-//    @Test
-//    // FIXME to update
-//    public void getPlaceholder() {
-//        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.insertValue(), scenarioGrid.getPlaceholder(true));
-//        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.defineValidType(), scenarioGrid.getPlaceholder(false));
-//    }
+    @Test
+    public void getPlaceholder() {
+        FactMapping stringFactMapping = new FactMapping(
+                FactIdentifier.create("test", String.class.getCanonicalName()),
+                ExpressionIdentifier.create("test", FactMappingType.GIVEN));
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.insertValue(),
+                     scenarioGrid.getPlaceholder(true, stringFactMapping));
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.defineValidType(),
+                     scenarioGrid.getPlaceholder(false, stringFactMapping));
+
+        FactMapping localDateFactMapping = new FactMapping(
+                FactIdentifier.create("test", LocalDate.class.getCanonicalName()),
+                ExpressionIdentifier.create("test", FactMappingType.GIVEN));
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.dateFormatPlaceholder(),
+                     scenarioGrid.getPlaceholder(true, localDateFactMapping));
+        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.defineValidType(),
+                     scenarioGrid.getPlaceholder(false, localDateFactMapping));
+    }
 
     @Test
     public void appendRows() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -59,6 +59,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -211,13 +212,13 @@ public class ScenarioGridTest {
         String columnGroup = type.name();
         scenarioGrid.setHeaderColumn(1, factMappingDescription, true);
         verify(scenarioGrid, times(1)).isPropertyAssigned(eq(true), eq(factMappingDescription));
-        verify(scenarioGrid, times(1)).getPlaceholder(eq(true));
+        verify(scenarioGrid, times(1)).getPlaceholder(eq(true), any());
         verify(scenarioGrid, times(1)).getScenarioGridColumnLocal(eq(EXPRESSION_ALIAS_DESCRIPTION),
                                                                   any(),
                                                                   eq(columnId),
                                                                   eq(columnGroup),
                                                                   eq(type),
-                                                                  eq(ScenarioSimulationEditorConstants.INSTANCE.insertValue()));
+                                                                  anyString());
         verify(scenarioGridColumnMock, times(1)).setColumnWidthMode(ColumnWidthMode.FIXED);
 
         reset(scenarioGrid);
@@ -228,13 +229,13 @@ public class ScenarioGridTest {
         columnGroup = type.name();
         scenarioGrid.setHeaderColumn(1, factMappingGiven, true);
         verify(scenarioGrid, times(1)).isPropertyAssigned(eq(true), eq(factMappingGiven));
-        verify(scenarioGrid, times(1)).getPlaceholder(eq(false));
+        verify(scenarioGrid, times(1)).getPlaceholder(eq(false), any());
         verify(scenarioGrid, times(1)).getScenarioGridColumnLocal(eq(EXPRESSION_ALIAS_GIVEN),
                                                                   any(),
                                                                   eq(columnId),
                                                                   eq(columnGroup),
                                                                   eq(type),
-                                                                  eq(ScenarioSimulationEditorConstants.INSTANCE.defineValidType()));
+                                                                  anyString());
         verify(scenarioGridColumnMock, never()).setColumnWidthMode(any());
     }
 
@@ -280,11 +281,12 @@ public class ScenarioGridTest {
         assertTrue(scenarioGrid.isPropertyAssigned(true, factMappingInteger));
     }
 
-    @Test
-    public void getPlaceholder() {
-        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.insertValue(), scenarioGrid.getPlaceholder(true));
-        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.defineValidType(), scenarioGrid.getPlaceholder(false));
-    }
+//    @Test
+//    // FIXME to update
+//    public void getPlaceholder() {
+//        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.insertValue(), scenarioGrid.getPlaceholder(true));
+//        assertEquals(ScenarioSimulationEditorConstants.INSTANCE.defineValidType(), scenarioGrid.getPlaceholder(false));
+//    }
 
     @Test
     public void appendRows() {


### PR DESCRIPTION
This PR introduce a basic support for `LocalDate` class to Rule based scenario.
On client side `LocalDate` are managed as simple types so user will need to write the full date in a single cell using the format `yyyy-MM-dd`. A custom placeholder is displayed in `LocalDate`s cells to inform the user about the format.

NOTE: `LocalDate` is not supported by GWT on client side so I had to use hardcoded strings for `simpleName` and `canonicalName` (the only information required on client side)

https://issues.jboss.org/browse/DROOLS-4018

@jomarko @gitgabrio @Rikkola 

PRs list:
- https://github.com/kiegroup/drools-wb/pull/1148
- https://github.com/kiegroup/drools/pull/2359