### PR TITLE
[DROOLS-3870] Fix top vertical spaces in test scenario docks

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/TestRunnerReportingPanelWrapperImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/TestRunnerReportingPanelWrapperImpl.java
@@ -18,6 +18,9 @@ package org.drools.workbench.screens.scenariosimulation.businesscentral.client.r
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestRunnerReportingPanelWrapper;
 import org.guvnor.common.services.shared.test.TestResultMessage;
@@ -45,6 +48,9 @@ public class TestRunnerReportingPanelWrapperImpl implements TestRunnerReportingP
 
     @Override
     public IsWidget asWidget() {
-        return testRunnerReportingPanel.asWidget();
+        FlowPanel flowPanel = GWT.create(FlowPanel.class);
+        flowPanel.getElement().getStyle().setPaddingTop(4, Style.Unit.PX);
+        flowPanel.add(testRunnerReportingPanel.asWidget());
+        return flowPanel;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/TestRunnerReportingPanelWrapperImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/TestRunnerReportingPanelWrapperImpl.java
@@ -48,6 +48,7 @@ public class TestRunnerReportingPanelWrapperImpl implements TestRunnerReportingP
 
     @Override
     public IsWidget asWidget() {
+        /* Here, a FlowPanel is added to align the padding with other DocksPanels */
         FlowPanel flowPanel = GWT.create(FlowPanel.class);
         flowPanel.getElement().getStyle().setPaddingTop(4, Style.Unit.PX);
         flowPanel.add(testRunnerReportingPanel.asWidget());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsViewImpl.html
@@ -18,7 +18,6 @@
 <!-- TEST TOOLS -->
 <div id="testtools-panel" class="uf-scroll-panel">
     <div id="kieTestToolsContent" class="tab-pane kie-tab-pane--scesim-panel">
-        <br/>
         <p>To create a test template, define the "Given" and "Expect" columns by using the expression editor below.</p>
 
         <label for="kie-search">Select Data Object</label>
@@ -27,7 +26,6 @@
             <div class="search-pf has-button">
                 <div class="form-group has-clear">
                     <div class="search-pf-input-group">
-                        <!-- <label for="search1" class="sr-only">Search</label> -->
                         <input id="search1" type="search" class="form-control" data-field="inputSearch" placeholder="Search">
                         <button type="button" class="clear" data-field="clearSearchButton" aria-hidden="true">
                             <span class="pficon pficon-close"></span>


### PR DESCRIPTION
@kkufova @gitgabrio @danielezonca Can you please review it?

Basically, we have 2 changes here:
- Removed a `<BR>` tag on TestTools docks;
- Added a FlowPanel which wraps TestRunnerReportingPanel widget adding the missing padding pixels. Consider that isn't possible to modify the original panel, nor extends it to override its style.  