### PR TITLE
[DROOLS-4571] It's possible to set an empty title header

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -47,7 +47,7 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
 
     @Override
     public void flush(final String value) {
-        if (Objects.isNull(value) || value.isEmpty()) {
+        if (Objects.isNull(value) || value.trim().isEmpty()) {
             ((ScenarioGrid) gridWidget).getEventBus().fireEvent(
                     new ScenarioNotificationEvent(
                             ScenarioSimulationEditorConstants.INSTANCE.headerTitleEmptyError(),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -19,12 +19,15 @@ package org.drools.workbench.screens.scenariosimulation.client.domelements;
 import java.util.Objects;
 
 import org.drools.workbench.screens.scenariosimulation.client.events.ReloadTestToolsEvent;
+import org.drools.workbench.screens.scenariosimulation.client.events.ScenarioNotificationEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.SetHeaderCellValueEvent;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.workbench.events.NotificationEvent;
 
 public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMElement {
 
@@ -44,6 +47,13 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
 
     @Override
     public void flush(final String value) {
+        if (Objects.isNull(value) || value.isEmpty()) {
+            ((ScenarioGrid) gridWidget).getEventBus().fireEvent(
+                    new ScenarioNotificationEvent(
+                            ScenarioSimulationEditorConstants.INSTANCE.headerTitleEmptyError(),
+                            NotificationEvent.NotificationType.ERROR));
+            return;
+        }
         if (scenarioHeaderMetaData != null) {
             scenarioHeaderMetaData.setEditingMode(false);
             if (Objects.equals(value, scenarioHeaderMetaData.getTitle())) {
@@ -53,6 +63,7 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
         internalFlush(value);
     }
 
+    @Override
     protected void internalFlush(final String value) {
         final int rowIndex = context.getRowIndex();
         final int columnIndex = context.getColumnIndex();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -990,12 +990,12 @@ public class ScenarioGridModel extends BaseGridData {
      * Verify the given value is not already used as instance header name <b>between different groups</b>
      * @param instanceHeaderCellValue
      * @param columnIndex
-     * @throws Exception if the given <b>instanceHeaderCellValue</b> contains a <i>dot</i> <b>OR</b> it has already been used
-     * inside the <b>group (GIVEN/EXPECT)</b> of the given column
+     * @throws IllegalArgumentException if the given <b>instanceHeaderCellValue</b> contains a <i>dot</i> <b>OR</b>
+     * it has already been used inside the <b>group (GIVEN/EXPECT)</b> of the given column
      */
-    protected void checkValidAndUniqueInstanceHeaderTitle(String instanceHeaderCellValue, int columnIndex) throws Exception {
+    protected void checkValidAndUniqueInstanceHeaderTitle(String instanceHeaderCellValue, int columnIndex) {
         if (instanceHeaderCellValue.contains(".")) {
-            throw new Exception("An instance alias cannot contain periods!");
+            throw new IllegalArgumentException(ScenarioSimulationEditorConstants.INSTANCE.instanceTitleWithPeriodsError());
         }
         Range instanceLimits = getInstanceLimits(columnIndex);
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
@@ -1007,7 +1007,8 @@ public class ScenarioGridModel extends BaseGridData {
                 .filter(elem -> elem.getInformationHeaderMetaData() != null)
                 .map(ScenarioGridColumn::getInformationHeaderMetaData)
                 .anyMatch(elem -> Objects.equals(elem.getTitle(), instanceHeaderCellValue))) {
-            throw new Exception(instanceHeaderCellValue + " has already been used inside the current group");
+            throw new IllegalArgumentException(ScenarioSimulationEditorConstants.INSTANCE.
+                    instanceTitleAssignedError(instanceHeaderCellValue));
         }
     }
 
@@ -1015,12 +1016,12 @@ public class ScenarioGridModel extends BaseGridData {
      * Verify if the given value is not already used as property header name <b>inside the same instance</b>
      * @param propertyHeaderCellValue
      * @param columnIndex
-     * @throws Exception if the given <b>propertyHeaderCellValue</b> contains a <i>dot</i> <b>OR</b> it has already been used
-     * inside the <b>instance</b> of the given column
+     * @throws IllegalArgumentException if the given <b>propertyHeaderCellValue</b> contains a <i>dot</i> <b>OR</b>
+     * it has already been used inside the <b>instance</b> of the given column
      */
-    protected void checkValidAndUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) throws Exception {
+    protected void checkValidAndUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) {
         if (propertyHeaderCellValue.contains(".")) {
-            throw new Exception("A property alias cannot contain periods!");
+            throw new IllegalArgumentException(ScenarioSimulationEditorConstants.INSTANCE.propertyTitleWithPeriodsError());
         }
         checkUniquePropertyHeaderTitle(propertyHeaderCellValue, columnIndex);
     }
@@ -1029,10 +1030,10 @@ public class ScenarioGridModel extends BaseGridData {
      * Verify if the given value is not already used as property header name <b>inside the same instance</b>
      * @param propertyHeaderCellValue
      * @param columnIndex
-     * @throws Exception if the given <b>propertyHeaderCellValue</b> has already been used
+     * @throws IllegalArgumentException if the given <b>propertyHeaderCellValue</b> has already been used
      * inside the <b>instance</b> of the given column
      */
-    protected void checkUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) throws Exception {
+    protected void checkUniquePropertyHeaderTitle(String propertyHeaderCellValue, int columnIndex) {
         SimulationDescriptor simulationDescriptor = simulation.getSimulationDescriptor();
         FactIdentifier factIdentifier = simulationDescriptor.getFactMappingByIndex(columnIndex).getFactIdentifier();
         if (IntStream.range(0, getColumnCount())
@@ -1042,7 +1043,8 @@ public class ScenarioGridModel extends BaseGridData {
                 .filter(elem -> elem.getPropertyHeaderMetaData() != null)
                 .map(ScenarioGridColumn::getPropertyHeaderMetaData)
                 .anyMatch(elem -> Objects.equals(elem.getTitle(), propertyHeaderCellValue))) {
-            throw new Exception(propertyHeaderCellValue + " has already been used inside the current instance");
+            throw new IllegalArgumentException(ScenarioSimulationEditorConstants.INSTANCE.
+                    propertyTitleAssignedError(propertyHeaderCellValue));
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.java
@@ -314,7 +314,15 @@ public interface ScenarioSimulationEditorConstants
 
     String noRulesAvailable();
 
+    String headerTitleEmptyError();
+
     String instanceTitleAssignedError(String title);
+
+    String instanceTitleWithPeriodsError();
+
+    String propertyTitleAssignedError(String title);
+
+    String propertyTitleWithPeriodsError();
 
     String validationErrorTitle();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -106,11 +106,6 @@ public class ScenarioGrid extends BaseGridWidget {
      */
     public void setSelectedColumnAndHeader(int headerRowIndex, int columnIndex) {
         ((ScenarioGridModel) model).selectColumn(columnIndex);
-
-
-
-
-
         model.selectHeaderCell(headerRowIndex, columnIndex);
         getLayer().batch();
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -106,6 +106,11 @@ public class ScenarioGrid extends BaseGridWidget {
      */
     public void setSelectedColumnAndHeader(int headerRowIndex, int columnIndex) {
         ((ScenarioGridModel) model).selectColumn(columnIndex);
+
+
+
+
+
         model.selectHeaderCell(headerRowIndex, columnIndex);
         getLayer().batch();
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/i18n/ScenarioSimulationEditorConstants.properties
@@ -166,7 +166,11 @@ reportCoverageRuleLabel=Percentage of rules fired:
 noDecisionsAvailable=A coverage report cannot be generated when no decisions are available.
 noRulesAvailable=A coverage report cannot be generated when no rules are available.
 
-instanceTitleAssignedError=An instance with title ''{0}'' is already assigned
+headerTitleEmptyError=Not possible to assign an empty title!
+instanceTitleAssignedError=An instance with title ''{0}'' has already been used inside the current group
+instanceTitleWithPeriodsError=An instance alias cannot contain periods!
+propertyTitleAssignedError=A property with title ''{0}'' has already been used inside the current instance
+propertyTitleWithPeriodsError=A property alias cannot contain periods!
 validationErrorMessage=The data structure behind these columns has changed and need to be fixed
 validationErrorTitle=Wrong column mapping
 validationFailedNotification=Impossible to validate. Please verify project build compilation errors

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -89,6 +89,13 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
     }
 
     @Test
+    public void flushEmptyStringMultipleSpaces() {
+        scenarioHeaderTextAreaDOMElement.flush("            ");
+        verify(eventBusMock, times(1)).fireEvent(isA(ScenarioNotificationEvent.class));
+        verify(scenarioHeaderTextAreaDOMElement, never()).internalFlush(any());
+    }
+
+    @Test
     public void flushNullMetadata() {
         scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(null);
         scenarioHeaderTextAreaDOMElement.flush(MULTIPART_VALUE);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.domelements;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.user.client.ui.AbsolutePanel;
+import org.drools.workbench.screens.scenariosimulation.client.events.ScenarioNotificationEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.SetHeaderCellValueEvent;
 import org.drools.workbench.screens.scenariosimulation.client.factories.AbstractFactoriesTest;
 import org.drools.workbench.screens.scenariosimulation.client.metadata.ScenarioHeaderMetaData;
@@ -29,6 +30,7 @@ import org.mockito.Mock;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
@@ -70,6 +72,20 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
         scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(scenarioHeaderMetaDataMock);
         scenarioHeaderTextAreaDOMElement.flush(MULTIPART_VALUE);
         verify(scenarioHeaderTextAreaDOMElement, times(1)).internalFlush(eq(MULTIPART_VALUE));
+    }
+
+    @Test
+    public void flushNullString() {
+        scenarioHeaderTextAreaDOMElement.flush(null);
+        verify(eventBusMock, times(1)).fireEvent(isA(ScenarioNotificationEvent.class));
+        verify(scenarioHeaderTextAreaDOMElement, never()).internalFlush(any());
+    }
+
+    @Test
+    public void flushEmptyString() {
+        scenarioHeaderTextAreaDOMElement.flush("");
+        verify(eventBusMock, times(1)).fireEvent(isA(ScenarioNotificationEvent.class));
+        verify(scenarioHeaderTextAreaDOMElement, never()).internalFlush(any());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -51,6 +51,7 @@ import static org.drools.workbench.screens.scenariosimulation.client.TestPropert
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_GROUP;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_ID;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_COLUMN_TITLE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_PROPERTY_TITLE;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.GRID_ROWS;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.HEADER_META_DATA;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
@@ -569,14 +570,14 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     private void commonValidatePropertyUpdate(int columnIndex, boolean isPropertyType, boolean isSamePropertyHeader, boolean isUnique, boolean expectedValid) throws Exception {
         if (isSamePropertyHeader) {
-            doThrow(new Exception("isSamePropertyHeader")).when(scenarioGridModel).checkSamePropertyHeader(columnIndex, MULTIPART_VALUE_ELEMENTS);
+            doThrow(new IllegalArgumentException("isSamePropertyHeader")).when(scenarioGridModel).checkSamePropertyHeader(columnIndex, MULTIPART_VALUE_ELEMENTS);
         } else {
             doNothing().when(scenarioGridModel).checkSamePropertyHeader(columnIndex, MULTIPART_VALUE_ELEMENTS);
         }
         if (isUnique) {
             doNothing().when(scenarioGridModel).checkValidAndUniquePropertyHeaderTitle(MULTIPART_VALUE, columnIndex);
         } else {
-            doThrow(new Exception("isUnique")).when(scenarioGridModel).checkValidAndUniquePropertyHeaderTitle(MULTIPART_VALUE, columnIndex);
+            doThrow(new IllegalArgumentException("isUnique")).when(scenarioGridModel).checkValidAndUniquePropertyHeaderTitle(MULTIPART_VALUE, columnIndex);
         }
         try {
             scenarioGridModel.validatePropertyHeaderUpdate(MULTIPART_VALUE, columnIndex, isPropertyType);
@@ -586,6 +587,11 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
             }
         }
         reset(eventBusMock);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkUniquePropertyHeaderTitle_AssignedLabel() {
+        scenarioGridModel.checkUniquePropertyHeaderTitle(GRID_PROPERTY_TITLE, COLUMN_INDEX);
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -549,14 +549,14 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
 
     private void commonValidateInstanceHeaderUpdate(int columnIndex, boolean isADataType, boolean isSameInstanceHeader, boolean isUnique, boolean expectedValid) throws Exception {
         if (isSameInstanceHeader) {
-            doThrow(new Exception("isSameInstanceHeader")).when(scenarioGridModel).checkSameInstanceHeader(columnIndex, MULTIPART_VALUE_ELEMENTS.get(MULTIPART_VALUE_ELEMENTS.size() - 1));
+            doThrow(new IllegalArgumentException("isSameInstanceHeader")).when(scenarioGridModel).checkSameInstanceHeader(columnIndex, MULTIPART_VALUE_ELEMENTS.get(MULTIPART_VALUE_ELEMENTS.size() - 1));
         } else {
             doNothing().when(scenarioGridModel).checkSameInstanceHeader(columnIndex, MULTIPART_VALUE_ELEMENTS.get(MULTIPART_VALUE_ELEMENTS.size() - 1));
         }
         if (isUnique) {
             doNothing().when(scenarioGridModel).checkValidAndUniqueInstanceHeaderTitle(MULTIPART_VALUE, columnIndex);
         } else {
-            doThrow(new Exception("isUnique")).when(scenarioGridModel).checkValidAndUniqueInstanceHeaderTitle(MULTIPART_VALUE, columnIndex);
+            doThrow(new IllegalArgumentException("isUnique")).when(scenarioGridModel).checkValidAndUniqueInstanceHeaderTitle(MULTIPART_VALUE, columnIndex);
         }
         try {
             scenarioGridModel.validateInstanceHeaderUpdate(MULTIPART_VALUE, columnIndex, isADataType);


### PR DESCRIPTION
@dupliaka  @gitgabrio @danielezonca Can you please test it and review?

Currently it is possible to set an empty label in header cell type (instance title or property title). This PR adds a check which prevent it. In that case, an error message is thrown.

https://issues.jboss.org/browse/DROOLS-4571