### PR TITLE
[DROOLS-3775] Added stateless kiesession support

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
@@ -106,6 +106,7 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
         view.getRuleSettings().getStyle().setDisplay(Style.Display.INLINE);
         view.getDmoSession().setValue(Optional.ofNullable(simulationDescriptor.getDmoSession()).orElse(""));
         view.getRuleFlowGroup().setValue(Optional.ofNullable(simulationDescriptor.getRuleFlowGroup()).orElse(""));
+        view.getStateless().setChecked(simulationDescriptor.isStateless());
     }
 
     protected void setDMNSettings(SimulationDescriptor simulationDescriptor) {
@@ -119,6 +120,7 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     protected void saveRuleSettings() {
         simulationDescriptor.setDmoSession(getCleanValue(() -> view.getDmoSession().getValue()));
         simulationDescriptor.setRuleFlowGroup(getCleanValue(() -> view.getRuleFlowGroup().getValue()));
+        simulationDescriptor.setStateless(view.getStateless().isChecked());
     }
 
     protected void saveDMNSettings() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
@@ -69,5 +69,7 @@ public interface SettingsView
 
     SpanElement getSkipFromBuildLabel();
 
+    InputElement getStateless();
+
     ButtonElement getSaveButton();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.html
@@ -33,6 +33,12 @@
         </div>
         <br/>
         <div data-field="ruleSettings">
+            <div class="checkbox">
+                <label for="kieScenarioSettingsStateless">
+                    <input type="checkbox" data-field="stateless" id="kieScenarioSettingsStateless">Stateless Session
+                </label>
+            </div>
+            <br/>
             <div class="pf-c-form__group">
                 <label for="kieScenarioSettingsKieSession">
                     KieSession

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.java
@@ -84,11 +84,14 @@ public class SettingsViewImpl
     @DataField("skipFromBuild")
     protected InputElement skipFromBuild = Document.get().createCheckInputElement();
 
+    @DataField("skipFromBuildLabel")
+    protected SpanElement skipFromBuildLabel = Document.get().createSpanElement();
+
     @DataField("saveButton")
     protected ButtonElement saveButton = Document.get().createButtonElement();
 
-    @DataField("skipFromBuildLabel")
-    protected SpanElement skipFromBuildLabel = Document.get().createSpanElement();
+    @DataField("stateless")
+    protected InputElement stateless = Document.get().createCheckInputElement();
 
     public SettingsViewImpl() {
     }
@@ -111,6 +114,7 @@ public class SettingsViewImpl
         dmnNamespace.setValue("");
         dmnFilePath.setValue("");
         skipFromBuild.setChecked(false);
+        stateless.setChecked(false);
         dmnSettings.getStyle().setDisplay(Style.Display.NONE);
         ruleSettings.getStyle().setDisplay(Style.Display.NONE);
     }
@@ -196,6 +200,11 @@ public class SettingsViewImpl
     }
 
     @Override
+    public InputElement getStateless() {
+        return stateless;
+    }
+
+    @Override
     public ButtonElement getSaveButton() {
         return saveButton;
     }
@@ -204,5 +213,4 @@ public class SettingsViewImpl
     public void onSaveButtonClickEvent(ClickEvent event) {
         presenter.onSaveButton(scenarioType.getInnerText());
     }
-
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
@@ -87,6 +87,9 @@ abstract class AbstractSettingsTest {
     protected InputElement skipFromBuildMock;
 
     @Mock
+    protected InputElement statelessMock;
+
+    @Mock
     protected ButtonElement saveButtonMock;
 
     protected void setup() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
@@ -74,12 +74,14 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
         when(settingsViewMock.getDmnName()).thenReturn(dmnNameMock);
         when(settingsViewMock.getSkipFromBuild()).thenReturn(skipFromBuildMock);
         when(settingsViewMock.getSaveButton()).thenReturn(saveButtonMock);
+        when(settingsViewMock.getStateless()).thenReturn(statelessMock);
 
         when(simulationDescriptorMock.getRuleFlowGroup()).thenReturn(RULE_FLOW_GROUP);
         when(simulationDescriptorMock.getDmoSession()).thenReturn(DMO_SESSION);
         when(simulationDescriptorMock.getDmnFilePath()).thenReturn(DMN_FILE_PATH);
         when(simulationDescriptorMock.getDmnNamespace()).thenReturn(DMN_NAMESPACE);
         when(simulationDescriptorMock.getDmnName()).thenReturn(DMN_NAME);
+        when(simulationDescriptorMock.isStateless()).thenReturn(true);
 
         this.settingsPresenter = spy(new SettingsPresenter(settingsViewMock) {
             {
@@ -189,6 +191,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
         verify(dmoSessionMock, times(1)).setValue(eq(DMO_SESSION));
         verify(settingsViewMock, times(1)).getRuleFlowGroup();
         verify(ruleFlowGroupMock, times(1)).setValue(eq(RULE_FLOW_GROUP));
+        verify(statelessMock, times(1)).setChecked(eq(simulationDescriptorMock.isStateless()));
     }
 
     @Test
@@ -214,6 +217,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
         verify(settingsViewMock, times(1)).getDmoSession();
         verify(settingsViewMock, times(1)).getRuleFlowGroup();
         verify(simulationDescriptorMock, times(1)).setRuleFlowGroup(eq(RULE_FLOW_GROUP));
+        verify(simulationDescriptorMock, times(1)).setStateless(eq(false));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
@@ -59,6 +59,7 @@ public class SettingsViewImplTest extends AbstractSettingsTest {
                 this.dmnNameLabel = dmnNameLabelMock;
                 this.dmnName = dmnNameMock;
                 this.skipFromBuild = skipFromBuildMock;
+                this.stateless = statelessMock;
                 this.saveButton = saveButtonMock;
             }
         });
@@ -80,6 +81,7 @@ public class SettingsViewImplTest extends AbstractSettingsTest {
         verify(dmnNamespaceMock, times(1)).setValue(eq(""));
         verify(dmnFilePathMock, times(1)).setValue(eq(""));
         verify(skipFromBuildMock, times(1)).setChecked(eq(false));
+        verify(statelessMock, times(1)).setChecked(eq(false));
         verify(ruleSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.NONE));
         verify(dmnSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.NONE));
     }


### PR DESCRIPTION
This PR enables stateless kieSession testing.
Setting dock now contains a checkbox to specify if the session is stateless or not.
All the existing session settings are supported by stateless kiesession too: it is possible to specify session name and/or ruleFlowGroup/agendaGroup

@kkufova @Rikkola @gitgabrio @yesamer 

https://issues.jboss.org/browse/DROOLS-3775

PR list:
- https://github.com/kiegroup/drools/pull/2405
- https://github.com/kiegroup/drools-wb/pull/1174