### PR TITLE
 [DROOLS-4108] Add check to avoid DMN test scenario to be created without any GIVEN or EXPECT column

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
@@ -73,7 +73,7 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
             addToScenario(factMappingExtractor, factModelTree, new ArrayList<>(), hiddenValues);
         });
 
-        addEmptyColumnIfNeeded(toReturn, scenarioWithIndex);
+        addEmptyColumnsIfNeeded(toReturn, scenarioWithIndex);
 
         return toReturn;
     }
@@ -83,7 +83,7 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
      * @param simulation
      * @param scenarioWithIndex
      */
-    protected void addEmptyColumnIfNeeded(Simulation simulation, ScenarioWithIndex scenarioWithIndex) {
+    protected void addEmptyColumnsIfNeeded(Simulation simulation, ScenarioWithIndex scenarioWithIndex) {
         boolean hasGiven = false;
         boolean hasExpect = false;
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategy.java
@@ -30,6 +30,7 @@ import org.drools.scenariosimulation.api.model.FactMapping;
 import org.drools.scenariosimulation.api.model.FactMappingType;
 import org.drools.scenariosimulation.api.model.Scenario;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
 import org.drools.scenariosimulation.api.model.Simulation;
 import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
@@ -38,6 +39,8 @@ import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.Fact
 import org.drools.workbench.screens.scenariosimulation.service.DMNTypeService;
 import org.uberfire.backend.vfs.Path;
 
+import static org.drools.scenariosimulation.api.model.FactMappingType.EXPECT;
+import static org.drools.scenariosimulation.api.model.FactMappingType.GIVEN;
 import static org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree.Type;
 
 @ApplicationScoped
@@ -54,9 +57,8 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
         SimulationDescriptor simulationDescriptor = toReturn.getSimulationDescriptor();
         simulationDescriptor.setType(ScenarioSimulationModel.Type.DMN);
         simulationDescriptor.setDmnFilePath(dmnFilePath);
-        Scenario scenario = createScenario(toReturn, simulationDescriptor);
+        ScenarioWithIndex scenarioWithIndex = createScenario(toReturn, simulationDescriptor);
 
-        int row = toReturn.getUnmodifiableScenarios().indexOf(scenario);
         AtomicInteger id = new AtomicInteger(1);
         final Collection<FactModelTree> visibleFactTrees = factModelTuple.getVisibleFacts().values();
         final Map<String, FactModelTree> hiddenValues = factModelTuple.getHiddenFacts();
@@ -67,11 +69,62 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
             return aType.equals(bType) ? 0 : (Type.INPUT.equals(aType) ? -1 : 1);
         }).forEach(factModelTree -> {
             FactIdentifier factIdentifier = new FactIdentifier(factModelTree.getFactName(), factModelTree.getFactName());
-            FactMappingExtractor factMappingExtractor = new FactMappingExtractor(factIdentifier, row, id, convert(factModelTree.getType()), simulationDescriptor, scenario);
+            FactMappingExtractor factMappingExtractor = new FactMappingExtractor(factIdentifier, scenarioWithIndex.getIndex(), id, convert(factModelTree.getType()), simulationDescriptor, scenarioWithIndex.getScenario());
             addToScenario(factMappingExtractor, factModelTree, new ArrayList<>(), hiddenValues);
         });
 
+        addEmptyColumnIfNeeded(toReturn, scenarioWithIndex);
+
         return toReturn;
+    }
+
+    /**
+     * If DMN model is empty, contains only inputs or only outputs this method add one GIVEN and/or EXPECT empty column
+     * @param simulation
+     * @param scenarioWithIndex
+     */
+    protected void addEmptyColumnIfNeeded(Simulation simulation, ScenarioWithIndex scenarioWithIndex) {
+        boolean hasGiven = false;
+        boolean hasExpect = false;
+        SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
+        for (FactMapping factMapping : simulationDescriptor.getFactMappings()) {
+            FactMappingType factMappingType = factMapping.getExpressionIdentifier().getType();
+            if (!hasGiven && GIVEN.equals(factMappingType)) {
+                hasGiven = true;
+            } else if (!hasExpect && EXPECT.equals(factMappingType)) {
+                hasExpect = true;
+            }
+        }
+        if (!hasGiven) {
+            createEmptyColumn(simulationDescriptor,
+                              scenarioWithIndex,
+                              1,
+                              GIVEN,
+                              findNewIndexOfGroup(simulationDescriptor, GIVEN));
+        }
+        if (!hasExpect) {
+            createEmptyColumn(simulationDescriptor,
+                              scenarioWithIndex,
+                              2,
+                              EXPECT,
+                              findNewIndexOfGroup(simulationDescriptor, EXPECT));
+        }
+    }
+
+    protected int findNewIndexOfGroup(SimulationDescriptor simulationDescriptor, FactMappingType factMappingType) {
+        List<FactMapping> factMappings = simulationDescriptor.getFactMappings();
+        if (GIVEN.equals(factMappingType)) {
+            for (int i = 0; i < factMappings.size(); i += 1) {
+                if (EXPECT.equals(factMappings.get(i).getExpressionIdentifier().getType())) {
+                    return i;
+                }
+            }
+            return factMappings.size();
+        } else if (EXPECT.equals(factMappingType)) {
+            return factMappings.size();
+        } else {
+            throw new IllegalArgumentException("This method can be invoked only with GIVEN or EXPECT as FactMappingType");
+        }
     }
 
     // Indirection for test
@@ -161,9 +214,9 @@ public class DMNSimulationCreationStrategy implements SimulationCreationStrategy
     static private FactMappingType convert(Type modelTreeType) {
         switch (modelTreeType) {
             case INPUT:
-                return FactMappingType.GIVEN;
+                return GIVEN;
             case DECISION:
-                return FactMappingType.EXPECT;
+                return EXPECT;
             default:
                 throw new IllegalArgumentException("Impossible to map");
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/RULESimulationCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/RULESimulationCreationStrategy.java
@@ -17,15 +17,14 @@ package org.drools.workbench.screens.scenariosimulation.backend.server.util;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
-import org.drools.scenariosimulation.api.model.FactIdentifier;
-import org.drools.scenariosimulation.api.model.FactMapping;
-import org.drools.scenariosimulation.api.model.FactMappingType;
-import org.drools.scenariosimulation.api.model.Scenario;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
 import org.drools.scenariosimulation.api.model.Simulation;
 import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.uberfire.backend.vfs.Path;
+
+import static org.drools.scenariosimulation.api.model.FactMappingType.EXPECT;
+import static org.drools.scenariosimulation.api.model.FactMappingType.GIVEN;
 
 @ApplicationScoped
 public class RULESimulationCreationStrategy implements SimulationCreationStrategy {
@@ -37,21 +36,21 @@ public class RULESimulationCreationStrategy implements SimulationCreationStrateg
         simulationDescriptor.setType(ScenarioSimulationModel.Type.RULE);
         simulationDescriptor.setDmoSession(value);
 
-        Scenario scenario = createScenario(toReturn, simulationDescriptor);
-        int row = toReturn.getUnmodifiableScenarios().indexOf(scenario);
+        ScenarioWithIndex scenarioWithIndex = createScenario(toReturn, simulationDescriptor);
+
         // Add GIVEN Fact
-        int id = 1;
-        ExpressionIdentifier givenExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.GIVEN);
-        final FactMapping givenFactMapping = simulationDescriptor.addFactMapping(FactMapping.getInstancePlaceHolder(id), FactIdentifier.EMPTY, givenExpression);
-        givenFactMapping.setExpressionAlias(FactMapping.getPropertyPlaceHolder(id));
-        scenario.addMappingValue(FactIdentifier.EMPTY, givenExpression, null);
+        createEmptyColumn(simulationDescriptor,
+                          scenarioWithIndex,
+                          1,
+                          GIVEN,
+                          simulationDescriptor.getFactMappings().size());
 
         // Add EXPECT Fact
-        id = 2;
-        ExpressionIdentifier expectedExpression = ExpressionIdentifier.create(row + "|" + id, FactMappingType.EXPECT);
-        final FactMapping expectedFactMapping = simulationDescriptor.addFactMapping(FactMapping.getInstancePlaceHolder(id), FactIdentifier.EMPTY, expectedExpression);
-        expectedFactMapping.setExpressionAlias(FactMapping.getPropertyPlaceHolder(id));
-        scenario.addMappingValue(FactIdentifier.EMPTY, expectedExpression, null);
+        createEmptyColumn(simulationDescriptor,
+                          scenarioWithIndex,
+                          2,
+                          EXPECT,
+                          simulationDescriptor.getFactMappings().size());
         return toReturn;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/SimulationCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/SimulationCreationStrategy.java
@@ -17,7 +17,10 @@ package org.drools.workbench.screens.scenariosimulation.backend.server.util;
 
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.FactMappingType;
 import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
 import org.drools.scenariosimulation.api.model.Simulation;
 import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.uberfire.backend.vfs.Path;
@@ -29,11 +32,38 @@ public interface SimulationCreationStrategy {
 
     Simulation createSimulation(Path context, String value) throws Exception;
 
-    default Scenario createScenario(Simulation simulation, SimulationDescriptor simulationDescriptor) {
+    default ScenarioWithIndex createScenario(Simulation simulation, SimulationDescriptor simulationDescriptor) {
         simulationDescriptor.addFactMapping(FactIdentifier.INDEX.getName(), FactIdentifier.INDEX, ExpressionIdentifier.INDEX);
         simulationDescriptor.addFactMapping(FactIdentifier.DESCRIPTION.getName(), FactIdentifier.DESCRIPTION, ExpressionIdentifier.DESCRIPTION);
-        Scenario toReturn = simulation.addScenario();
-        toReturn.setDescription(null);
-        return toReturn;
+        Scenario scenario = simulation.addScenario();
+        scenario.setDescription(null);
+        int index = simulation.getUnmodifiableScenarios().indexOf(scenario) + 1;
+        return new ScenarioWithIndex(index, scenario);
+    }
+
+    /**
+     * Create an empty column using factMappingType defined. The new column will be added as last column of
+     * the group (GIVEN/EXPECT) (see findLastIndexOfGroup)
+     * @param simulationDescriptor
+     * @param scenarioWithIndex
+     * @param placeholderId
+     * @param factMappingType
+     */
+    default void createEmptyColumn(SimulationDescriptor simulationDescriptor,
+                                   ScenarioWithIndex scenarioWithIndex,
+                                   int placeholderId,
+                                   FactMappingType factMappingType,
+                                   int columnIndex) {
+        int row = scenarioWithIndex.getIndex();
+        final ExpressionIdentifier expressionIdentifier = ExpressionIdentifier.create(row + "|" + placeholderId, factMappingType);
+
+        final FactMapping factMapping = simulationDescriptor
+                .addFactMapping(
+                        columnIndex,
+                        FactMapping.getInstancePlaceHolder(placeholderId),
+                        FactIdentifier.EMPTY,
+                        expressionIdentifier);
+        factMapping.setExpressionAlias(FactMapping.getPropertyPlaceHolder(placeholderId));
+        scenarioWithIndex.getScenario().addMappingValue(FactIdentifier.EMPTY, expressionIdentifier, null);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategyTest.java
@@ -43,8 +43,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.drools.scenariosimulation.api.model.FactMappingType.EXPECT;
 import static org.drools.scenariosimulation.api.model.FactMappingType.GIVEN;
+import static org.drools.scenariosimulation.api.model.FactMappingType.OTHER;
 import static org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree.Type.DECISION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -110,7 +112,7 @@ public class DMNSimulationCreationStrategyTest extends AbstractDMNTest {
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
         simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, givenExpressionIdentifier);
 
-        dmnSimulationCreationStrategy.addEmptyColumnIfNeeded(simulation, scenarioWithIndex);
+        dmnSimulationCreationStrategy.addEmptyColumnsIfNeeded(simulation, scenarioWithIndex);
         assertEquals(2, simulationDescriptor.getFactMappings().size());
         assertTrue(simulationDescriptor.getFactMappings().stream()
                            .anyMatch(elem -> EXPECT.equals(elem.getExpressionIdentifier().getType())));
@@ -121,7 +123,7 @@ public class DMNSimulationCreationStrategyTest extends AbstractDMNTest {
         simulationDescriptor = simulation.getSimulationDescriptor();
         simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, expectExpressionIdentifier);
 
-        dmnSimulationCreationStrategy.addEmptyColumnIfNeeded(simulation, scenarioWithIndex);
+        dmnSimulationCreationStrategy.addEmptyColumnsIfNeeded(simulation, scenarioWithIndex);
         assertEquals(2, simulationDescriptor.getFactMappings().size());
         assertTrue(simulationDescriptor.getFactMappings().stream()
                            .anyMatch(elem -> GIVEN.equals(elem.getExpressionIdentifier().getType())));
@@ -129,18 +131,21 @@ public class DMNSimulationCreationStrategyTest extends AbstractDMNTest {
 
     @Test
     public void findNewIndexOfGroup() {
-        Simulation simulation = new Simulation();
-        SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
+        SimulationDescriptor simulationDescriptorGiven = new SimulationDescriptor();
         ExpressionIdentifier givenExpressionIdentifier = ExpressionIdentifier.create("given1", GIVEN);
-        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, givenExpressionIdentifier);
-        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, GIVEN));
-        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, EXPECT));
+        simulationDescriptorGiven.addFactMapping(FactIdentifier.EMPTY, givenExpressionIdentifier);
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptorGiven, GIVEN));
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptorGiven, EXPECT));
 
-        simulationDescriptor = new SimulationDescriptor();
+        SimulationDescriptor simulationDescriptorExpect = new SimulationDescriptor();
         ExpressionIdentifier expectExpressionIdentifier = ExpressionIdentifier.create("expect1", EXPECT);
-        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, expectExpressionIdentifier);
-        assertEquals(0, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, GIVEN));
-        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, EXPECT));
+        simulationDescriptorExpect.addFactMapping(FactIdentifier.EMPTY, expectExpressionIdentifier);
+        assertEquals(0, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptorExpect, GIVEN));
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptorExpect, EXPECT));
+
+        assertThatThrownBy(() -> dmnSimulationCreationStrategy.findNewIndexOfGroup(new SimulationDescriptor(), OTHER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("This method can be invoked only with GIVEN or EXPECT as FactMappingType");
     }
 
     private void verifySimulationCreated(boolean hasInput, boolean hasOutput) throws Exception {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationCreationStrategyTest.java
@@ -18,11 +18,17 @@ package org.drools.workbench.screens.scenariosimulation.backend.server.util;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
 import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.drools.workbench.screens.scenariosimulation.backend.server.AbstractDMNTest;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTuple;
@@ -37,9 +43,14 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
 
+import static org.drools.scenariosimulation.api.model.FactMappingType.EXPECT;
+import static org.drools.scenariosimulation.api.model.FactMappingType.GIVEN;
+import static org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree.Type.DECISION;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -73,21 +84,108 @@ public class DMNSimulationCreationStrategyTest extends AbstractDMNTest {
         final Simulation retrieved = dmnSimulationCreationStrategy.createSimulation(pathMock, dmnFilePath);
 
         assertNotNull(retrieved);
-        verify(dmnTypeServiceMock, times(1)).initializeNameAndNamespace(any(), any(), anyString());
+        verify(dmnTypeServiceMock, times(1)).initializeNameAndNamespace(
+                any(Simulation.class),
+                eq(pathMock),
+                eq(dmnFilePath));
+    }
+
+    @Test
+    public void createSimulationCornerCases() throws Exception {
+        // no inputs no outputs
+        verifySimulationCreated(false, false);
+
+        // only inputs
+        verifySimulationCreated(true, false);
+
+        // only outputs
+        verifySimulationCreated(false, true);
+    }
+
+    @Test
+    public void addEmptyColumnIfNeeded() {
+        Simulation simulation = new Simulation();
+        ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(1, simulation.addScenario());
+        ExpressionIdentifier givenExpressionIdentifier = ExpressionIdentifier.create("given1", GIVEN);
+        SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
+        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, givenExpressionIdentifier);
+
+        dmnSimulationCreationStrategy.addEmptyColumnIfNeeded(simulation, scenarioWithIndex);
+        assertEquals(2, simulationDescriptor.getFactMappings().size());
+        assertTrue(simulationDescriptor.getFactMappings().stream()
+                           .anyMatch(elem -> EXPECT.equals(elem.getExpressionIdentifier().getType())));
+
+        simulation = new Simulation();
+        scenarioWithIndex = new ScenarioWithIndex(1, simulation.addScenario());
+        ExpressionIdentifier expectExpressionIdentifier = ExpressionIdentifier.create("expect1", EXPECT);
+        simulationDescriptor = simulation.getSimulationDescriptor();
+        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, expectExpressionIdentifier);
+
+        dmnSimulationCreationStrategy.addEmptyColumnIfNeeded(simulation, scenarioWithIndex);
+        assertEquals(2, simulationDescriptor.getFactMappings().size());
+        assertTrue(simulationDescriptor.getFactMappings().stream()
+                           .anyMatch(elem -> GIVEN.equals(elem.getExpressionIdentifier().getType())));
+    }
+
+    @Test
+    public void findNewIndexOfGroup() {
+        Simulation simulation = new Simulation();
+        SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
+        ExpressionIdentifier givenExpressionIdentifier = ExpressionIdentifier.create("given1", GIVEN);
+        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, givenExpressionIdentifier);
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, GIVEN));
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, EXPECT));
+
+        simulationDescriptor = new SimulationDescriptor();
+        ExpressionIdentifier expectExpressionIdentifier = ExpressionIdentifier.create("expect1", EXPECT);
+        simulationDescriptor.addFactMapping(FactIdentifier.EMPTY, expectExpressionIdentifier);
+        assertEquals(0, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, GIVEN));
+        assertEquals(1, dmnSimulationCreationStrategy.findNewIndexOfGroup(simulationDescriptor, EXPECT));
+    }
+
+    private void verifySimulationCreated(boolean hasInput, boolean hasOutput) throws Exception {
+        final Path pathMock = mock(Path.class);
+        final String dmnFilePath = "test";
+
+        FactModelTuple factModelTuple = getFactModelTuple(hasInput, hasOutput);
+        doReturn(factModelTuple).when(dmnSimulationCreationStrategy).getFactModelTuple(any(), any());
+        Simulation simulation = dmnSimulationCreationStrategy.createSimulation(pathMock, dmnFilePath);
+
+        assertNotNull(simulation);
+        List<FactMapping> factMappings = simulation.getSimulationDescriptor().getFactMappings();
+        if (hasInput) {
+            assertTrue(factMappings.stream().anyMatch(elem -> GIVEN.equals(elem.getExpressionIdentifier().getType())));
+        } else {
+            assertEquals(1, factMappings.stream().filter(elem -> GIVEN.equals(elem.getExpressionIdentifier().getType())).count());
+        }
+        if (hasOutput) {
+            assertTrue(factMappings.stream().anyMatch(elem -> EXPECT.equals(elem.getExpressionIdentifier().getType())));
+        } else {
+            assertEquals(1, factMappings.stream().filter(elem -> EXPECT.equals(elem.getExpressionIdentifier().getType())).count());
+        }
     }
 
     private FactModelTuple getFactModelTuple() throws IOException {
+        return getFactModelTuple(true, true);
+    }
+
+    private FactModelTuple getFactModelTuple(boolean hasInput, boolean hasOutput) throws IOException {
+
         SortedMap<String, FactModelTree> visibleFacts = new TreeMap<>();
         SortedMap<String, FactModelTree> hiddenFacts = new TreeMap<>();
 
-        for (InputDataNode input : dmnModelLocal.getInputs()) {
-            DMNType type = input.getType();
-            visibleFacts.put(input.getName(), createFactModelTree(input.getName(), input.getName(), type, hiddenFacts, FactModelTree.Type.INPUT));
+        if (hasInput) {
+            for (InputDataNode input : dmnModelLocal.getInputs()) {
+                DMNType type = input.getType();
+                visibleFacts.put(input.getName(), createFactModelTree(input.getName(), input.getName(), type, hiddenFacts, FactModelTree.Type.INPUT));
+            }
         }
 
-        for (DecisionNode decision : dmnModelLocal.getDecisions()) {
-            DMNType type = decision.getResultType();
-            visibleFacts.put(decision.getName(), createFactModelTree(decision.getName(), decision.getName(), type, hiddenFacts, FactModelTree.Type.DECISION));
+        if (hasOutput) {
+            for (DecisionNode decision : dmnModelLocal.getDecisions()) {
+                DMNType type = decision.getResultType();
+                visibleFacts.put(decision.getName(), createFactModelTree(decision.getName(), decision.getName(), type, hiddenFacts, DECISION));
+            }
         }
         return new FactModelTuple(visibleFacts, hiddenFacts);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/SimulationCreationStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/SimulationCreationStrategyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.backend.server.util;
+
+import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
+import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.scenariosimulation.api.model.SimulationDescriptor;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.drools.scenariosimulation.api.model.FactMappingType.GIVEN;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SimulationCreationStrategyTest {
+
+    @Test
+    public void createEmptyColumn() {
+        ArgumentCaptor<ExpressionIdentifier> expressionIdentifierCaptor1 = ArgumentCaptor.forClass(ExpressionIdentifier.class);
+        ArgumentCaptor<ExpressionIdentifier> expressionIdentifierCaptor2 = ArgumentCaptor.forClass(ExpressionIdentifier.class);
+        int placeholderId = 1;
+        int columnIndex = 0;
+        SimulationCreationStrategy simulationCreationStrategy = (context, value) -> null;
+        SimulationDescriptor simulationDescriptorSpy = spy(new SimulationDescriptor());
+        Scenario scenarioSpy = spy(new Scenario());
+        ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(1, scenarioSpy);
+
+        simulationCreationStrategy.createEmptyColumn(simulationDescriptorSpy, scenarioWithIndex, placeholderId, GIVEN, columnIndex);
+
+        verify(simulationDescriptorSpy, times(1)).addFactMapping(
+                eq(columnIndex),
+                eq(FactMapping.getInstancePlaceHolder(placeholderId)),
+                eq(FactIdentifier.EMPTY),
+                expressionIdentifierCaptor1.capture());
+
+        assertEquals(GIVEN, expressionIdentifierCaptor1.getValue().getType());
+
+        verify(scenarioSpy, times(1)).addMappingValue(
+                eq(FactIdentifier.EMPTY),
+                expressionIdentifierCaptor2.capture(),
+                isNull());
+
+        assertEquals(GIVEN, expressionIdentifierCaptor2.getValue().getType());
+    }
+}


### PR DESCRIPTION
This PR cover these situations:
- DMN model with no elements -> it creates an empty GIVEN column and an empty EXPECT column
- DMN model contains only input nodes -> it adds an empty EXPECT column
- DMN model contains only decision nodes -> it adds an empty GIVEN column

https://issues.jboss.org/browse/DROOLS-4108

@kkufova @yesamer @Rikkola 