### PR TITLE
DROOLS-4042: [DMN Designer] Add support for importing and consuming PMML models

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -1068,6 +1068,15 @@
       <groupId>org.kie.workbench</groupId>
       <artifactId>kie-wb-common-dmn-backend</artifactId>
     </dependency>
+    <!-- Required for PMML integration. These are provided/optional scope in kie-dmn-core -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
 
     <!-- PMML Text Editor -->
     <dependency>
@@ -1289,12 +1298,6 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4042

Further too https://github.com/kiegroup/kie-wb-common/pull/2683 `drools-wb-webapp` needs a JAXB implementation in order for the PMML integration with DMN to function correctly. `kie-wb-distributions` has a JAXB implementation bundled with it by virtue of depending on `kie-pmml` too.