### PR TITLE
[DROOLS-4180] Invoking "duplicate instance" from a row causes unexpected error

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -247,6 +247,9 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
 
     @Override
     public void onEvent(DuplicateInstanceEvent event) {
+        if (context.getModel().getSelectedColumn() == null) {
+            return;
+        }
         context.getStatus().setColumnId(String.valueOf(new Date().getTime()));
         context.getStatus().setColumnIndex(event.getColumnIndex());
         context.getStatus().setRight(true);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.commands;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -77,6 +78,7 @@ import org.drools.workbench.screens.scenariosimulation.client.popup.DeletePopupP
 import org.drools.workbench.screens.scenariosimulation.client.popup.FileUploadPopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.popup.PreserveDeletePopupPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,6 +96,9 @@ import static org.drools.workbench.screens.scenariosimulation.client.TestPropert
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.VALUE_CLASS_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyObject;
@@ -278,7 +283,22 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
     public void onDuplicateColumnEvent() {
         DuplicateInstanceEvent event = new DuplicateInstanceEvent(COLUMN_INDEX);
         scenarioSimulationEventHandler.onEvent(event);
-        verify(scenarioSimulationEventHandler).commonExecution(eq(scenarioSimulationContextLocal),
+        verify(scenarioSimulationEventHandler, times(1)).commonExecution(eq(scenarioSimulationContextLocal),
+                                                               isA(DuplicateInstanceCommand.class),
+                                                               eq(true));
+        assertNotNull(scenarioSimulationContextLocal.getStatus().getColumnId());
+        assertEquals(scenarioSimulationContextLocal.getStatus().getColumnIndex(), COLUMN_INDEX);
+        assertTrue(scenarioSimulationContextLocal.getStatus().isRight());
+        assertFalse(scenarioSimulationContextLocal.getStatus().isAsProperty());
+        assertEquals(scenarioSimulationContextLocal.getStatus().getFullPackage(), factIdentifierMock.getPackageWithoutClassName());
+    }
+
+    @Test
+    public void onDuplicateColumnEvent_EmptySelectedColumn() {
+        when(scenarioGridModelMock.getSelectedColumn()).thenReturn(null);
+        DuplicateInstanceEvent event = new DuplicateInstanceEvent(COLUMN_INDEX);
+        scenarioSimulationEventHandler.onEvent(event);
+        verify(scenarioSimulationEventHandler, never()).commonExecution(eq(scenarioSimulationContextLocal),
                                                                isA(DuplicateInstanceCommand.class),
                                                                eq(true));
     }


### PR DESCRIPTION
@kkufova  Basically I restored the previous behaviour: Not possible to duplicate an instance starting from a NON header cell.

@kkufova @gitgabrio @danielezonca Please review it.

https://issues.jboss.org/browse/DROOLS-4180