### PR TITLE
DROOLS-4131: Allow any characters for list operators

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/BaseColumnConverterImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/BaseColumnConverterImpl.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.Date;
 import java.util.List;
 
+import org.drools.workbench.models.datamodel.rule.HasOperator;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
@@ -129,6 +130,17 @@ public abstract class BaseColumnConverterImpl implements BaseColumnConverter {
     protected GridColumn<?> newColumn(final BaseColumn column,
                                       final GuidedDecisionTablePresenter.Access access,
                                       final GuidedDecisionTableView gridWidget) {
+
+        if (column instanceof HasOperator && OperatorsOracle.operatorRequiresList(((HasOperator) column).getOperator())) {
+            return newStringColumn(makeHeaderMetaData(column),
+                                   Math.max(column.getWidth(),
+                                            DEFAULT_COLUMN_WIDTH),
+                                   true,
+                                   !column.isHideColumn(),
+                                   access,
+                                   gridWidget);
+        }
+
         //Get a column based upon the data-type
         final String type = columnUtilities.getType(column);
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImplTest.java
@@ -22,6 +22,7 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
@@ -34,6 +35,8 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
 import org.drools.workbench.screens.guided.rule.client.widget.attribute.RuleAttributeWidget;
 import org.junit.Before;
@@ -277,5 +280,36 @@ public class GridWidgetColumnFactoryImplTest extends BaseConverterTest {
 
         assertEquals(false,
                      uiColumn.isVisible());
+    }
+
+    @Test
+    public void testNumericColumn_IsContainedInOperator() {
+        final BRLConditionVariableColumn column = new BRLConditionVariableColumn("$a",
+                                                                                 DataType.TYPE_NUMERIC_INTEGER,
+                                                                                 "Applicant",
+                                                                                 "age",
+                                                                                 "in");
+        column.setHeader("age is");
+
+        final GridColumn gridColumn = factory.convertColumn(column, access, gridWidget);
+
+        assertTrue(gridColumn instanceof StringUiColumn);
+    }
+
+    @Test
+    public void testNumericColumn_EqualOperator() {
+        final BRLConditionVariableColumn column = new BRLConditionVariableColumn("$a",
+                                                                                 DataType.TYPE_NUMERIC_INTEGER,
+                                                                                 "Applicant",
+                                                                                 "age",
+                                                                                 "==");
+        column.setHeader("age equal to");
+
+        when(oracle.getFieldType("Applicant",
+                                 "age")).thenReturn(DataType.TYPE_NUMERIC_INTEGER);
+
+        final GridColumn gridColumn = factory.convertColumn(column, access, gridWidget);
+
+        assertTrue(gridColumn instanceof IntegerUiColumn);
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.kie.soup.project.datamodel.oracle.DataType;
+import org.kie.soup.project.datamodel.oracle.OperatorsOracle;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.AbstractCellFactory;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.DecoratedGridCellValueAdaptor;
@@ -64,8 +65,13 @@ public class TemplateDataCellFactory
      */
     public DecoratedGridCellValueAdaptor<? extends Comparable<?>> getCell(TemplateDataColumn column) {
 
-        if(column.getDataType().equals(TemplateModel.DEFAULT_TYPE)){
-            return makeTextCell();
+        if (column.getDataType().equals(TemplateModel.DEFAULT_TYPE)) {
+            return makeTextCellWrapper();
+        }
+
+        if (OperatorsOracle.operatorRequiresList(column.getOperator())) {
+            // " " and "," needed to list multiple values
+            return makeTextCellWrapper();
         }
 
         //Check if the column has an enumeration
@@ -101,7 +107,7 @@ public class TemplateDataCellFactory
             } else if (dataType.equals(DataType.TYPE_NUMERIC_SHORT)) {
                 return makeNumericShortCell();
             } else {
-                return makeTextCell();
+                return makeTextCellWrapper();
             }
         }
     }
@@ -218,5 +224,12 @@ public class TemplateDataCellFactory
         }
 
         return cell;
+    }
+
+    /**
+     * Wrapper method due to a test purpose
+     */
+    protected DecoratedGridCellValueAdaptor<String> makeTextCellWrapper() {
+        return makeTextCell();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellValueFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellValueFactory.java
@@ -25,6 +25,7 @@ import org.drools.workbench.models.datamodel.rule.InterpolationVariable;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.soup.project.datamodel.oracle.DateConverter;
+import org.kie.soup.project.datamodel.oracle.OperatorsOracle;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.AbstractCellValueFactory;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.CellValue;
@@ -154,6 +155,10 @@ public class TemplateDataCellValueFactory
     @Override
     public CellValue<? extends Comparable<?>> convertModelCellValue(TemplateDataColumn column,
                                                                     String dcv) {
+
+        if (OperatorsOracle.operatorRequiresList(column.getOperator())) {
+            return makeNewStringCellValue(dcv);
+        }
 
         DataType.DataTypes dataType = getDataType(column);
         CellValue<? extends Comparable<?>> cell = null;
@@ -307,6 +312,10 @@ public class TemplateDataCellValueFactory
     public String convertToModelCell(TemplateDataColumn column,
                                      CellValue<?> cv) {
         DataType.DataTypes dataType = getDataType(column);
+
+        if (OperatorsOracle.operatorRequiresList(column.getOperator())) {
+            return cv.getValue().toString();
+        }
 
         switch (dataType) {
             case BOOLEAN:

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
@@ -73,6 +73,7 @@ public class TemplateDataCellFactoryTest {
         testedFactory.getCell(column);
 
         verify(testedFactory, never()).makeSelectionEnumCell(factType, factField, "==", dataType);
+        verify(testedFactory).makeTextCellWrapper();
     }
 
     @Test
@@ -90,6 +91,7 @@ public class TemplateDataCellFactoryTest {
         testedFactory.getCell(column);
 
         verify(testedFactory).makeSelectionEnumCell(factType, factField, "==", dataType);
+        verify(testedFactory, never()).makeTextCellWrapper();
     }
 
     @Test
@@ -107,5 +109,42 @@ public class TemplateDataCellFactoryTest {
         testedFactory.getCell(column);
 
         verify(testedFactory, never()).makeSelectionEnumCell(anyString(), anyString(), anyString(), anyString());
+        verify(testedFactory).makeTextCellWrapper();
+    }
+
+    @Test
+    public void testGetCellForInteger() {
+        final String factType = "org.kiegroup.Car";
+        final String factField = "price";
+        final String dataType = DataType.TYPE_NUMERIC_INTEGER;
+        final String operator = ">";
+
+        doReturn(factType).when(column).getFactType();
+        doReturn(factField).when(column).getFactField();
+        doReturn(dataType).when(column).getDataType();
+        doReturn(operator).when(column).getOperator();
+
+        testedFactory.getCell(column);
+
+        verify(testedFactory, never()).makeSelectionEnumCell(factType, factField, operator, dataType);
+        verify(testedFactory, never()).makeTextCellWrapper();
+    }
+
+    @Test
+    public void testGetCellForListOperator() {
+        final String factType = "org.kiegroup.Car";
+        final String factField = "price";
+        final String dataType = DataType.TYPE_NUMERIC_INTEGER;
+        final String operator = "in";
+
+        doReturn(factType).when(column).getFactType();
+        doReturn(factField).when(column).getFactField();
+        doReturn(dataType).when(column).getDataType();
+        doReturn(operator).when(column).getOperator();
+
+        testedFactory.getCell(column);
+
+        verify(testedFactory, never()).makeSelectionEnumCell(factType, factField, operator, dataType);
+        verify(testedFactory).makeTextCellWrapper();
     }
 }


### PR DESCRIPTION
Ensmeble together with:
- https://github.com/kiegroup/drools/pull/2379

This PR fixes the issue in guided rule templates. User was not able to put multiple numeric values separated by comma as the numeric text box was forcing just numbers. This PR change the behavior in the way allowing all characters if the "in" or "not in" operator is selected in the guided rule template.

@Rikkola @Bonuseto may I ask you for a review?