### PR TITLE
DROOLS-4211 / DROOLS-4212: Search feature - Implement search mechanism PoC on GDT / DMN graph

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -230,7 +230,11 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
         viewMenuBuilder.setModeller(modeller);
         insertMenuBuilder.setModeller(modeller);
         radarMenuBuilder.setModeller(modeller);
-        view.setModellerView(modeller.getView());
+        view.setModellerView(getModellerView());
+    }
+
+    protected GuidedDecisionTableModellerView getModellerView() {
+        return modeller.getView();
     }
 
     protected void onStartup(final ObservablePath path,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenter.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.guided.dtable.client.editor;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -30,13 +31,17 @@ import javax.inject.Inject;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
 import elemental2.promise.Promise;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.EditMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.page.ColumnsPage;
+import org.drools.workbench.screens.guided.dtable.client.editor.search.GuidedDecisionTableSearchableElement;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
@@ -49,9 +54,13 @@ import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
+import org.kie.workbench.common.widgets.client.search.common.EditorSearchIndex;
+import org.kie.workbench.common.widgets.client.search.common.HasSearchableElements;
+import org.kie.workbench.common.widgets.client.search.component.SearchBarComponent;
 import org.kie.workbench.common.workbench.client.docks.AuthoringWorkbenchDocks;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
@@ -81,9 +90,15 @@ import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.ED
  */
 @Dependent
 @WorkbenchEditor(identifier = "GuidedDecisionTableEditor", supportedTypes = {GuidedDTableResourceType.class}, lockingStrategy = EDITOR_PROVIDED)
-public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableEditorPresenter {
+public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableEditorPresenter implements HasSearchableElements<GuidedDecisionTableSearchableElement> {
 
     private final SaveAndRenameCommandBuilder<GuidedDecisionTable52, Metadata> saveAndRenameCommandBuilder;
+
+    private final Elemental2DomUtil util;
+
+    private final EditorSearchIndex<GuidedDecisionTableSearchableElement> editorSearchIndex;
+
+    private final SearchBarComponent<GuidedDecisionTableSearchableElement> searchBarComponent;
 
     @Inject
     public GuidedDecisionTableEditorPresenter(final View view,
@@ -104,7 +119,10 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
                                               final ColumnsPage columnsPage,
                                               final SaveAndRenameCommandBuilder<GuidedDecisionTable52, Metadata> saveAndRenameCommandBuilder,
                                               final AlertsButtonMenuItemBuilder alertsButtonMenuItemBuilder,
-                                              final DownloadMenuItem downloadMenuItem) {
+                                              final DownloadMenuItem downloadMenuItem,
+                                              final Elemental2DomUtil util,
+                                              final EditorSearchIndex<GuidedDecisionTableSearchableElement> editorSearchIndex,
+                                              final SearchBarComponent<GuidedDecisionTableSearchableElement> searchBarComponent) {
         super(view,
               service,
               docks,
@@ -125,12 +143,18 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
               downloadMenuItem);
 
         this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilder;
+        this.util = util;
+        this.editorSearchIndex = editorSearchIndex;
+        this.searchBarComponent = searchBarComponent;
     }
 
     @Override
     @PostConstruct
     public void init() {
         super.init();
+        editorSearchIndex.setIsDirtySupplier(getIsDirtySupplier());
+        editorSearchIndex.registerSubIndex(this);
+        searchBarComponent.init(editorSearchIndex);
     }
 
     @Override
@@ -157,6 +181,55 @@ public class GuidedDecisionTableEditorPresenter extends BaseGuidedDecisionTableE
         service.call(getLoadContentSuccessCallback(path,
                                                    placeRequest),
                      getNoSuchFileExceptionErrorCallback()).loadContent(path);
+    }
+
+    @Override
+    protected GuidedDecisionTableModellerView getModellerView() {
+
+        final GuidedDecisionTableModellerView view = super.getModellerView();
+        final HTMLElement modellerViewElement = util.asHTMLElement(view.asWidget().getElement());
+
+        modellerViewElement.appendChild(getSearchElement());
+
+        return view;
+    }
+
+    private Element getSearchElement() {
+        return searchBarComponent.getView().getElement();
+    }
+
+    @Override
+    public List<GuidedDecisionTableSearchableElement> getSearchableElements() {
+
+        final List<GuidedDecisionTableSearchableElement> searchableElements = new ArrayList<>();
+        final GuidedDecisionTable52 model = getContentSupplier().get();
+        final List<List<DTCellValue52>> data = model.getData();
+
+        for (int row = 0, dataSize = data.size(); row < dataSize; row++) {
+            for (int line = 0; line < data.get(row).size(); line++) {
+
+                final DTCellValue52 cellValue52 = data.get(row).get(line);
+                final GuidedDecisionTableSearchableElement searchableElement = makeSearchable(row, line, cellValue52);
+
+                searchableElements.add(searchableElement);
+            }
+        }
+
+        return searchableElements;
+    }
+
+    private GuidedDecisionTableSearchableElement makeSearchable(final int row,
+                                                                final int column,
+                                                                final DTCellValue52 cellValue52) {
+
+        final GuidedDecisionTableSearchableElement searchableElement = new GuidedDecisionTableSearchableElement();
+
+        searchableElement.setCellValue52(cellValue52);
+        searchableElement.setRow(row);
+        searchableElement.setColumn(column);
+        searchableElement.setModeller(modeller);
+
+        return searchableElement;
     }
 
     protected RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback(final ObservablePath path,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableEditorSearchIndex.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableEditorSearchIndex.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.editor.search;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.workbench.common.widgets.client.search.common.BaseEditorSearchIndex;
+
+@Dependent
+public class GuidedDecisionTableEditorSearchIndex extends BaseEditorSearchIndex<GuidedDecisionTableSearchableElement> {
+
+    private List<GuidedDecisionTableSearchableElement> searchableElements;
+
+    @Override
+    protected List<GuidedDecisionTableSearchableElement> getSearchableElements() {
+        if (isDirty() || searchableElements == null) {
+            searchableElements = loadSearchableElements();
+        }
+        return searchableElements;
+    }
+
+    List<GuidedDecisionTableSearchableElement> loadSearchableElements() {
+        return getSubIndexes()
+                .stream()
+                .flatMap(elements -> elements.getSearchableElements().stream())
+                .collect(Collectors.toList());
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableSearchableElement.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableSearchableElement.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.editor.search;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.ait.lienzo.client.core.shape.IDrawable;
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.kie.workbench.common.widgets.client.search.common.Searchable;
+import org.uberfire.ext.wires.core.grids.client.util.GridHighlightHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+import org.uberfire.mvp.Command;
+
+public class GuidedDecisionTableSearchableElement implements Searchable {
+
+    private static final String NONE = "";
+
+    private final DateTimeFormat formatter = getFormat();
+
+    private DTCellValue52 cellValue52;
+
+    private Integer row;
+
+    private Integer column;
+
+    private GuidedDecisionTableModellerView.Presenter modeller;
+
+    public void setCellValue52(final DTCellValue52 cellValue52) {
+        this.cellValue52 = cellValue52;
+    }
+
+    @Override
+    public boolean matches(final String text) {
+        return getValue().toUpperCase().contains(text.toUpperCase());
+    }
+
+    public String getValue() {
+        return convertDTCellValueToString(cellValue52);
+    }
+
+    @Override
+    public Command onFound() {
+        return () -> highlightHelper()
+                .withMinX(getMinX())
+                .withMinY(getMinY())
+                .withPaddingX(200)
+                .withPaddingY(100)
+                .highlight(row, column);
+    }
+
+    String convertDTCellValueToString(final DTCellValue52 cellValue52) {
+
+        final String stringValue = cellValue52.getStringValue();
+        final String numericValue = getStringValue(cellValue52.getNumericValue());
+        final String booleanValue = getStringValue(cellValue52.getBooleanValue());
+        final String dateValue = getStringValue(cellValue52.getDateValue());
+
+        return nonNull(stringValue, numericValue, booleanValue, dateValue);
+    }
+
+    private String nonNull(final String... values) {
+        return Stream.of(values).filter(Objects::nonNull).findFirst().orElse(NONE);
+    }
+
+    private String getStringValue(final Number number) {
+        return number == null ? null : number.toString();
+    }
+
+    private String getStringValue(final Boolean bool) {
+        return bool == null ? null : bool.toString();
+    }
+
+    private String getStringValue(final Date date) {
+        return date == null ? null : formatter.format(date);
+    }
+
+    private DateTimeFormat getFormat() {
+        return DateTimeFormat.getFormat(ApplicationPreferences.getDroolsDateFormat());
+    }
+
+    public void setRow(final int row) {
+        this.row = row;
+    }
+
+    public void setColumn(final int column) {
+        this.column = column;
+    }
+
+    private Double getMinX() {
+        return mapVisibleGridWidgetsAndGetMin(IPrimitive::getX);
+    }
+
+    private Double getMinY() {
+        return mapVisibleGridWidgetsAndGetMin(IPrimitive::getY);
+    }
+
+    private Double mapVisibleGridWidgetsAndGetMin(final Function<GridWidget, Double> mapper) {
+        return getVisibleGridWidgets()
+                .map(mapper)
+                .reduce(Double::min)
+                .orElseThrow(UnsupportedOperationException::new);
+    }
+
+    private Stream<GridWidget> getVisibleGridWidgets() {
+        return getView()
+                .getGridLayerView()
+                .getGridWidgets()
+                .stream()
+                .filter(IDrawable::isVisible);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final GuidedDecisionTableSearchableElement that = (GuidedDecisionTableSearchableElement) o;
+
+        if (!cellValue52.equals(that.cellValue52)) {
+            return false;
+        }
+        if (!row.equals(that.row)) {
+            return false;
+        }
+        return column.equals(that.column);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = cellValue52.hashCode();
+        result = ~~result;
+        result = 31 * result + row.hashCode();
+        result = ~~result;
+        result = 31 * result + column.hashCode();
+        result = ~~result;
+        return result;
+    }
+
+    GridHighlightHelper highlightHelper() {
+        return makeGridHighlightHelper(getGridPanel(), getGridWidget());
+    }
+
+    GridHighlightHelper makeGridHighlightHelper(final GridLienzoPanel gridPanel,
+                                                final GridWidget gridWidget) {
+        return new GridHighlightHelper(gridPanel, gridWidget);
+    }
+
+    private GridWidget getGridWidget() {
+        return getView()
+                .getGridWidgets()
+                .stream()
+                .filter(GridWidget::isSelected)
+                .findFirst()
+                .orElseThrow(UnsupportedOperationException::new);
+    }
+
+    private GridLienzoPanel getGridPanel() {
+        return getView().getGridPanel();
+    }
+
+    private GuidedDecisionTableModellerView getView() {
+        return getModeller().getView();
+    }
+
+    public void setModeller(final GuidedDecisionTableModellerView.Presenter modeller) {
+        this.modeller = modeller;
+    }
+
+    public GuidedDecisionTableModellerView.Presenter getModeller() {
+        return modeller;
+    }
+
+    public int getRow() {
+        return row;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -100,7 +100,10 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                                                       columnsPage,
                                                       saveAndRenameCommandBuilder,
                                                       alertsButtonMenuItemBuilder,
-                                                      downloadMenuItem) {
+                                                      downloadMenuItem,
+                                                      elemental2DomUtil,
+                                                      editorSearchIndex,
+                                                      searchBarComponent) {
             {
                 promises = BaseGuidedDecisionTableEditorPresenterTest.this.promises;
                 projectController = BaseGuidedDecisionTableEditorPresenterTest.this.projectController;
@@ -123,6 +126,11 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                times(1)).setModeller(eq(modeller));
         verify(view,
                times(1)).setModellerView(eq(modellerView));
+    }
+
+    @Test
+    public void testGetModellerView() {
+        assertEquals(modellerView, presenter.getModellerView());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
@@ -22,6 +22,9 @@ import java.util.Optional;
 
 import javax.enterprise.event.Event;
 
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.Widget;
+import elemental2.dom.HTMLElement;
 import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.EditMenuBuilder;
@@ -29,6 +32,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.menu.InsertMenuB
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.page.ColumnsPage;
+import org.drools.workbench.screens.guided.dtable.client.editor.search.GuidedDecisionTableSearchableElement;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
@@ -42,15 +46,20 @@ import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
 import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
+import org.kie.soup.commons.util.Maps;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilderImpl;
 import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
+import org.kie.workbench.common.widgets.client.search.common.EditorSearchIndex;
+import org.kie.workbench.common.widgets.client.search.component.SearchBarComponent;
 import org.kie.workbench.common.widgets.configresource.client.widget.bound.ImportsWidgetPresenter;
 import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorWrapperView;
 import org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuBuilder;
@@ -92,6 +101,7 @@ import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 import static org.junit.Assert.fail;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -269,7 +279,31 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
     protected AlertsButtonMenuItemBuilder alertsButtonMenuItemBuilder;
 
     @Mock
+    protected Elemental2DomUtil elemental2DomUtil;
+
+    @Mock
+    protected EditorSearchIndex<GuidedDecisionTableSearchableElement> editorSearchIndex;
+
+    @Mock
+    protected SearchBarComponent<GuidedDecisionTableSearchableElement> searchBarComponent;
+
+    @Mock
     protected MenuItem alertsButtonMenuItem;
+
+    @Mock
+    protected Widget modellerViewWidget;
+
+    @Mock
+    protected Element modellerViewWidgetElement;
+
+    @Mock
+    protected HTMLElement modellerViewElement;
+
+    @Mock
+    protected SearchBarComponent.View searchBarView;
+
+    @Mock
+    protected HTMLElement searchBarViewHTMLElement;
 
     protected Promises promises;
 
@@ -277,6 +311,9 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
 
     @Before
     public void setup() {
+
+        ApplicationPreferences.setUp(new Maps.Builder<String, String>().put(DATE_FORMAT, "dd/mm/yy").build());
+
         this.promises = new SyncPromises();
         this.dtServiceCaller = new CallerMock<>(dtService);
         this.versionServiceCaller = new CallerMock<>(versionService);
@@ -312,6 +349,12 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
         when(workbenchContext.getActiveOrganizationalUnit()).thenReturn(Optional.empty());
         when(workbenchContext.getActiveWorkspaceProject()).thenReturn(Optional.of(mock(WorkspaceProject.class)));
         when(downloadMenuItem.build(any())).thenReturn(downloadMenuItemButton);
+
+        when(modellerView.asWidget()).thenReturn(modellerViewWidget);
+        when(modellerViewWidget.getElement()).thenReturn(modellerViewWidgetElement);
+        when(elemental2DomUtil.asHTMLElement(modellerViewWidgetElement)).thenReturn(modellerViewElement);
+        when(searchBarComponent.getView()).thenReturn(searchBarView);
+        when(searchBarView.getElement()).thenReturn(searchBarViewHTMLElement);
 
         doReturn(alertsButtonMenuItem).when(alertsButtonMenuItemBuilder).build();
         doReturn(currentPerspective).when(perspectiveManager).getCurrentPerspective();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorMenusTest.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipboard;
@@ -30,6 +32,7 @@ import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuBu
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuView;
 import org.drools.workbench.screens.guided.dtable.client.editor.menu.ViewMenuBuilder;
 import org.drools.workbench.screens.guided.dtable.client.editor.page.ColumnsPage;
+import org.drools.workbench.screens.guided.dtable.client.editor.search.GuidedDecisionTableSearchableElement;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
@@ -42,6 +45,7 @@ import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
@@ -51,6 +55,8 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.kie.workbench.common.widgets.client.menu.FileMenuBuilderImpl;
 import org.kie.workbench.common.widgets.client.popups.validation.ValidationPopup;
+import org.kie.workbench.common.widgets.client.search.common.EditorSearchIndex;
+import org.kie.workbench.common.widgets.client.search.component.SearchBarComponent;
 import org.kie.workbench.common.widgets.configresource.client.widget.bound.ImportsWidgetPresenter;
 import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorWrapperView;
 import org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuBuilder;
@@ -270,6 +276,27 @@ public class GuidedDecisionTableEditorMenusTest {
     @Mock
     protected PerspectiveManager perspectiveManager;
 
+    @Mock
+    protected Elemental2DomUtil elemental2DomUtil;
+
+    @Mock
+    protected EditorSearchIndex<GuidedDecisionTableSearchableElement> editorSearchIndex;
+
+    @Mock
+    protected SearchBarComponent<GuidedDecisionTableSearchableElement> searchBarComponent;
+
+    @Mock
+    protected Widget modellerViewWidget;
+
+    @Mock
+    protected Element modellerViewWidgetElement;
+
+    @Mock
+    protected elemental2.dom.HTMLElement modellerViewElement;
+
+    @Mock
+    protected SearchBarComponent.View searchBarView;
+
     protected Promises promises;
 
     private GuidedDecisionTableEditorPresenter presenter;
@@ -328,6 +355,10 @@ public class GuidedDecisionTableEditorMenusTest {
         when(menuItemViewDividerProducer.get()).thenReturn(mock(MenuItemDividerView.class));
         when(menuItemViewWithIconProducer.get()).thenReturn(menuItemWithIconView);
         when(menuItemWithIconView.getElement()).thenReturn(mock(HTMLElement.class));
+        when(modellerView.asWidget()).thenReturn(modellerViewWidget);
+        when(modellerViewWidget.getElement()).thenReturn(modellerViewWidgetElement);
+        when(elemental2DomUtil.asHTMLElement(modellerViewWidgetElement)).thenReturn(modellerViewElement);
+        when(searchBarComponent.getView()).thenReturn(searchBarView);
 
         this.dtServiceCaller = new CallerMock<>(dtService);
         this.versionServiceCaller = new CallerMock<>(versionService);
@@ -367,7 +398,10 @@ public class GuidedDecisionTableEditorMenusTest {
                                                                                                   columnsPage,
                                                                                                   saveAndRenameCommandBuilder,
                                                                                                   alertsButtonMenuItemBuilder,
-                                                                                                  downloadMenuItem) {
+                                                                                                  downloadMenuItem,
+                                                                                                  elemental2DomUtil,
+                                                                                                  editorSearchIndex,
+                                                                                                  searchBarComponent) {
             {
                 promises = GuidedDecisionTableEditorMenusTest.this.promises;
             }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
@@ -17,12 +17,17 @@
 package org.drools.workbench.screens.guided.dtable.client.editor;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.client.editor.search.GuidedDecisionTableSearchableElement;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
@@ -46,12 +51,14 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.MenuItem;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -59,6 +66,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTablePresenterTest<GuidedDecisionTableEditorPresenter> {
@@ -91,7 +99,10 @@ public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTa
                                                       columnsPage,
                                                       saveAndRenameCommandBuilder,
                                                       alertsButtonMenuItemBuilder,
-                                                      downloadMenuItem) {
+                                                      downloadMenuItem,
+                                                      elemental2DomUtil,
+                                                      editorSearchIndex,
+                                                      searchBarComponent) {
             {
                 workbenchContext = GuidedDecisionTableEditorPresenterTest.this.workbenchContext;
                 projectController = GuidedDecisionTableEditorPresenterTest.this.projectController;
@@ -103,6 +114,67 @@ public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTa
                 return mock(Command.class);
             }
         };
+    }
+
+    @Test
+    public void testInit() {
+
+        final Supplier<Boolean> isDirty = () -> true;
+
+        doReturn(isDirty).when(presenter).getIsDirtySupplier();
+
+        // init is called on @Before
+
+        editorSearchIndex.setIsDirtySupplier(isDirty);
+        verify(editorSearchIndex).registerSubIndex(presenter);
+        verify(searchBarComponent).init(editorSearchIndex);
+    }
+
+    @Test
+    public void testGetModellerView() {
+
+        final GuidedDecisionTableModellerView actual = presenter.getModellerView();
+
+        // appendChild is called more than one time due to @Before setup
+        verify(modellerViewElement, atLeastOnce()).appendChild(searchBarViewHTMLElement);
+        assertEquals(modellerView, actual);
+    }
+
+    @Test
+    public void testGetSearchableElements() {
+
+        final GuidedDecisionTable52 model = mock(GuidedDecisionTable52.class);
+        final Supplier<GuidedDecisionTable52> modelSupplier = () -> model;
+        final List<DTCellValue52> row1 = asList(new DTCellValue52("cell 1"), new DTCellValue52("cell 2"));
+        final List<DTCellValue52> row2 = asList(new DTCellValue52("cell 3"), new DTCellValue52("cell 4"));
+        final List<List<DTCellValue52>> data = asList(row1, row2);
+
+        doReturn(modelSupplier).when(presenter).getContentSupplier();
+        when(model.getData()).thenReturn(data);
+
+        final List<GuidedDecisionTableSearchableElement> elements = presenter.getSearchableElements();
+
+        assertEquals(4, elements.size());
+
+        assertEquals("cell 1", elements.get(0).getValue());
+        assertEquals("cell 2", elements.get(1).getValue());
+        assertEquals("cell 3", elements.get(2).getValue());
+        assertEquals("cell 4", elements.get(3).getValue());
+
+        assertEquals(0, elements.get(0).getRow());
+        assertEquals(0, elements.get(1).getRow());
+        assertEquals(1, elements.get(2).getRow());
+        assertEquals(1, elements.get(3).getRow());
+
+        assertEquals(0, elements.get(0).getColumn());
+        assertEquals(1, elements.get(1).getColumn());
+        assertEquals(0, elements.get(2).getColumn());
+        assertEquals(1, elements.get(3).getColumn());
+
+        assertEquals(modeller, elements.get(0).getModeller());
+        assertEquals(modeller, elements.get(1).getModeller());
+        assertEquals(modeller, elements.get(2).getModeller());
+        assertEquals(modeller, elements.get(3).getModeller());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableEditorSearchIndexTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableEditorSearchIndexTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.editor.search;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.search.common.HasSearchableElements;
+import org.mockito.Mock;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedDecisionTableEditorSearchIndexTest {
+
+    private GuidedDecisionTableEditorSearchIndex searchIndex;
+
+    @Mock
+    private GuidedDecisionTableSearchableElement element1;
+
+    @Mock
+    private GuidedDecisionTableSearchableElement element2;
+
+    @Mock
+    private GuidedDecisionTableSearchableElement element3;
+
+    @Mock
+    private GuidedDecisionTableSearchableElement element4;
+
+    @Mock
+    private GuidedDecisionTableSearchableElement element5;
+
+    private List<GuidedDecisionTableSearchableElement> expectedElements;
+
+    @Before
+    public void setup() {
+
+        searchIndex = spy(new GuidedDecisionTableEditorSearchIndex());
+        expectedElements = asList(element1, element2, element3, element4, element5);
+
+        searchIndex.setIsDirtySupplier(() -> false);
+        searchIndex.registerSubIndex(new FakeHasSearchableElements(asList(element1, element2)));
+        searchIndex.registerSubIndex(new FakeHasSearchableElements(asList(element3, element4, element5)));
+    }
+
+    @Test
+    public void testGetSearchableElementsWhenItsTheFirstCall() {
+
+        final List<GuidedDecisionTableSearchableElement> actualElements = searchIndex.getSearchableElements();
+
+        verify(searchIndex, times(1)).loadSearchableElements();
+        assertEquals(expectedElements, actualElements);
+    }
+
+    @Test
+    public void testGetSearchableElementsWhenItsTheSecondCall() {
+
+        final List<GuidedDecisionTableSearchableElement> firstResult = searchIndex.getSearchableElements();
+        final List<GuidedDecisionTableSearchableElement> secondResult = searchIndex.getSearchableElements();
+
+        verify(searchIndex, times(1)).loadSearchableElements();
+        assertEquals(expectedElements, firstResult);
+        assertSame(firstResult, secondResult);
+    }
+
+    @Test
+    public void testGetSearchableElementsWhenItsDirtyCall() {
+
+        searchIndex.setIsDirtySupplier(() -> true);
+
+        final List<GuidedDecisionTableSearchableElement> firstResult = searchIndex.getSearchableElements();
+        final List<GuidedDecisionTableSearchableElement> secondResult = searchIndex.getSearchableElements();
+
+        verify(searchIndex, times(2)).loadSearchableElements();
+        assertEquals(expectedElements, firstResult);
+        assertNotSame(firstResult, secondResult);
+    }
+
+    class FakeHasSearchableElements implements HasSearchableElements<GuidedDecisionTableSearchableElement> {
+
+        final List<GuidedDecisionTableSearchableElement> searchableElements;
+
+        FakeHasSearchableElements(final List<GuidedDecisionTableSearchableElement> searchableElements) {
+            this.searchableElements = searchableElements;
+        }
+
+        @Override
+        public List<GuidedDecisionTableSearchableElement> getSearchableElements() {
+            return searchableElements;
+        }
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableSearchableElementTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/search/GuidedDecisionTableSearchableElementTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.editor.search;
+
+import java.util.HashSet;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.util.GridHighlightHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.DATE_FORMAT;
+import static org.kie.workbench.common.services.shared.preferences.ApplicationPreferences.getDroolsDateFormat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedDecisionTableSearchableElementTest {
+
+    @Mock
+    private GuidedDecisionTableModellerView.Presenter modeller;
+
+    @Mock
+    private GuidedDecisionTableModellerView view;
+
+    @Mock
+    private GridLayer gridLayer;
+
+    @Mock
+    private GridWidget gridWidget1;
+
+    @Mock
+    private GridWidget gridWidget2;
+
+    @Mock
+    private GridWidget gridWidget3;
+
+    @Mock
+    private GridLienzoPanel gridPanel;
+
+    private DateTimeFormat format;
+
+    private DTCellValue52 cellValue52;
+
+    private String stringValue = "Element value";
+
+    private Double minY = -2400d;
+
+    private Double minX = -3400d;
+
+    private GuidedDecisionTableSearchableElement element;
+
+    @Before
+    public void setUp() {
+
+        final HashSet<GridWidget> gridWidgets = new HashSet<>(asList(gridWidget1, gridWidget2, gridWidget3));
+
+        ApplicationPreferences.setUp(new Maps.Builder<String, String>().put(DATE_FORMAT, "dd/mm/yy").build());
+
+        format = DateTimeFormat.getFormat(getDroolsDateFormat());
+        cellValue52 = new DTCellValue52(stringValue);
+        element = spy(new GuidedDecisionTableSearchableElement());
+
+        element.setCellValue52(cellValue52);
+        element.setModeller(modeller);
+
+        when(gridWidget1.getY()).thenReturn(0d);
+        when(gridWidget2.getY()).thenReturn(0d);
+        when(gridWidget3.getY()).thenReturn(minY);
+        when(gridWidget1.getX()).thenReturn(0d);
+        when(gridWidget2.getX()).thenReturn(0d);
+        when(gridWidget3.getX()).thenReturn(minX);
+        when(gridWidget2.isSelected()).thenReturn(true);
+        when(gridWidget1.isVisible()).thenReturn(true);
+        when(gridWidget2.isVisible()).thenReturn(true);
+        when(gridWidget3.isVisible()).thenReturn(true);
+        when(modeller.getView()).thenReturn(view);
+        when(view.getGridLayerView()).thenReturn(gridLayer);
+        when(view.getGridPanel()).thenReturn(gridPanel);
+        when(view.getGridWidgets()).thenReturn(gridWidgets);
+        when(gridLayer.getGridWidgets()).thenReturn(gridWidgets);
+    }
+
+    @Test
+    public void testMatchesWhenItReturnsTrue() {
+        final boolean matches = element.matches("ELE");
+        assertTrue(matches);
+    }
+
+    @Test
+    public void testMatchesWhenItReturnsFalse() {
+        final boolean matches = element.matches("LEE");
+        assertFalse(matches);
+    }
+
+    @Test
+    public void testConvertDTCellValueToString() {
+        assertEquals("string", element.convertDTCellValueToString(new DTCellValue52("string")));
+        assertEquals("10", element.convertDTCellValueToString(new DTCellValue52(10)));
+        assertEquals("true", element.convertDTCellValueToString(new DTCellValue52(true)));
+        assertEquals("02/01/92", element.convertDTCellValueToString(new DTCellValue52(format.parse("02/01/92"))));
+    }
+
+    @Test
+    public void testOnFound() {
+
+        final GridHighlightHelper highlightHelper = mock(GridHighlightHelper.class);
+        final int row = 64;
+        final int column = 128;
+
+        element.setRow(row);
+        element.setColumn(column);
+
+        doReturn(highlightHelper).when(element).highlightHelper();
+        when(highlightHelper.withMinX(minX)).thenReturn(highlightHelper);
+        when(highlightHelper.withMinY(minY)).thenReturn(highlightHelper);
+        when(highlightHelper.withPaddingX(200)).thenReturn(highlightHelper);
+        when(highlightHelper.withPaddingY(100)).thenReturn(highlightHelper);
+
+        element.onFound().execute();
+
+        verify(highlightHelper).highlight(row, column);
+    }
+
+    @Test
+    public void testHighlightHelper() {
+
+        final GridHighlightHelper expectedHighlightHelper = mock(GridHighlightHelper.class);
+
+        doReturn(expectedHighlightHelper).when(element).makeGridHighlightHelper(gridPanel, gridWidget2);
+
+        final GridHighlightHelper actualHighlightHelper = element.highlightHelper();
+
+        assertEquals(expectedHighlightHelper, actualHighlightHelper);
+    }
+}


### PR DESCRIPTION
### JIRAs:

- https://issues.jboss.org/browse/DROOLS-4211
- https://issues.jboss.org/browse/DROOLS-4212

---

### Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/738
- https://github.com/kiegroup/kie-wb-common/pull/2749
- https://github.com/kiegroup/drools-wb/pull/1190

---

### Description
DROOLS-4211 and DROOLS-4212 JIRAs comprehend only the search mechanism. Thus, the PR implements that for Guided Decision Tables, DMN graphs, and DMN boxed expressions, without a rick user experience (which will be implemented on [DROOLS-4306](https://issues.jboss.org/browse/DROOLS-4306)).
 
To test this PR, just execute the following code into the _browser inspector_:
 
```javascript
document.querySelector('.kie-search-bar').style.display = ""
```

The search component will be enabled:

Now, you can type something and press <kbd>Enter</kbd> to trigger the search.

![2019-07-11 12 57 45](https://user-images.githubusercontent.com/1079279/61076885-a01ac480-a3f3-11e9-8eba-35faafb3a1e2.gif)
