### PR TITLE
DROOLS-4563: managing javax.validation-api for GWT code to 1.0.0.GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
        possible to measure cross-module test coverage -->
     <!--suppress UnresolvedMavenProperty -->
     <code.coverage.disabled>false</code.coverage.disabled>
+    <!-- The version greater than 1.0.0.GA is not compatible with GWT 2.8.x -->
+    <version.javax.validation>1.0.0.GA</version.javax.validation>
   </properties>
 
   <repositories>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4563

Parent PR:
- kiegroup/droolsjbpm-build-bootstrap#1075

Dependent PRs:

- kiegroup/appformer#814
- kiegroup/kie-wb-common#2934
- kiegroup/drools-wb#1238
- kiegroup/optaplanner-wb/pull/348