### PR TITLE
[DROOLS-3926] Passing test scenario with empty cells starts failing after export + import

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/importexport/ScenarioCsvImportExport.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/importexport/ScenarioCsvImportExport.java
@@ -81,9 +81,10 @@ public class ScenarioCsvImportExport {
             }
             for (int i = 0; i < factMappings.size(); i += 1) {
                 FactMapping factMapping = factMappings.get(i);
+                String valueToImport = "".equals(csvRecord.get(i)) ? null : csvRecord.get(i);
                 scenarioToFill.addMappingValue(factMapping.getFactIdentifier(),
                                                factMapping.getExpressionIdentifier(),
-                                               csvRecord.get(i));
+                                               valueToImport);
             }
         }
         return toReturn;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/importexport/ScenarioCsvImportExportTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/importexport/ScenarioCsvImportExportTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.drools.workbench.screens.scenariosimulation.backend.server.importexport.ScenarioCsvImportExport.HEADER_SIZE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ScenarioCsvImportExportTest {
 
@@ -73,7 +74,7 @@ public class ScenarioCsvImportExportTest {
         String rawCSV = "OTHER,OTHER,GIVEN,GIVEN,GIVEN\r\n" +
                 "#,Scenario description,instance1,instance2,instance3\r\n" +
                 "Index,Description,property1,property2,property3\r\n" +
-                "1,My Scenario,value1,value2,value3";
+                "1,My Scenario,value1,value2,";
 
         Simulation simulation = scenarioCsvImportExport.importData(rawCSV, originalSimulation);
 
@@ -81,7 +82,7 @@ public class ScenarioCsvImportExportTest {
 
         assertEquals("value1", simulation.getScenarioByIndex(0).getFactMappingValue(simulation.getSimulationDescriptor().getFactMappingByIndex(2)).get().getRawValue());
         assertEquals("value2", simulation.getScenarioByIndex(0).getFactMappingValue(simulation.getSimulationDescriptor().getFactMappingByIndex(3)).get().getRawValue());
-        assertEquals("value3", simulation.getScenarioByIndex(0).getFactMappingValue(simulation.getSimulationDescriptor().getFactMappingByIndex(4)).get().getRawValue());
+        assertNull(simulation.getScenarioByIndex(0).getFactMappingValue(simulation.getSimulationDescriptor().getFactMappingByIndex(4)).get().getRawValue());
 
         assertThatThrownBy(() -> scenarioCsvImportExport.importData("", originalSimulation))
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Replace empty string with `null` during import

https://issues.jboss.org/browse/DROOLS-3926

@kkufova @gitgabrio @Rikkola 