### PR TITLE
[DROOLS-4573] Cell selection doesn't span the entire cell

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationContext.java
@@ -144,7 +144,7 @@ public class ScenarioSimulationContext {
      */
     public void setStatusSimulationIfEmpty() {
         if (status.getSimulation() == null) {
-            status.setSimulation(model.getSimulation().get());
+            status.setSimulation(model.getSimulation().orElseThrow(IllegalStateException::new));
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
@@ -79,6 +79,7 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
         return false;
     }
 
+    // Indirection for tests
     protected Point2D getMiddleXYCell(GridWidget gridWidget, GridColumn column, boolean isHeader, int uiRowIndex, GridLayer gridLayer) {
         return ScenarioSimulationUtils.getMiddleXYCell(gridWidget, column, isHeader, uiRowIndex, gridLayer);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
 import com.ait.lienzo.client.core.types.Point2D;
 import org.drools.workbench.screens.scenariosimulation.client.menu.ScenarioContextMenuRegistry;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -26,8 +27,6 @@ import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.KeyboardOperationInvokeContextMenuForSelectedCell;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
-
-import static org.drools.workbench.screens.scenariosimulation.client.utils.ScenarioSimulationUtils.getMiddleXYCell;
 
 public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationInvokeContextMenuForSelectedCell {
 
@@ -49,12 +48,16 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
     @Override
     public boolean perform(final GridWidget gridWidget, final boolean isShiftKeyDown, final boolean isControlKeyDown) {
         final GridData model = gridWidget.getModel();
+        if (!model.getSelectedHeaderCells().isEmpty()
+                && !model.getSelectedCells().isEmpty()) {
+            return false;
+        }
         GridData.SelectedCell origin = null;
         boolean isHeader = false;
         if (!model.getSelectedHeaderCells().isEmpty()) {
             origin = model.getSelectedHeaderCells().get(0);
             isHeader = true;
-        } else if (!model.getSelectedCells().isEmpty()) {
+        } else if (model.getSelectedCells().size() == 1) {
             origin = model.getSelectedCellsOrigin();
         }
         if (origin == null) {
@@ -65,7 +68,7 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
                                                                          origin.getColumnIndex());
         final GridColumn<?> column = model.getColumns().get(uiColumnIndex);
         if (column instanceof ScenarioGridColumn) {
-            final Point2D middleXYCell = getMiddleXYCell(gridWidget, column, isHeader, uiRowIndex, gridLayer);
+            final Point2D middleXYCell = this.getMiddleXYCell(gridWidget, column, isHeader, uiRowIndex, gridLayer);
             return scenarioContextMenuRegistry.manageRightClick((ScenarioGrid) gridWidget,
                                                                 (int) middleXYCell.getX(),
                                                                 (int) middleXYCell.getY(),
@@ -74,5 +77,9 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
                                                                 isHeader);
         }
         return false;
+    }
+
+    protected Point2D getMiddleXYCell(GridWidget gridWidget, GridColumn column, boolean isHeader, int uiRowIndex, GridLayer gridLayer) {
+        return ScenarioSimulationUtils.getMiddleXYCell(gridWidget, column, isHeader, uiRowIndex, gridLayer);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCell.java
@@ -42,13 +42,8 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
     @Override
     public boolean isExecutable(final GridWidget gridWidget) {
         final GridData model = gridWidget.getModel();
-        if (model.getSelectedHeaderCells().size() == 1 && model.getSelectedCells().size() == 0) {
-            return true;
-        }
-        if (model.getSelectedHeaderCells().size() == 0 && model.getSelectedCells().size() == 1) {
-            return true;
-        }
-        return false;
+        return ((!model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().isEmpty()) ||
+                (model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().size() == 1));
     }
 
     @Override
@@ -56,12 +51,14 @@ public class ScenarioInvokeContextMenuForSelectedCell extends KeyboardOperationI
         final GridData model = gridWidget.getModel();
         GridData.SelectedCell origin = null;
         boolean isHeader = false;
-        if (model.getSelectedHeaderCells().size() == 1) {
+        if (!model.getSelectedHeaderCells().isEmpty()) {
             origin = model.getSelectedHeaderCells().get(0);
             isHeader = true;
-        } else if (model.getSelectedCells().size() == 1) {
+        } else if (!model.getSelectedCells().isEmpty()) {
             origin = model.getSelectedCellsOrigin();
-            isHeader = false;
+        }
+        if (origin == null) {
+            return false;
         }
         final int uiRowIndex = origin.getRowIndex();
         final int uiColumnIndex = ColumnIndexUtilities.findUiColumnIndex(model.getColumns(),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandler.java
@@ -37,8 +37,8 @@ import static org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities.
 import static org.uberfire.ext.wires.core.grids.client.util.CoordinateUtilities.getRelativeYOfEvent;
 
 @Dependent
-public class ScenarioSimulationGridPanelClickHandler extends AbstractScenarioSimulationGridPanelHandler implements ClickHandler,
-                                                                ContextMenuHandler {
+public class ScenarioSimulationGridPanelClickHandler extends AbstractScenarioSimulationGridPanelHandler
+        implements ClickHandler, ContextMenuHandler {
 
     protected ScenarioContextMenuRegistry scenarioContextMenuRegistry;
     protected EventBus eventBus;
@@ -66,7 +66,6 @@ public class ScenarioSimulationGridPanelClickHandler extends AbstractScenarioSim
         final int canvasY = getRelativeYOfEvent(event);
         scenarioContextMenuRegistry.hideMenus();
         scenarioContextMenuRegistry.hideErrorReportPopover();
-        scenarioGrid.clearSelections();
         if (!manageCoordinates(canvasX, canvasY)) { // It was not a grid click
             eventBus.fireEvent(new DisableTestToolsEvent());
         }
@@ -100,8 +99,7 @@ public class ScenarioSimulationGridPanelClickHandler extends AbstractScenarioSim
                                                          ScenarioGridColumn scenarioGridColumn,
                                                          String group,
                                                          Integer uiColumnIndex) {
-        scenarioGrid.setSelectedColumnAndHeader(scenarioGridColumn.getHeaderMetaData().indexOf(clickedScenarioHeaderMetadata), uiColumnIndex);
-
+        scenarioGrid.setSelectedColumn(uiColumnIndex);
         if (scenarioGridColumn.isInstanceAssigned() && clickedScenarioHeaderMetadata.getMetadataType().equals(ScenarioHeaderMetaData.MetadataType.INSTANCE)) {
             eventBus.fireEvent(new ReloadTestToolsEvent(true, true));
             return true;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandler.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.ait.lienzo.client.core.event.AbstractNodeMouseEvent;
 import com.ait.lienzo.client.core.types.Point2D;
@@ -48,8 +49,13 @@ public class ScenarioSimulationGridWidgetMouseEventHandler extends DefaultGridWi
         }
         final ScenarioHeaderMetaData headerMetaData = (ScenarioHeaderMetaData) column.getHeaderMetaData().get(uiHeaderRowIndex);
         final GridData gridData = gridWidget.getModel();
-        if (gridData.getSelectedHeaderCells().size() == 1 && editSupportedLocal(headerMetaData.getSupportedEditAction(), event)) {
-            return startEditLocal((ScenarioGrid) gridWidget, uiHeaderColumnIndex, (ScenarioGridColumn) column, uiHeaderRowIndex, true);
+        if (!gridData.getSelectedHeaderCells().isEmpty() && editSupportedLocal(headerMetaData.getSupportedEditAction(), event)) {
+            final GridData.SelectedCell firstSelectedHeaderCell = gridData.getSelectedHeaderCells().get(0);
+            final Optional<GridColumn<?>> firstSelectedColumnOptional = gridData.getColumns().stream()
+                    .filter(col -> col.getIndex() == firstSelectedHeaderCell.getColumnIndex())
+                    .findFirst();
+            final int firstSelectedColumnPosition = gridData.getColumns().indexOf(firstSelectedColumnOptional.orElseThrow(IllegalStateException::new));
+            return startEditLocal((ScenarioGrid) gridWidget, firstSelectedColumnPosition, (ScenarioGridColumn) column, uiHeaderRowIndex, true);
         }
         return true;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
@@ -33,10 +33,8 @@ public class ScenarioSimulationKeyboardEditHandler extends KeyboardOperationEdit
     @Override
     public boolean isExecutable(final GridWidget gridWidget) {
         final GridData model = gridWidget.getModel();
-        if (model.getSelectedHeaderCells().size() == 1 && model.getSelectedCells().size() == 0) {
-            return true;
-        }
-        if (model.getSelectedHeaderCells().size() == 0 && model.getSelectedCells().size() == 1) {
+        if ((!model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().isEmpty()) ||
+                (model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().size() == 1)) {
             return true;
         }
         return false;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
@@ -33,11 +33,8 @@ public class ScenarioSimulationKeyboardEditHandler extends KeyboardOperationEdit
     @Override
     public boolean isExecutable(final GridWidget gridWidget) {
         final GridData model = gridWidget.getModel();
-        if ((!model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().isEmpty()) ||
-                (model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().size() == 1)) {
-            return true;
-        }
-        return false;
+        return ((!model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().isEmpty()) ||
+                (model.getSelectedHeaderCells().isEmpty() && model.getSelectedCells().size() == 1));
     }
 
     @Override
@@ -49,9 +46,9 @@ public class ScenarioSimulationKeyboardEditHandler extends KeyboardOperationEdit
         // Allows editing only if a single cell is selected
         GridData.SelectedCell selectedCell = null;
         boolean isHeader = true;
-        if (scenarioGridModel.getSelectedHeaderCells().size() > 0) {
+        if (!scenarioGridModel.getSelectedHeaderCells().isEmpty()) {
             selectedCell = scenarioGridModel.getSelectedHeaderCells().get(0);
-        } else if (scenarioGridModel.getSelectedCells().size() > 0) {
+        } else if (!scenarioGridModel.getSelectedCells().isEmpty()) {
             selectedCell = scenarioGridModel.getSelectedCellsOrigin();
             isHeader = false;
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandler.java
@@ -44,11 +44,15 @@ public class ScenarioSimulationKeyboardEditHandler extends KeyboardOperationEdit
         ScenarioGrid scenarioGrid = (ScenarioGrid) gridWidget;
         final ScenarioGridModel scenarioGridModel = scenarioGrid.getModel();
         // Allows editing only if a single cell is selected
+        if (!scenarioGridModel.getSelectedHeaderCells().isEmpty()
+                && !scenarioGridModel.getSelectedCells().isEmpty()) {
+            return false;
+        }
         GridData.SelectedCell selectedCell = null;
         boolean isHeader = true;
         if (!scenarioGridModel.getSelectedHeaderCells().isEmpty()) {
             selectedCell = scenarioGridModel.getSelectedHeaderCells().get(0);
-        } else if (!scenarioGridModel.getSelectedCells().isEmpty()) {
+        } else if (scenarioGridModel.getSelectedCells().size() == 1) {
             selectedCell = scenarioGridModel.getSelectedCellsOrigin();
             isHeader = false;
         }
@@ -62,6 +66,11 @@ public class ScenarioSimulationKeyboardEditHandler extends KeyboardOperationEdit
         if (scenarioGridColumn == null) {
             return false;
         }
-        return CommonEditHandler.startEdit(scenarioGrid, uiColumnIndex, scenarioGridColumn, uiRowIndex, isHeader);
+        return startEdit(scenarioGrid, uiColumnIndex, uiRowIndex, scenarioGridColumn, isHeader);
+    }
+
+    // Indirection for tests
+    protected boolean startEdit(ScenarioGrid scenarioGrid, int uiColumnIndex, int uiRowIndex, ScenarioGridColumn column, boolean isHeader) {
+        return CommonEditHandler.startEdit(scenarioGrid, uiColumnIndex, column, uiRowIndex, isHeader);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -581,17 +581,12 @@ public class ScenarioGridModel extends BaseGridData {
     }
 
     /**
-     * Select all the cells of the given column
+     * It put the column present in the given columnIndex as the current selected one.
      * @param columnIndex
      */
     public void selectColumn(int columnIndex) {
-        if (columnIndex > getColumnCount() - 1) {
-            return;
-        }
-        if (!selectedHeaderCells.isEmpty()) {
-            final SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
-            selectedHeaderCells.clear();
-            selectHeaderCell(selectedHeaderCell.getRowIndex(), columnIndex);
+        if (columnIndex > getColumnCount() - 1 || columnIndex < 0) {
+            throw new IllegalArgumentException("Wrong column index: " + columnIndex);
         }
         selectedColumn = getColumns().get(columnIndex);
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -581,7 +581,7 @@ public class ScenarioGridModel extends BaseGridData {
     }
 
     /**
-     * It put the column present in the given columnIndex as the current selected one.
+     * It puts the column present in the given columnIndex as the current selected one.
      * @param columnIndex
      */
     public void selectColumn(int columnIndex) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGrid.java
@@ -101,12 +101,21 @@ public class ScenarioGrid extends BaseGridWidget {
     }
 
     /**
+     * Set the current <b>selectedColumn</b> given its columnIndex
+     * @param columnIndex
+     */
+    public void setSelectedColumn(int columnIndex) {
+        ((ScenarioGridModel) model).selectColumn(columnIndex);
+    }
+
+    /**
      * Set the <b>selectedColumn</b> status of the model and select the header cell actually clicked
+     * This should be used when header cells selection is NOT handled natively by the extended widget
      * @param columnIndex
      */
     public void setSelectedColumnAndHeader(int headerRowIndex, int columnIndex) {
-        ((ScenarioGridModel) model).selectColumn(columnIndex);
-        model.selectHeaderCell(headerRowIndex, columnIndex);
+        selectHeaderCell(headerRowIndex, columnIndex, false, false);
+        setSelectedColumn(columnIndex);
         getLayer().batch();
     }
 
@@ -271,14 +280,14 @@ public class ScenarioGrid extends BaseGridWidget {
     protected void signalTestTools() {
         eventBus.fireEvent(new DisableTestToolsEvent());
 
-        if (model.getSelectedHeaderCells().size() > 0) {
+        if (!model.getSelectedHeaderCells().isEmpty()) {
             final GridData.SelectedCell cell = model.getSelectedHeaderCells().get(0);
 
             final int uiColumnIndex = ColumnIndexUtilities.findUiColumnIndex(model.getColumns(),
                                                                              cell.getColumnIndex());
             final int uiRowIndex = cell.getRowIndex();
 
-            setSelectedColumnAndHeader(uiRowIndex, uiColumnIndex);
+            setSelectedColumn(uiColumnIndex);
 
             final GridColumn column = model.getColumns().get(uiColumnIndex);
             if (uiRowIndex > 0 && column instanceof ScenarioGridColumn) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCellTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCellTest.java
@@ -15,10 +15,10 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import com.ait.lienzo.client.core.types.Point2D;
-import com.google.gwt.dev.util.collect.Lists;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.menu.ScenarioContextMenuRegistry;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
@@ -33,8 +33,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -84,7 +84,7 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
             }
         });
         when(scenarioGridMock.getModel()).thenReturn(scenarioGridModelMock);
-        when(scenarioGridModelMock.getColumns()).thenReturn(Lists.create(gridColumnMock, gridColumnMock2));
+        when(scenarioGridModelMock.getColumns()).thenReturn(Arrays.asList(gridColumnMock, gridColumnMock2));
     }
 
     @Test
@@ -96,14 +96,14 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
 
     @Test
     public void isExecutable_CellSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_CellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         assertFalse(handler.isExecutable(scenarioGridMock));
     }
@@ -111,21 +111,21 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
     @Test
     public void isExecutable_HeaderCellSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell));
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_HeaderCellsSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_CellsAndHeaderCellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell2));
         assertFalse(handler.isExecutable(scenarioGridMock));
     }
 
@@ -139,7 +139,7 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
 
     @Test
     public void perform_CellSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
         handler.perform(scenarioGridMock, false, false);
@@ -148,7 +148,7 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
 
     @Test
     public void perform_CellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
         assertFalse(handler.perform(scenarioGridMock, false, false));
@@ -158,7 +158,7 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
     @Test
     public void perform_HeaderCellSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell));
         handler.perform(scenarioGridMock, false, false);
         verify(scenarioContextMenuRegistry, times(1)).manageRightClick(eq(scenarioGridMock), eq(0), eq(0), anyInt(), anyInt(), eq(true));
     }
@@ -166,15 +166,15 @@ public class ScenarioInvokeContextMenuForSelectedCellTest {
     @Test
     public void perform_HeaderCellsSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         handler.perform(scenarioGridMock, false, false);
         verify(scenarioContextMenuRegistry, times(1)).manageRightClick(eq(scenarioGridMock), eq(0), eq(0), anyInt(), anyInt(), eq(true));
     }
 
     @Test
     public void perform_CellAndHeaderCellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell2));
         assertFalse(handler.perform(scenarioGridMock, false, false));
         verify(scenarioContextMenuRegistry, never()).manageRightClick(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCellTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioInvokeContextMenuForSelectedCellTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.handlers;
+
+import java.util.Collections;
+
+import com.ait.lienzo.client.core.types.Point2D;
+import com.google.gwt.dev.util.collect.Lists;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.menu.ScenarioContextMenuRegistry;
+import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ScenarioInvokeContextMenuForSelectedCellTest {
+
+    @Mock
+    private GridLayer gridLayerMock;
+
+    @Mock
+    private ScenarioGrid scenarioGridMock;
+
+    @Mock
+    private ScenarioGridModel scenarioGridModelMock;
+
+    @Mock
+    private ScenarioGridColumn gridColumnMock;
+
+    @Mock
+    private ScenarioGridColumn gridColumnMock2;
+
+    @Mock
+    private ScenarioContextMenuRegistry scenarioContextMenuRegistry;
+
+    @Mock
+    private Point2D pointMock;
+
+    private ScenarioInvokeContextMenuForSelectedCell handler;
+    private GridData.SelectedCell selectedCell;
+    private GridData.SelectedCell selectedCell2;
+
+    @Before
+    public void setup() {
+        selectedCell = new GridData.SelectedCell(0, 0);
+        selectedCell2 = new GridData.SelectedCell(1, 1);
+        handler = spy(new ScenarioInvokeContextMenuForSelectedCell(gridLayerMock, scenarioContextMenuRegistry) {
+            @Override
+            protected Point2D getMiddleXYCell(GridWidget gridWidget, GridColumn column, boolean isHeader, int uiRowIndex, GridLayer gridLayer) {
+                return pointMock;
+            }
+        });
+        when(scenarioGridMock.getModel()).thenReturn(scenarioGridModelMock);
+        when(scenarioGridModelMock.getColumns()).thenReturn(Lists.create(gridColumnMock, gridColumnMock2));
+    }
+
+    @Test
+    public void isExecutable_NoSelection() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_HeaderCellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_HeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellsAndHeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void perform_NoSelection() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(scenarioContextMenuRegistry, never()).manageRightClick(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    public void perform_CellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
+        handler.perform(scenarioGridMock, false, false);
+        verify(scenarioContextMenuRegistry, times(1)).manageRightClick(eq(scenarioGridMock), eq(0), eq(0), anyInt(), anyInt(), eq(false));
+    }
+
+    @Test
+    public void perform_CellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(scenarioContextMenuRegistry, never()).manageRightClick(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    public void perform_HeaderCellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell));
+        handler.perform(scenarioGridMock, false, false);
+        verify(scenarioContextMenuRegistry, times(1)).manageRightClick(eq(scenarioGridMock), eq(0), eq(0), anyInt(), anyInt(), eq(true));
+    }
+
+    @Test
+    public void perform_HeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        handler.perform(scenarioGridMock, false, false);
+        verify(scenarioContextMenuRegistry, times(1)).manageRightClick(eq(scenarioGridMock), eq(0), eq(0), anyInt(), anyInt(), eq(true));
+    }
+
+    @Test
+    public void perform_CellAndHeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(scenarioContextMenuRegistry, never()).manageRightClick(any(), anyInt(), anyInt(), anyInt(), anyInt(), anyBoolean());
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridPanelClickHandlerTest.java
@@ -38,6 +38,7 @@ import static org.drools.workbench.screens.scenariosimulation.client.TestPropert
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.UI_ROW_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
@@ -83,6 +84,7 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
     @Test
     public void setEventBus() {
         scenarioSimulationGridPanelClickHandler.setEventBus(eventBusMock);
+        assertSame(scenarioSimulationGridPanelClickHandler.eventBus, eventBusMock);
     }
 
     @Test
@@ -115,7 +117,7 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
         assertTrue("Click to readonly header cell.",
                    scenarioSimulationGridPanelClickHandler.manageCoordinates((int) CLICK_POINT_X,
                                                                            (int) CLICK_POINT_Y));
-        verify(scenarioGridMock, times(1)).setSelectedColumnAndHeader(anyInt(), anyInt());
+        verify(scenarioGridMock, times(1)).setSelectedColumn(anyInt());
         verify(eventBusMock, times(1)).fireEvent(any(EnableTestToolsEvent.class));
     }
 
@@ -205,11 +207,11 @@ public class ScenarioSimulationGridPanelClickHandlerTest extends AbstractScenari
         String message = group + "Group fail";
         if (assertExpected) {
             assertTrue(message, scenarioSimulationGridPanelClickHandler.manageCoordinates((int) CLICK_POINT_X, (int) CLICK_POINT_Y));
-            verify(scenarioGridMock, times(1)).setSelectedColumnAndHeader(eq(0), eq(0));
+            verify(scenarioGridMock, times(1)).setSelectedColumn(eq(0));
             verify(eventBusMock, times(1)).fireEvent(isA(GwtEvent.class));
         } else {
             assertFalse(message, scenarioSimulationGridPanelClickHandler.manageCoordinates((int) CLICK_POINT_X, (int) CLICK_POINT_Y));
-            verify(scenarioGridMock, never()).setSelectedColumnAndHeader(eq(0), eq(0));
+            verify(scenarioGridMock, never()).setSelectedColumn(anyInt());
             verify(eventBusMock, never()).fireEvent(any());
             return;
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationGridWidgetMouseEventHandlerTest.java
@@ -118,6 +118,11 @@ public class ScenarioSimulationGridWidgetMouseEventHandlerTest extends AbstractS
     }
 
     @Test
+    public void handleHeaderCell_NonSelectedCells() {
+        commonHandleHeaderCell(false, false, 0, false, true);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void handleHeaderCell_EditableColumn_NotStartEdit() {
         commonHandleHeaderCell(true, false, 1, true, false);
@@ -131,8 +136,8 @@ public class ScenarioSimulationGridWidgetMouseEventHandlerTest extends AbstractS
 
     @Test
     @SuppressWarnings("unchecked")
-    public void handleHeaderCell_EditableColumn_WrongSelectedSize() {
-        commonHandleHeaderCell(true, true, 3, false, true);
+    public void handleHeaderCell_EditableColumn_MultiSelectedSize() {
+        commonHandleHeaderCell(true, true, 3, true, true);
     }
 
     @Test
@@ -206,11 +211,11 @@ public class ScenarioSimulationGridWidgetMouseEventHandlerTest extends AbstractS
                                                  uiHeaderColumnIndex,
                                                  clickEvent));
         }
+        int columnPosition = columnsMock.indexOf(gridColumnMock);
         if (startEditLocalCalled) {
-            verify(handler, times(1)).startEditLocal(eq(scenarioGridMock), eq(uiHeaderColumnIndex), eq(gridColumnMock), eq(uiHeaderRowIndex), eq(false));
+            verify(handler, times(1)).startEditLocal(eq(scenarioGridMock), eq(columnPosition), eq(gridColumnMock), eq(uiHeaderRowIndex), eq(false));
         } else {
-            verify(handler, never()).startEditLocal(eq(scenarioGridMock), eq(uiHeaderColumnIndex), eq(gridColumnMock), eq(uiHeaderRowIndex), eq(false));
+            verify(handler, never()).startEditLocal(eq(scenarioGridMock), eq(columnPosition), eq(gridColumnMock), eq(uiHeaderRowIndex), eq(false));
         }
     }
-
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandlerTest.java
@@ -15,9 +15,9 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
+import java.util.Arrays;
 import java.util.Collections;
 
-import com.google.gwt.dev.util.collect.Lists;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
@@ -29,8 +29,8 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -74,7 +74,7 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
             }
         });
         when(scenarioGridMock.getModel()).thenReturn(scenarioGridModelMock);
-        when(scenarioGridModelMock.getColumns()).thenReturn(Lists.create(gridColumnMock, gridColumnMock2));
+        when(scenarioGridModelMock.getColumns()).thenReturn(Arrays.asList(gridColumnMock, gridColumnMock2));
     }
 
     @Test
@@ -86,14 +86,14 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
 
     @Test
     public void isExecutable_CellSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_CellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         assertFalse(handler.isExecutable(scenarioGridMock));
     }
@@ -101,21 +101,21 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
     @Test
     public void isExecutable_HeaderCellSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_HeaderCellsSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell));
         assertTrue(handler.isExecutable(scenarioGridMock));
     }
 
     @Test
     public void isExecutable_CellsAndHeaderCellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell2));
         assertFalse(handler.isExecutable(scenarioGridMock));
     }
 
@@ -129,7 +129,7 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
 
     @Test
     public void perform_CellSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
         handler.perform(scenarioGridMock, false, false);
@@ -138,7 +138,7 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
 
     @Test
     public void perform_CellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
         when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
         assertFalse(handler.perform(scenarioGridMock, false, false));
@@ -148,7 +148,7 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
     @Test
     public void perform_HeaderCellSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell));
         handler.perform(scenarioGridMock, false, false);
         verify(handler, times(1)).startEdit(eq(scenarioGridMock), eq(0), eq(0), eq(gridColumnMock), eq(true));
     }
@@ -156,15 +156,15 @@ public class ScenarioSimulationKeyboardEditHandlerTest {
     @Test
     public void perform_HeaderCellsSelected() {
         when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell, selectedCell2));
         handler.perform(scenarioGridMock, false, false);
         verify(handler, times(1)).startEdit(eq(scenarioGridMock), eq(0), eq(0), eq(gridColumnMock), eq(true));
     }
 
     @Test
     public void perform_CellAndHeaderCellsSelected() {
-        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
-        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Arrays.asList(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Arrays.asList(selectedCell2));
         assertFalse(handler.perform(scenarioGridMock, false, false));
         verify(handler, never()).startEdit(any(), anyInt(), anyInt(), any(), anyBoolean());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/ScenarioSimulationKeyboardEditHandlerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.handlers;
+
+import java.util.Collections;
+
+import com.google.gwt.dev.util.collect.Lists;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.client.models.ScenarioGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGrid;
+import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ScenarioSimulationKeyboardEditHandlerTest {
+
+    @Mock
+    private GridLayer gridLayerMock;
+
+    @Mock
+    private ScenarioGrid scenarioGridMock;
+
+    @Mock
+    private ScenarioGridModel scenarioGridModelMock;
+
+    @Mock
+    private ScenarioGridColumn gridColumnMock;
+
+    @Mock
+    private ScenarioGridColumn gridColumnMock2;
+
+    private ScenarioSimulationKeyboardEditHandler handler;
+    private GridData.SelectedCell selectedCell;
+    private GridData.SelectedCell selectedCell2;
+
+    @Before
+    public void setup() {
+        selectedCell = new GridData.SelectedCell(0, 0);
+        selectedCell2 = new GridData.SelectedCell(1, 1);
+        handler = spy(new ScenarioSimulationKeyboardEditHandler(gridLayerMock) {
+            @Override
+            protected boolean startEdit(ScenarioGrid scenarioGrid, int uiColumnIndex, int uiRowIndex, ScenarioGridColumn column, boolean isHeader) {
+                return true;
+            }
+        });
+        when(scenarioGridMock.getModel()).thenReturn(scenarioGridModelMock);
+        when(scenarioGridModelMock.getColumns()).thenReturn(Lists.create(gridColumnMock, gridColumnMock2));
+    }
+
+    @Test
+    public void isExecutable_NoSelection() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_HeaderCellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_HeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        assertTrue(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void isExecutable_CellsAndHeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        assertFalse(handler.isExecutable(scenarioGridMock));
+    }
+
+    @Test
+    public void perform_NoSelection() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(handler, never()).startEdit(any(), anyInt(), anyInt(), any(), anyBoolean());
+    }
+
+    @Test
+    public void perform_CellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
+        handler.perform(scenarioGridMock, false, false);
+        verify(handler, times(1)).startEdit(eq(scenarioGridMock), eq(0), eq(0), eq(gridColumnMock), eq(false));
+    }
+
+    @Test
+    public void perform_CellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(selectedCell);
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(handler, never()).startEdit(any(), anyInt(), anyInt(), any(), anyBoolean());
+    }
+
+    @Test
+    public void perform_HeaderCellSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell));
+        handler.perform(scenarioGridMock, false, false);
+        verify(handler, times(1)).startEdit(eq(scenarioGridMock), eq(0), eq(0), eq(gridColumnMock), eq(true));
+    }
+
+    @Test
+    public void perform_HeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Collections.emptyList());
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell, selectedCell2));
+        handler.perform(scenarioGridMock, false, false);
+        verify(handler, times(1)).startEdit(eq(scenarioGridMock), eq(0), eq(0), eq(gridColumnMock), eq(true));
+    }
+
+    @Test
+    public void perform_CellAndHeaderCellsSelected() {
+        when(scenarioGridModelMock.getSelectedCells()).thenReturn(Lists.create(selectedCell));
+        when(scenarioGridModelMock.getSelectedHeaderCells()).thenReturn(Lists.create(selectedCell2));
+        assertFalse(handler.perform(scenarioGridMock, false, false));
+        verify(handler, never()).startEdit(any(), anyInt(), anyInt(), any(), anyBoolean());
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModelTest.java
@@ -301,6 +301,24 @@ public class ScenarioGridModelTest extends AbstractScenarioSimulationTest {
     }
 
     @Test
+    public void setSelectedColumn() {
+        scenarioGridModel.selectColumn(COLUMN_INDEX);
+        assertEquals(gridColumnMock, scenarioGridModel.getSelectedColumn());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSelectedColumn_NegativeIndex() {
+        int columnIndex = -1;
+        scenarioGridModel.selectColumn(columnIndex);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setSelectedColumn_OverflowIndex() {
+        int columnIndex = 7;
+        scenarioGridModel.selectColumn(columnIndex);
+    }
+
+    @Test
     public void getInstancesCount() {
         long count = scenarioGridModel.getInstancesCount(FULL_CLASS_NAME);
         assertEquals(1, count);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/widgets/ScenarioGridTest.java
@@ -228,13 +228,21 @@ public class ScenarioGridTest {
     }
 
     @Test
+    public void setSelectedColumn() {
+        int columnIndex = 1;
+        scenarioGrid.setSelectedColumn(columnIndex);
+        verify(scenarioGridModelMock, times(1)).selectColumn(eq(columnIndex));
+    }
+
+    @Test
     public void setSelectedColumnAndHeader() {
         int headerRowIndex = 1;
         int columnIndex = 1;
         scenarioGrid.setSelectedColumnAndHeader(headerRowIndex, columnIndex);
-        verify(scenarioGridModelMock, times(1)).selectColumn(eq(columnIndex));
-        verify(scenarioGridModelMock, times(1)).selectHeaderCell(eq(headerRowIndex), eq(columnIndex));
-        verify(scenarioGridLayerMock, times(1)).batch();
+        InOrder callsOrder = inOrder(scenarioGrid, scenarioGridLayerMock);
+        callsOrder.verify(scenarioGrid, times(1)).selectHeaderCell(eq(headerRowIndex), eq(columnIndex), eq(false), eq(false));
+        callsOrder.verify(scenarioGrid, times(1)).setSelectedColumn(eq(columnIndex));
+        callsOrder.verify(scenarioGridLayerMock, times(1)).batch();
     }
 
     @Test
@@ -369,7 +377,7 @@ public class ScenarioGridTest {
         scenarioGrid.adjustSelection(mock(SelectionExtension.class), false);
 
         verify(scenarioGrid).signalTestTools();
-        verify(scenarioGrid).setSelectedColumnAndHeader(uiRowIndex, uiColumnIndex);
+        verify(scenarioGrid).setSelectedColumn(eq(uiColumnIndex));
         verify(eventBusMock).fireEvent(any(EnableTestToolsEvent.class));
 
         // context menus could be shown


### PR DESCRIPTION
@dupliaka @gitgabrio @danielezonca can you please test and review it?

The original GridPanel fully supports cells selection span. I simply restored the native handling removing the wrong overridden logic in ScenarioSimulation code.

![Screenshot from 2019-09-30 10-26-36](https://user-images.githubusercontent.com/16005046/65861655-f3564080-e36c-11e9-9417-6aa6ccf0273d.png)

Bow works for:
- Left click,
- Right click
- Keyboard navigation
- Double click + editing mode

https://issues.jboss.org/browse/DROOLS-4573