### PR TITLE
[DROOLS-3855] Unsupported DMN asset shows each item two times

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -16,11 +16,12 @@
 
 package org.drools.workbench.screens.scenariosimulation.backend.server;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -305,14 +306,14 @@ public class DMNTypeServiceImpl
 
     static class ErrorHolder {
 
-        List<String> multipleNestedObject = new ArrayList<>();
-        List<String> multipleNestedCollection = new ArrayList<>();
+        Set<String> multipleNestedObject = new HashSet<>();
+        Set<String> multipleNestedCollection = new HashSet<>();
 
-        public List<String> getMultipleNestedObject() {
+        public Set<String> getMultipleNestedObject() {
             return multipleNestedObject;
         }
 
-        public List<String> getMultipleNestedCollection() {
+        public Set<String> getMultipleNestedCollection() {
             return multipleNestedCollection;
         }
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -18,7 +18,6 @@ package org.drools.workbench.screens.scenariosimulation.backend.server;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class DMNTypeServiceImpl
         ErrorHolder errorHolder = new ErrorHolder();
         for (InputDataNode input : dmnModel.getInputs()) {
             DMNType type = input.getType();
-            checkTypeSupport(type, errorHolder, input.getName());
+            checkTypeSupport(type, false, errorHolder, input.getName());
             try {
                 visibleFacts.put(input.getName(), createTopLevelFactModelTree(input.getName(), type, hiddenFacts, FactModelTree.Type.INPUT));
             } catch (WrongDMNTypeException e) {
@@ -70,7 +69,7 @@ public class DMNTypeServiceImpl
         }
         for (DecisionNode decision : dmnModel.getDecisions()) {
             DMNType type = decision.getResultType();
-            checkTypeSupport(type, errorHolder, decision.getName());
+            checkTypeSupport(type, false, errorHolder, decision.getName());
             try {
                 visibleFacts.put(decision.getName(), createTopLevelFactModelTree(decision.getName(), type, hiddenFacts, FactModelTree.Type.DECISION));
             } catch (WrongDMNTypeException e) {
@@ -214,16 +213,6 @@ public class DMNTypeServiceImpl
     }
 
     /**
-     * Check the given <code>DMNType</code> to eventually detect if it is currently supported and add errors to given <code>ErrorHolder</code>
-     * @param type
-     * @param errorHolder
-     * @param fullPropertyPath
-     */
-    protected void checkTypeSupport(DMNType type, ErrorHolder errorHolder, String fullPropertyPath) {
-        visitCompositeType(type, false, errorHolder, fullPropertyPath);
-    }
-
-    /**
      * Return <code>true</code> if the given <code>BaseDMNTypeImpl</code> has to be managed as <b>collection</b>
      * @param type
      * @return <code>true</code> if <code>BaseDMNTypeImpl.isCollection() == true</code> <b>and</b> <code>BaseDMNTypeImpl.getFeelType() != BuiltInType.UNKNOWN</code>
@@ -280,10 +269,10 @@ public class DMNTypeServiceImpl
      * @param errorHolder
      * @param fullPropertyPath
      */
-    private void visitCompositeType(DMNType type,
-                                    boolean alreadyInCollection,
-                                    ErrorHolder errorHolder,
-                                    String fullPropertyPath) {
+    protected void checkTypeSupport(DMNType type,
+                                  boolean alreadyInCollection,
+                                  ErrorHolder errorHolder,
+                                  String fullPropertyPath) {
         if (type.isComposite()) {
             for (Map.Entry<String, DMNType> entry : type.getFields().entrySet()) {
                 String name = entry.getKey();
@@ -295,10 +284,10 @@ public class DMNTypeServiceImpl
                 if (alreadyInCollection && nestedType.isComposite()) {
                     errorHolder.getMultipleNestedObject().add(nestedPath);
                 }
-                visitCompositeType(nestedType,
-                                   alreadyInCollection || nestedType.isCollection(),
-                                   errorHolder,
-                                   nestedPath);
+                checkTypeSupport(nestedType,
+                                 alreadyInCollection || nestedType.isCollection(),
+                                 errorHolder,
+                                 nestedPath);
             }
         }
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -61,7 +62,6 @@ public class DMNTypeServiceImpl
         for (InputDataNode input : dmnModel.getInputs()) {
             DMNType type = input.getType();
             checkTypeSupport(type, errorHolder, input.getName());
-            visitCompositeType(type, false, errorHolder, input.getName());
             try {
                 visibleFacts.put(input.getName(), createTopLevelFactModelTree(input.getName(), type, hiddenFacts, FactModelTree.Type.INPUT));
             } catch (WrongDMNTypeException e) {
@@ -71,7 +71,6 @@ public class DMNTypeServiceImpl
         for (DecisionNode decision : dmnModel.getDecisions()) {
             DMNType type = decision.getResultType();
             checkTypeSupport(type, errorHolder, decision.getName());
-            visitCompositeType(type, false, errorHolder, decision.getName());
             try {
                 visibleFacts.put(decision.getName(), createTopLevelFactModelTree(decision.getName(), type, hiddenFacts, FactModelTree.Type.DECISION));
             } catch (WrongDMNTypeException e) {
@@ -306,8 +305,8 @@ public class DMNTypeServiceImpl
 
     static class ErrorHolder {
 
-        Set<String> multipleNestedObject = new HashSet<>();
-        Set<String> multipleNestedCollection = new HashSet<>();
+        Set<String> multipleNestedObject = new TreeSet<>();
+        Set<String> multipleNestedCollection = new TreeSet<>();
 
         public Set<String> getMultipleNestedObject() {
             return multipleNestedObject;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -186,7 +186,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         dmnTypeServiceImpl.checkTypeSupport(singleCompositeWithComplexCollection, errorHolder, "fieldName");
         assertEquals(0, errorHolder.getMultipleNestedObject().size());
         assertEquals(1, errorHolder.getMultipleNestedCollection().size());
-        assertEquals("fieldName.phoneNumbers.numbers", errorHolder.getMultipleNestedCollection().get(0));
+        assertTrue(errorHolder.getMultipleNestedCollection().contains("fieldName.phoneNumbers.numbers"));
     }
 
     @Test
@@ -201,7 +201,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         dmnTypeServiceImpl.checkTypeSupport(person, errorHolder, "fieldName");
         assertEquals(1, errorHolder.getMultipleNestedObject().size());
         assertEquals(0, errorHolder.getMultipleNestedCollection().size());
-        assertEquals("fieldName.phoneNumbers.complexNumbers", errorHolder.getMultipleNestedObject().get(0));
+        assertTrue(errorHolder.getMultipleNestedCollection().contains("fieldName.phoneNumbers.complexNumbers"));
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -173,7 +173,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         // top level collection
         SimpleTypeImpl topLevelCollection = getSimpleCollection();
         DMNTypeServiceImpl.ErrorHolder errorHolder = new DMNTypeServiceImpl.ErrorHolder();
-        dmnTypeServiceImpl.checkTypeSupport(topLevelCollection, errorHolder, "fieldName");
+        dmnTypeServiceImpl.checkTypeSupport(topLevelCollection, false, errorHolder, "fieldName");
         assertEquals(0, errorHolder.getMultipleNestedObject().size());
         assertEquals(0, errorHolder.getMultipleNestedCollection().size());
     }
@@ -183,7 +183,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         // nested collection
         CompositeTypeImpl singleCompositeWithComplexCollection = getSingleCompositeWithNestedCollection();
         DMNTypeServiceImpl.ErrorHolder errorHolder = new DMNTypeServiceImpl.ErrorHolder();
-        dmnTypeServiceImpl.checkTypeSupport(singleCompositeWithComplexCollection, errorHolder, "fieldName");
+        dmnTypeServiceImpl.checkTypeSupport(singleCompositeWithComplexCollection, false, errorHolder, "fieldName");
         assertEquals(0, errorHolder.getMultipleNestedObject().size());
         assertEquals(1, errorHolder.getMultipleNestedCollection().size());
         assertTrue(errorHolder.getMultipleNestedCollection().contains("fieldName.phoneNumbers.numbers"));
@@ -198,7 +198,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         phoneNumberCompositeCollection.addField("complexNumbers", complexNumbers);
         person.addField(EXPANDABLE_PROPERTY_PHONENUMBERS, phoneNumberCompositeCollection);
         DMNTypeServiceImpl.ErrorHolder errorHolder = new DMNTypeServiceImpl.ErrorHolder();
-        dmnTypeServiceImpl.checkTypeSupport(person, errorHolder, "fieldName");
+        dmnTypeServiceImpl.checkTypeSupport(person, false, errorHolder, "fieldName");
         assertEquals(1, errorHolder.getMultipleNestedObject().size());
         assertEquals(0, errorHolder.getMultipleNestedCollection().size());
         assertTrue(errorHolder.getMultipleNestedObject().contains("fieldName.phoneNumbers.complexNumbers"));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -201,7 +201,7 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         dmnTypeServiceImpl.checkTypeSupport(person, errorHolder, "fieldName");
         assertEquals(1, errorHolder.getMultipleNestedObject().size());
         assertEquals(0, errorHolder.getMultipleNestedCollection().size());
-        assertTrue(errorHolder.getMultipleNestedCollection().contains("fieldName.phoneNumbers.complexNumbers"));
+        assertTrue(errorHolder.getMultipleNestedObject().contains("fieldName.phoneNumbers.complexNumbers"));
     }
 
     /**


### PR DESCRIPTION
@jomarko  @gitgabrio @danielezonca Can you please review it?

The error checking is perfmormed 2 times, so I simply replaced the List with a Set to avoid duplicates.

https://issues.jboss.org/browse/DROOLS-3855