### PR TITLE
Drools 4638 - Disable Save button on settings for user without write permission

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -125,11 +125,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
                    place,
                    type);
         scenarioSimulationEditorPresenter.init(this, (ObservablePath) place.getPath());
-        workbenchContext.getActiveWorkspaceProject()
-                .ifPresent(activeProject -> projectController.canUpdateProject(activeProject).then(canUpdateProject -> {
-            scenarioSimulationEditorPresenter.setSaveEnabled(canUpdateProject);
-            return promises.resolve();
-        }));
+        setSaveEnabled();
     }
 
     @OnClose
@@ -172,7 +168,6 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     @Override
     public void showDocks() {
         super.showDocks();
-
         final DefaultPlaceRequest placeRequest = new DefaultPlaceRequest(TestToolsPresenter.IDENTIFIER);
         scenarioSimulationEditorPresenter.showDocks(placeManager.getStatus(placeRequest));
         registerTestToolsCallback();
@@ -247,6 +242,18 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
 
     protected void unRegisterTestToolsCallback() {
         placeManager.getOnOpenCallbacks(new DefaultPlaceRequest(TestToolsPresenter.IDENTIFIER)).remove(scenarioSimulationEditorPresenter.getPopulateTestToolsCommand());
+    }
+
+    protected void setSaveEnabled() {
+        workbenchContext.getActiveWorkspaceProject()
+                .ifPresent(activeProject -> projectController.canUpdateProject(activeProject).then(canUpdateProject -> {
+                    setSaveEnabled(canUpdateProject);
+                    return promises.resolve();
+                }));
+    }
+
+    protected void setSaveEnabled(boolean toSet) {
+        scenarioSimulationEditorPresenter.setSaveEnabled(toSet);
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -45,6 +45,7 @@ import org.drools.workbench.screens.scenariosimulation.service.DMNTypeService;
 import org.drools.workbench.screens.scenariosimulation.service.ImportExportService;
 import org.drools.workbench.screens.scenariosimulation.service.RunnerReportService;
 import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
+import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
@@ -125,7 +126,6 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
                    place,
                    type);
         scenarioSimulationEditorPresenter.init(this, (ObservablePath) place.getPath());
-        setSaveEnabled();
     }
 
     @OnClose
@@ -244,14 +244,6 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
         placeManager.getOnOpenCallbacks(new DefaultPlaceRequest(TestToolsPresenter.IDENTIFIER)).remove(scenarioSimulationEditorPresenter.getPopulateTestToolsCommand());
     }
 
-    protected void setSaveEnabled() {
-        workbenchContext.getActiveWorkspaceProject()
-                .ifPresent(activeProject -> projectController.canUpdateProject(activeProject).then(canUpdateProject -> {
-                    setSaveEnabled(canUpdateProject);
-                    return promises.resolve();
-                }));
-    }
-
     protected void setSaveEnabled(boolean toSet) {
         scenarioSimulationEditorPresenter.setSaveEnabled(toSet);
     }
@@ -262,7 +254,22 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     @Override
     protected Promise<Void> makeMenuBar() {
         scenarioSimulationEditorPresenter.makeMenuBar(fileMenuBuilder);
-        return super.makeMenuBar();
+        if (workbenchContext.getActiveWorkspaceProject().isPresent()) {
+            final WorkspaceProject activeProject = workbenchContext.getActiveWorkspaceProject().get();
+            return projectController.canUpdateProject(activeProject).then(canUpdateProject -> {
+                if (canUpdateProject) {
+                    addSave(fileMenuBuilder);
+                    addCopy(fileMenuBuilder);
+                    addRename(fileMenuBuilder);
+                    addDelete(fileMenuBuilder);
+                }
+                addDownloadMenuItem(fileMenuBuilder);
+                addCommonActions(fileMenuBuilder);
+                setSaveEnabled(canUpdateProject);
+                return promises.resolve();
+            });
+        }
+        return promises.resolve();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -125,6 +125,11 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
                    place,
                    type);
         scenarioSimulationEditorPresenter.init(this, (ObservablePath) place.getPath());
+        workbenchContext.getActiveWorkspaceProject()
+                .ifPresent(activeProject -> projectController.canUpdateProject(activeProject).then(canUpdateProject -> {
+            scenarioSimulationEditorPresenter.setSaveEnabled(canUpdateProject);
+            return promises.resolve();
+        }));
     }
 
     @OnClose

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
@@ -121,6 +121,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     @Mock
     private Supplier<ScenarioSimulationModel> contentSupplierMock;
 
+
     private CallerMock<ScenarioSimulationService> scenarioSimulationCaller;
     private CallerMock<ImportExportService> importExportCaller;
     private CallerMock<RunnerReportService> runnerReportServiceCaller;
@@ -178,6 +179,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     public void onStartup() {
         scenarioSimulationEditorBusinessClientWrapper.onStartup(observablePathMock, placeRequestMock);
         verify(scenarioSimulationEditorPresenterMock, times(1)).init(eq(scenarioSimulationEditorBusinessClientWrapper), eq(observablePathMock));
+        verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setSaveEnabled();
     }
 
     @Test
@@ -273,6 +275,19 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         verify(placeManagerMock, times(1)).getOnOpenCallbacks(eq(request));
         assertFalse(commands.contains(populateTestToolsCommand));
     }
+
+    @Test
+    public void setSaveEnabledTrue() {
+        scenarioSimulationEditorBusinessClientWrapper.setSaveEnabled(true);
+        verify(scenarioSimulationEditorPresenterMock, times(1)).setSaveEnabled(eq(true));
+    }
+
+    @Test
+    public void setSaveEnabledFalse() {
+        scenarioSimulationEditorBusinessClientWrapper.setSaveEnabled(false);
+        verify(scenarioSimulationEditorPresenterMock, times(1)).setSaveEnabled(eq(false));
+    }
+
 
     @Test
     public void makeMenuBar() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.scenariosimulation.businesscentral.client.e
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -37,6 +38,8 @@ import org.drools.workbench.screens.scenariosimulation.service.ImportExportServi
 import org.drools.workbench.screens.scenariosimulation.service.ImportExportType;
 import org.drools.workbench.screens.scenariosimulation.service.RunnerReportService;
 import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
+import org.guvnor.common.services.project.client.security.ProjectController;
+import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
 import org.jboss.errai.common.client.api.ErrorCallback;
@@ -74,6 +77,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -120,6 +124,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     private AssetUpdateValidator assetUpdateValidatorMock;
     @Mock
     private Supplier<ScenarioSimulationModel> contentSupplierMock;
+    @Mock
+    private ProjectController projectControllerMock;
 
 
     private CallerMock<ScenarioSimulationService> scenarioSimulationCaller;
@@ -161,6 +167,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
                 this.metadata = metaDataMock;
                 this.saveAndRenameCommandBuilder = saveAndRenameCommandBuilderMock;
                 this.assetUpdateValidator = assetUpdateValidatorMock;
+                this.projectController = projectControllerMock;
             }
         });
         when(placeRequestMock.getPath()).thenReturn(observablePathMock);
@@ -179,7 +186,6 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     public void onStartup() {
         scenarioSimulationEditorBusinessClientWrapper.onStartup(observablePathMock, placeRequestMock);
         verify(scenarioSimulationEditorPresenterMock, times(1)).init(eq(scenarioSimulationEditorBusinessClientWrapper), eq(observablePathMock));
-        verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setSaveEnabled();
     }
 
     @Test
@@ -290,9 +296,21 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
 
 
     @Test
-    public void makeMenuBar() {
+    public void makeMenuBarCanUpdateProjectTrue() {
+        doReturn(Optional.of(mock(WorkspaceProject.class))).when(workbenchContextMock).getActiveWorkspaceProject();
+        doReturn(promises.resolve(true)).when(projectControllerMock).canUpdateProject(any());
         scenarioSimulationEditorBusinessClientWrapper.makeMenuBar();
         verify(scenarioSimulationEditorPresenterMock, times(1)).makeMenuBar(same(fileMenuBuilderMock));
+        verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setSaveEnabled(eq(true));
+    }
+
+    @Test
+    public void makeMenuBarCanUpdateProjectFalse() {
+        doReturn(Optional.of(mock(WorkspaceProject.class))).when(workbenchContextMock).getActiveWorkspaceProject();
+        doReturn(promises.resolve(false)).when(projectControllerMock).canUpdateProject(any());
+        scenarioSimulationEditorBusinessClientWrapper.makeMenuBar();
+        verify(scenarioSimulationEditorPresenterMock, times(1)).makeMenuBar(same(fileMenuBuilderMock));
+        verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setSaveEnabled(eq(false));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -109,6 +109,7 @@ public class ScenarioSimulationEditorPresenter {
     protected TestRunnerReportingPanelWrapper testRunnerReportingPanel;
     protected SimulationRunResult lastRunResult;
     protected long scenarioPresenterId;
+    protected boolean saveEnabled = true;
     private ScenarioSimulationResourceType type;
     private ScenarioSimulationView view;
     private Command populateTestToolsCommand;
@@ -116,7 +117,6 @@ public class ScenarioSimulationEditorPresenter {
     private ConfirmPopupPresenter confirmPopupPresenter;
     private ScenarioSimulationDocksHandler scenarioSimulationDocksHandler;
     private ScenarioSimulationEditorWrapper scenarioSimulationEditorWrapper;
-    private boolean saveEnabled = true;
 
     public ScenarioSimulationEditorPresenter() {
         //Zero-parameter constructor for CDI proxies
@@ -156,10 +156,7 @@ public class ScenarioSimulationEditorPresenter {
 
     public void setSaveEnabled(boolean toSet) {
         saveEnabled = toSet;
-        getSettingsPresenter(getCurrentRightDockPlaceRequest(SettingsPresenter.IDENTIFIER)).ifPresent(presenter -> {
-            setSettings(presenter);
-            presenter.setSaveEnabled(toSet);
-        });
+        getSettingsPresenter(getCurrentRightDockPlaceRequest(SettingsPresenter.IDENTIFIER)).ifPresent(presenter -> presenter.setSaveEnabled(toSet));
     }
 
     public void setPackageName(String packageName) {
@@ -548,6 +545,9 @@ public class ScenarioSimulationEditorPresenter {
         presenter.setScenarioType(type, model.getSimulation().getSimulationDescriptor(), path.getFileName());
         if (saveEnabled) {
             presenter.setSaveCommand(getSaveCommand());
+            presenter.setSaveEnabled(true);
+        } else {
+            presenter.setSaveEnabled(false);
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -116,6 +116,7 @@ public class ScenarioSimulationEditorPresenter {
     private ConfirmPopupPresenter confirmPopupPresenter;
     private ScenarioSimulationDocksHandler scenarioSimulationDocksHandler;
     private ScenarioSimulationEditorWrapper scenarioSimulationEditorWrapper;
+    private boolean saveEnabled = true;
 
     public ScenarioSimulationEditorPresenter() {
         //Zero-parameter constructor for CDI proxies
@@ -151,6 +152,14 @@ public class ScenarioSimulationEditorPresenter {
         this.scenarioSimulationEditorWrapper = scenarioSimulationEditorWrapper;
         this.path = path;
         testRunnerReportingPanel.reset();
+    }
+
+    public void setSaveEnabled(boolean toSet) {
+        saveEnabled = toSet;
+        getSettingsPresenter(getCurrentRightDockPlaceRequest(SettingsPresenter.IDENTIFIER)).ifPresent(presenter -> {
+            setSettings(presenter);
+            presenter.setSaveEnabled(toSet);
+        });
     }
 
     public void setPackageName(String packageName) {
@@ -537,7 +546,9 @@ public class ScenarioSimulationEditorPresenter {
     protected void setSettings(SettingsView.Presenter presenter) {
         Type type = dataManagementStrategy instanceof AbstractDMODataManagementStrategy ? Type.RULE : Type.DMN;
         presenter.setScenarioType(type, model.getSimulation().getSimulationDescriptor(), path.getFileName());
-        presenter.setSaveCommand(getSaveCommand());
+        if (saveEnabled) {
+            presenter.setSaveCommand(getSaveCommand());
+        }
     }
 
     protected void setCoverageReport(CoverageReportView.Presenter presenter) {
@@ -545,7 +556,7 @@ public class ScenarioSimulationEditorPresenter {
         SimulationRunMetadata simulationRunMetadata = lastRunResult != null ? lastRunResult.getSimulationRunMetadata() : null;
         presenter.populateCoverageReport(type, simulationRunMetadata);
         if (simulationRunMetadata != null && simulationRunMetadata.getAuditLog() != null) {
-            presenter.setDownloadReportCommand(getDownloadReportCommand(simulationRunMetadata.getAuditLog() ));
+            presenter.setDownloadReportCommand(getDownloadReportCommand(simulationRunMetadata.getAuditLog()));
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
@@ -50,6 +50,8 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
 
     protected SettingsScenarioSimulationDropdown settingsScenarioSimulationDropdown;
 
+    private boolean saveEnabled = true;
+
     public SettingsPresenter() {
         //Zero argument constructor for CDI
         title = ScenarioSimulationEditorConstants.INSTANCE.settings();
@@ -93,22 +95,34 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     }
 
     @Override
-    public void onSaveButton(String scenarioType) {
-        simulationDescriptor.setSkipFromBuild(view.getSkipFromBuild().isChecked());
-        switch (ScenarioSimulationModel.Type.valueOf(scenarioType)) {
-            case RULE:
-                saveRuleSettings();
-                break;
-            case DMN:
-                saveDMNSettings();
-                break;
+    public void setSaveEnabled(boolean toSet) {
+        saveEnabled = toSet;
+        view.getSaveButton().setDisabled(!saveEnabled);
+        if (!saveEnabled) {
+            saveCommand = null;
         }
-        saveCommand.execute();
+    }
+
+    @Override
+    public void onSaveButton(String scenarioType) {
+        if (saveCommand != null) {
+            simulationDescriptor.setSkipFromBuild(view.getSkipFromBuild().isChecked());
+            switch (ScenarioSimulationModel.Type.valueOf(scenarioType)) {
+                case RULE:
+                    saveRuleSettings();
+                    break;
+                case DMN:
+                    saveDMNSettings();
+                    break;
+            }
+            saveCommand.execute();
+        }
     }
 
     @Override
     public void reset() {
         view.reset();
+        view.getSaveButton().setDisabled(!saveEnabled);
         settingsScenarioSimulationDropdown.clear();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
@@ -50,7 +50,7 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
 
     protected SettingsScenarioSimulationDropdown settingsScenarioSimulationDropdown;
 
-    private boolean saveEnabled = true;
+    protected boolean saveEnabled = true;
 
     public SettingsPresenter() {
         //Zero argument constructor for CDI
@@ -97,9 +97,10 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     @Override
     public void setSaveEnabled(boolean toSet) {
         saveEnabled = toSet;
-        view.getSaveButton().setDisabled(!saveEnabled);
         if (!saveEnabled) {
-            saveCommand = null;
+            view.removeSaveButton();
+        } else {
+            view.restoreSaveButton();
         }
     }
 
@@ -122,7 +123,9 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     @Override
     public void reset() {
         view.reset();
-        view.getSaveButton().setDisabled(!saveEnabled);
+        if (!saveEnabled) {
+            view.getSaveButton().removeFromParent();
+        }
         settingsScenarioSimulationDropdown.clear();
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
@@ -86,6 +86,8 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
             case DMN:
                 setDMNSettings(simulationDescriptor);
                 break;
+            default:
+                // nop
         }
     }
 
@@ -115,6 +117,8 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
                 case DMN:
                     saveDMNSettings();
                     break;
+                default:
+                    // nop
             }
             saveCommand.execute();
         }
@@ -124,10 +128,19 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     public void reset() {
         view.reset();
         if (!saveEnabled) {
-            view.getSaveButton().removeFromParent();
+            view.removeSaveButton();
         }
         settingsScenarioSimulationDropdown.clear();
     }
+
+    public boolean isSaveEnabled() {
+        return saveEnabled;
+    }
+
+    public SettingsView getView() {
+        return view;
+    }
+
 
     protected void setRuleSettings(SimulationDescriptor simulationDescriptor) {
         view.getDmnSettings().getStyle().setDisplay(Style.Display.NONE);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
@@ -36,6 +36,8 @@ public interface SettingsView
         void onSaveButton(String type);
 
         void setSaveCommand(Command saveCommand);
+
+        void setSaveEnabled(boolean toSet);
     }
 
     void setupDropdown(Element dropdownElement);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsView.java
@@ -79,4 +79,8 @@ public interface SettingsView
     InputElement getStateless();
 
     ButtonElement getSaveButton();
+
+    void removeSaveButton();
+
+    void restoreSaveButton();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImpl.java
@@ -40,6 +40,9 @@ public class SettingsViewImpl
 
     protected Presenter presenter;
 
+    @DataField("kieSettingsContent")
+    protected DivElement kieSettingsContent = Document.get().createDivElement();
+
     @DataField("nameLabel")
     protected LabelElement nameLabel = Document.get().createLabelElement();
 
@@ -223,6 +226,16 @@ public class SettingsViewImpl
     @Override
     public ButtonElement getSaveButton() {
         return saveButton;
+    }
+
+    @Override
+    public void removeSaveButton() {
+        saveButton.removeFromParent();
+    }
+
+    @Override
+    public void restoreSaveButton() {
+        kieSettingsContent.appendChild(saveButton);
     }
 
     @EventHandler("saveButton")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/MockProducer.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/MockProducer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client;
+
+import com.google.gwt.dom.client.ButtonElement;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.dom.client.LabelElement;
+import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.Style;
+import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsView;
+
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAMESPACE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMO_SESSION;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_NAME;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.RULE_FLOW_GROUP;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.SCENARIO_TYPE;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockProducer {
+
+    public static SettingsView getSettingsViewMock() {
+        SettingsView toReturn = mock(SettingsView.class);
+        when(toReturn.getNameLabel()).thenReturn(nameLabelMock());
+        doReturn(fileNameMock()).when(toReturn).getFileName();
+        when(toReturn.getTypeLabel()).thenReturn(typeLabelMock());
+        doReturn(scenarioTypeMock()).when(toReturn).getScenarioType();
+        doReturn(ruleSettingsMock()).when(toReturn).getRuleSettings();
+        doReturn(dmoSessionMock()).when(toReturn).getDmoSession();
+        doReturn(ruleFlowGroupMock()).when(toReturn).getRuleFlowGroup();
+        doReturn(dmnSettingsMock()).when(toReturn).getDmnSettings();
+        when(toReturn.getDmnFileLabel()).thenReturn(dmnModelLabelMock());
+        doReturn(dmnFilePathPlaceholderMock()).when(toReturn).getDmnFilePathPlaceholder();
+        doReturn(dmnFilePathErrorLabelMock()).when(toReturn).getDmnFilePathErrorLabel();
+        when(toReturn.getDmnNamespaceLabel()).thenReturn(dmnNamespaceLabelMock());
+        doReturn(dmnNamespaceMock()).when(toReturn).getDmnNamespace();
+        when(toReturn.getDmnNameLabel()).thenReturn(dmnNameLabelMock());
+        doReturn(dmnNameMock()).when(toReturn).getDmnName();
+        when(toReturn.getSkipFromBuild()).thenReturn(skipFromBuildMock());
+        when(toReturn.getSaveButton()).thenReturn(saveButtonMock());
+        when(toReturn.getStateless()).thenReturn(statelessMock());
+        return toReturn;
+    }
+
+    public static DivElement kieSettingsContentMock() {
+        return mock(DivElement.class);
+    }
+
+    public static LabelElement typeLabelMock() {
+        return mock(LabelElement.class);
+    }
+
+    public static LabelElement nameLabelMock() {
+        return mock(LabelElement.class);
+    }
+
+    public static Style dmnFilePathErrorLabelStyleMock() {
+        return mock(Style.class);
+    }
+
+    public static Style dmnSettingsStyleMock() {
+        return mock(Style.class);
+    }
+
+    public static InputElement dmoSessionMock() {
+        InputElement toReturn = mock(InputElement.class);
+        when(toReturn.getValue()).thenReturn(DMO_SESSION);
+        return toReturn;
+    }
+
+    public static InputElement statelessMock() {
+        return mock(InputElement.class);
+    }
+
+    public static ButtonElement saveButtonMock() {
+        return mock(ButtonElement.class);
+    }
+
+    public static InputElement skipFromBuildMock() {
+        return mock(InputElement.class);
+    }
+
+    public static InputElement dmnNameMock() {
+        InputElement toReturn = mock(InputElement.class);
+        when(toReturn.getValue()).thenReturn(DMN_NAME);
+        return toReturn;
+    }
+
+    public static InputElement dmnNamespaceMock() {
+        InputElement toReturn = mock(InputElement.class);
+        when(toReturn.getValue()).thenReturn(DMN_NAMESPACE);
+        return toReturn;
+    }
+
+    public static LabelElement dmnNamespaceLabelMock() {
+        return mock(LabelElement.class);
+    }
+
+    public static SpanElement dmnFilePathErrorLabelMock() {
+        SpanElement toReturn = mock(SpanElement.class);
+        when(toReturn.getStyle()).thenReturn(dmnFilePathErrorLabelStyleMock());
+        return toReturn;
+    }
+
+    public static DivElement dmnFilePathPlaceholderMock() {
+        DivElement toReturn = mock(DivElement.class);
+        when(toReturn.getInnerText()).thenReturn("");
+        return toReturn;
+    }
+
+    public static LabelElement dmnModelLabelMock() {
+        return mock(LabelElement.class);
+    }
+
+    public static LabelElement dmnNameLabelMock() {
+        return mock(LabelElement.class);
+    }
+
+    public static DivElement dmnSettingsMock() {
+        DivElement toReturn = mock(DivElement.class);
+        when(toReturn.getStyle()).thenReturn(dmnSettingsStyleMock());
+        return toReturn;
+    }
+
+    public static InputElement ruleFlowGroupMock() {
+        InputElement toReturn = mock(InputElement.class);
+        when(toReturn.getValue()).thenReturn(RULE_FLOW_GROUP);
+        return toReturn;
+    }
+
+    public static SpanElement scenarioTypeMock() {
+        SpanElement toReturn = mock(SpanElement.class);
+        when(toReturn.getInnerText()).thenReturn(SCENARIO_TYPE);
+        return toReturn;
+    }
+
+    public static InputElement fileNameMock() {
+        InputElement toReturn = mock(InputElement.class);
+        when(toReturn.getValue()).thenReturn(FILE_NAME);
+        return toReturn;
+    }
+
+    public static Style ruleSettingsStyleMock() {
+        return mock(Style.class);
+    }
+
+    public static DivElement ruleSettingsMock() {
+        DivElement toReturn = mock(DivElement.class);
+        when(toReturn.getStyle()).thenReturn(ruleSettingsStyleMock());
+        return toReturn;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -34,7 +34,9 @@ import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
 import org.drools.scenariosimulation.api.model.Simulation;
 import org.drools.scenariosimulation.api.model.SimulationDescriptor;
 import org.drools.scenariosimulation.api.model.SimulationRunMetadata;
+import org.drools.workbench.screens.scenariosimulation.client.MockProducer;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
+import org.drools.workbench.screens.scenariosimulation.client.dropdown.SettingsScenarioSimulationDropdown;
 import org.drools.workbench.screens.scenariosimulation.client.editor.strategies.DataManagementStrategy;
 import org.drools.workbench.screens.scenariosimulation.client.events.ImportEvent;
 import org.drools.workbench.screens.scenariosimulation.client.events.RedoEvent;
@@ -91,6 +93,7 @@ import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -236,6 +239,53 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenter.setSaveEnabled(false);
         assertFalse(presenter.saveEnabled);
         verify(settingsPresenterMock, times(1)).setSaveEnabled(eq(false));
+    }
+
+    @Test
+    public void setSaveEnabledPopulateSettingsCombinedTrue() {
+        SettingsPresenter settingsPresenterSpy = getSettingsPresenterSpy();
+        doReturn(Optional.of(settingsPresenterSpy)).when(presenter).getSettingsPresenter(eq(placeRequestMock));
+        presenter.setSaveEnabled(true);
+        presenter.populateRightDocks(SettingsPresenter.IDENTIFIER);
+        assertTrue(presenter.saveEnabled);
+        assertTrue(settingsPresenterSpy.isSaveEnabled());
+        verify(settingsPresenterSpy.getView(), atLeastOnce()).restoreSaveButton();
+        verify(settingsPresenterSpy.getView(), never()).removeSaveButton();
+    }
+
+    @Test
+    public void setSaveEnabledPopulateSettingsCombinedFalse() {
+        SettingsPresenter settingsPresenterSpy = getSettingsPresenterSpy();
+        doReturn(Optional.of(settingsPresenterSpy)).when(presenter).getSettingsPresenter(eq(placeRequestMock));
+        presenter.setSaveEnabled(false);
+        presenter.populateRightDocks(SettingsPresenter.IDENTIFIER);
+        assertFalse(presenter.saveEnabled);
+        assertFalse(settingsPresenterSpy.isSaveEnabled());
+        verify(settingsPresenterSpy.getView(), atLeastOnce()).removeSaveButton();
+        verify(settingsPresenterSpy.getView(), never()).restoreSaveButton();
+    }
+
+    @Test
+    public void setPopulateSettingsSaveEnabledCombinedTrue() {
+        SettingsPresenter settingsPresenterSpy = getSettingsPresenterSpy();
+        doReturn(Optional.of(settingsPresenterSpy)).when(presenter).getSettingsPresenter(eq(placeRequestMock));
+        presenter.populateRightDocks(SettingsPresenter.IDENTIFIER);
+        presenter.setSaveEnabled(true);
+        assertTrue(presenter.saveEnabled);
+        assertTrue(settingsPresenterSpy.isSaveEnabled());
+        verify(settingsPresenterSpy.getView(), atLeastOnce()).restoreSaveButton();
+        verify(settingsPresenterSpy.getView(), never()).removeSaveButton();
+    }
+
+    @Test
+    public void setPopulateSettingsSaveEnabledCombinedFalse() {
+        SettingsPresenter settingsPresenterSpy = getSettingsPresenterSpy();
+        doReturn(Optional.of(settingsPresenterSpy)).when(presenter).getSettingsPresenter(eq(placeRequestMock));
+        presenter.populateRightDocks(SettingsPresenter.IDENTIFIER);
+        presenter.setSaveEnabled(false);
+        assertFalse(presenter.saveEnabled);
+        assertFalse(settingsPresenterSpy.isSaveEnabled());
+        verify(settingsPresenterSpy.getView(), atLeastOnce()).removeSaveButton();
     }
 
     @Test
@@ -741,5 +791,9 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenter.getValidationCallback().callback(validationErrors);
         verify(confirmPopupPresenterMock, times(1)).show(anyString(), contains(errorId));
         verify(confirmPopupPresenterMock, times(1)).show(anyString(), contains(errorMessage));
+    }
+
+    private SettingsPresenter getSettingsPresenterSpy() {
+        return spy(new SettingsPresenter(mock(SettingsScenarioSimulationDropdown.class), MockProducer.getSettingsViewMock()));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -225,6 +225,20 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
     }
 
     @Test
+    public void setSaveEnabledTrue() {
+        presenter.setSaveEnabled(true);
+        assertTrue(presenter.saveEnabled);
+        verify(settingsPresenterMock, times(1)).setSaveEnabled(eq(true));
+    }
+
+    @Test
+    public void setSaveEnabledFalse() {
+        presenter.setSaveEnabled(false);
+        assertFalse(presenter.saveEnabled);
+        verify(settingsPresenterMock, times(1)).setSaveEnabled(eq(false));
+    }
+
+    @Test
     public void onClose() {
         presenter.onClose();
         verify(scenarioGridPanelMock, times(1)).unregister();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
@@ -35,6 +35,9 @@ import static org.mockito.Mockito.when;
 abstract class AbstractSettingsTest {
 
     @Mock
+    protected DivElement kieSettingsContentMock;
+
+    @Mock
     protected LabelElement nameLabelMock;
 
     @Mock

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractSettingsTest.java
@@ -22,94 +22,79 @@ import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style;
-import org.mockito.Mock;
-
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAME;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMN_NAMESPACE;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.DMO_SESSION;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_NAME;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.RULE_FLOW_GROUP;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.SCENARIO_TYPE;
-import static org.mockito.Mockito.when;
+import org.drools.workbench.screens.scenariosimulation.client.MockProducer;
 
 abstract class AbstractSettingsTest {
 
-    @Mock
     protected DivElement kieSettingsContentMock;
 
-    @Mock
     protected LabelElement nameLabelMock;
 
-    @Mock
     protected InputElement fileNameMock;
 
-    @Mock
     protected LabelElement typeLabelMock;
 
-    @Mock
     protected SpanElement scenarioTypeMock;
 
-    @Mock
     protected DivElement ruleSettingsMock;
 
-    @Mock
     protected Style ruleSettingsStyleMock;
 
-    @Mock
     protected InputElement dmoSessionMock;
 
-    @Mock
     protected InputElement ruleFlowGroupMock;
 
-    @Mock
     protected DivElement dmnSettingsMock;
 
-    @Mock
     protected Style dmnSettingsStyleMock;
 
-    @Mock
     protected LabelElement dmnModelLabelMock;
 
-    @Mock
     protected DivElement dmnFilePathPlaceholderMock;
 
-    @Mock
     protected SpanElement dmnFilePathErrorLabelMock;
 
-    @Mock
     protected Style dmnFilePathErrorLabelStyleMock;
 
-    @Mock
     protected LabelElement dmnNamespaceLabelMock;
 
-    @Mock
     protected InputElement dmnNamespaceMock;
 
-    @Mock
     protected LabelElement dmnNameLabelMock;
 
-    @Mock
     protected InputElement dmnNameMock;
 
-    @Mock
     protected InputElement skipFromBuildMock;
 
-    @Mock
     protected InputElement statelessMock;
 
-    @Mock
     protected ButtonElement saveButtonMock;
 
+    protected SettingsView settingsViewMock;
+
     protected void setup() {
-        when(fileNameMock.getValue()).thenReturn(FILE_NAME);
-        when(scenarioTypeMock.getInnerText()).thenReturn(SCENARIO_TYPE);
-        when(dmoSessionMock.getValue()).thenReturn(DMO_SESSION);
-        when(ruleFlowGroupMock.getValue()).thenReturn(RULE_FLOW_GROUP);
-        when(dmnFilePathPlaceholderMock.getInnerText()).thenReturn("");
-        when(dmnNamespaceMock.getValue()).thenReturn(DMN_NAMESPACE);
-        when(dmnNameMock.getValue()).thenReturn(DMN_NAME);
-        when(ruleSettingsMock.getStyle()).thenReturn(ruleSettingsStyleMock);
-        when(dmnSettingsMock.getStyle()).thenReturn(dmnSettingsStyleMock);
-        when(dmnFilePathErrorLabelMock.getStyle()).thenReturn(dmnFilePathErrorLabelStyleMock);
+        settingsViewMock = MockProducer.getSettingsViewMock();
+        kieSettingsContentMock = MockProducer.kieSettingsContentMock();
+        nameLabelMock = settingsViewMock.getNameLabel();
+        fileNameMock = settingsViewMock.getFileName();
+        typeLabelMock = settingsViewMock.getTypeLabel();
+        scenarioTypeMock = settingsViewMock.getScenarioType();
+        ruleSettingsMock = settingsViewMock.getRuleSettings();
+        ruleSettingsStyleMock = ruleSettingsMock.getStyle();
+        dmoSessionMock = settingsViewMock.getDmoSession();
+        ruleFlowGroupMock = settingsViewMock.getRuleFlowGroup();
+        dmnSettingsMock = settingsViewMock.getDmnSettings();
+        dmnSettingsStyleMock = dmnSettingsMock.getStyle();
+        dmnModelLabelMock = settingsViewMock.getDmnNameLabel();
+        dmnFilePathPlaceholderMock = settingsViewMock.getDmnFilePathPlaceholder();
+        dmnFilePathErrorLabelMock = settingsViewMock.getDmnFilePathErrorLabel();
+        dmnFilePathErrorLabelStyleMock = dmnFilePathErrorLabelMock.getStyle();
+        dmnNamespaceLabelMock = settingsViewMock.getDmnNamespaceLabel();
+        dmnNamespaceMock = settingsViewMock.getDmnNamespace();
+        dmnNameLabelMock = settingsViewMock.getDmnNameLabel();
+        dmnNameMock = settingsViewMock.getDmnName();
+        skipFromBuildMock = settingsViewMock.getSkipFromBuild();
+        statelessMock = settingsViewMock.getStateless();
+        saveButtonMock = settingsViewMock.getSaveButton();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
@@ -53,9 +53,9 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
 
     private SettingsPresenter settingsPresenter;
 
-    @Mock
-    private SettingsView settingsViewMock;
-
+////    @Mock
+//    private SettingsView settingsViewMock;
+//
     @Mock
     private SimulationDescriptor simulationDescriptorMock;
 
@@ -68,24 +68,24 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     @Before
     public void setup() {
         super.setup();
-        when(settingsViewMock.getNameLabel()).thenReturn(nameLabelMock);
-        when(settingsViewMock.getFileName()).thenReturn(fileNameMock);
-        when(settingsViewMock.getTypeLabel()).thenReturn(typeLabelMock);
-        when(settingsViewMock.getScenarioType()).thenReturn(scenarioTypeMock);
-        when(settingsViewMock.getRuleSettings()).thenReturn(ruleSettingsMock);
-        when(settingsViewMock.getDmoSession()).thenReturn(dmoSessionMock);
-        when(settingsViewMock.getRuleFlowGroup()).thenReturn(ruleFlowGroupMock);
-        when(settingsViewMock.getDmnSettings()).thenReturn(dmnSettingsMock);
-        when(settingsViewMock.getDmnFileLabel()).thenReturn(dmnModelLabelMock);
-        when(settingsViewMock.getDmnFilePathPlaceholder()).thenReturn(dmnFilePathPlaceholderMock);
-        when(settingsViewMock.getDmnFilePathErrorLabel()).thenReturn(dmnFilePathErrorLabelMock);
-        when(settingsViewMock.getDmnNamespaceLabel()).thenReturn(dmnNamespaceLabelMock);
-        when(settingsViewMock.getDmnNamespace()).thenReturn(dmnNamespaceMock);
-        when(settingsViewMock.getDmnNameLabel()).thenReturn(dmnNameLabelMock);
-        when(settingsViewMock.getDmnName()).thenReturn(dmnNameMock);
-        when(settingsViewMock.getSkipFromBuild()).thenReturn(skipFromBuildMock);
-        when(settingsViewMock.getSaveButton()).thenReturn(saveButtonMock);
-        when(settingsViewMock.getStateless()).thenReturn(statelessMock);
+//        when(settingsViewMock.getNameLabel()).thenReturn(nameLabelMock);
+//        when(settingsViewMock.getFileName()).thenReturn(fileNameMock);
+//        when(settingsViewMock.getTypeLabel()).thenReturn(typeLabelMock);
+//        when(settingsViewMock.getScenarioType()).thenReturn(scenarioTypeMock);
+//        when(settingsViewMock.getRuleSettings()).thenReturn(ruleSettingsMock);
+//        when(settingsViewMock.getDmoSession()).thenReturn(dmoSessionMock);
+//        when(settingsViewMock.getRuleFlowGroup()).thenReturn(ruleFlowGroupMock);
+//        when(settingsViewMock.getDmnSettings()).thenReturn(dmnSettingsMock);
+//        when(settingsViewMock.getDmnFileLabel()).thenReturn(dmnModelLabelMock);
+//        when(settingsViewMock.getDmnFilePathPlaceholder()).thenReturn(dmnFilePathPlaceholderMock);
+//        when(settingsViewMock.getDmnFilePathErrorLabel()).thenReturn(dmnFilePathErrorLabelMock);
+//        when(settingsViewMock.getDmnNamespaceLabel()).thenReturn(dmnNamespaceLabelMock);
+//        when(settingsViewMock.getDmnNamespace()).thenReturn(dmnNamespaceMock);
+//        when(settingsViewMock.getDmnNameLabel()).thenReturn(dmnNameLabelMock);
+//        when(settingsViewMock.getDmnName()).thenReturn(dmnNameMock);
+//        when(settingsViewMock.getSkipFromBuild()).thenReturn(skipFromBuildMock);
+//        when(settingsViewMock.getSaveButton()).thenReturn(saveButtonMock);
+//        when(settingsViewMock.getStateless()).thenReturn(statelessMock);
 
         when(simulationDescriptorMock.getRuleFlowGroup()).thenReturn(RULE_FLOW_GROUP);
         when(simulationDescriptorMock.getDmoSession()).thenReturn(DMO_SESSION);
@@ -165,9 +165,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     public void setScenarioTypeRULESkipTrue() {
         when(simulationDescriptorMock.isSkipFromBuild()).thenReturn(true);
         settingsPresenter.setScenarioType(ScenarioSimulationModel.Type.RULE, simulationDescriptorMock, FILE_NAME);
-        verify(settingsViewMock, times(1)).getScenarioType();
         verify(scenarioTypeMock, times(1)).setInnerText(eq(ScenarioSimulationModel.Type.RULE.name()));
-        verify(settingsViewMock, times(1)).getFileName();
         verify(fileNameMock, times(1)).setValue(eq(FILE_NAME));
         verify(skipFromBuildMock, times(1)).setChecked(eq(true));
         verify(saveButtonMock, times(1)).setDisabled(eq(false));
@@ -178,9 +176,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     public void setScenarioTypeRULESkipFalse() {
         when(simulationDescriptorMock.isSkipFromBuild()).thenReturn(false);
         settingsPresenter.setScenarioType(ScenarioSimulationModel.Type.RULE, simulationDescriptorMock, FILE_NAME);
-        verify(settingsViewMock, times(1)).getScenarioType();
         verify(scenarioTypeMock, times(1)).setInnerText(eq(ScenarioSimulationModel.Type.RULE.name()));
-        verify(settingsViewMock, times(1)).getFileName();
         verify(fileNameMock, times(1)).setValue(eq(FILE_NAME));
         verify(skipFromBuildMock, times(1)).setChecked(eq(false));
         verify(saveButtonMock, times(1)).setDisabled(eq(false));
@@ -191,9 +187,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     public void setScenarioTypeDMNSkipTrue() {
         when(simulationDescriptorMock.isSkipFromBuild()).thenReturn(true);
         settingsPresenter.setScenarioType(ScenarioSimulationModel.Type.DMN, simulationDescriptorMock, FILE_NAME);
-        verify(settingsViewMock, times(1)).getScenarioType();
         verify(scenarioTypeMock, times(1)).setInnerText(eq(ScenarioSimulationModel.Type.DMN.name()));
-        verify(settingsViewMock, times(1)).getFileName();
         verify(fileNameMock, times(1)).setValue(eq(FILE_NAME));
         verify(skipFromBuildMock, times(1)).setChecked(eq(true));
         verify(saveButtonMock, times(1)).setDisabled(eq(false));
@@ -204,9 +198,7 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     public void setScenarioTypeDMNSkipFalse() {
         when(simulationDescriptorMock.isSkipFromBuild()).thenReturn(false);
         settingsPresenter.setScenarioType(ScenarioSimulationModel.Type.DMN, simulationDescriptorMock, FILE_NAME);
-        verify(settingsViewMock, times(1)).getScenarioType();
         verify(scenarioTypeMock, times(1)).setInnerText(eq(ScenarioSimulationModel.Type.DMN.name()));
-        verify(settingsViewMock, times(1)).getFileName();
         verify(fileNameMock, times(1)).setValue(eq(FILE_NAME));
         verify(skipFromBuildMock, times(1)).setChecked(eq(false));
         verify(saveButtonMock, times(1)).setDisabled(eq(false));
@@ -216,13 +208,9 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     @Test
     public void setRuleSettings() {
         settingsPresenter.setRuleSettings(simulationDescriptorMock);
-        verify(settingsViewMock, times(1)).getDmnSettings();
         verify(dmnSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.NONE));
-        verify(settingsViewMock, times(1)).getRuleSettings();
         verify(ruleSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.INLINE));
-        verify(settingsViewMock, times(1)).getDmoSession();
         verify(dmoSessionMock, times(1)).setValue(eq(DMO_SESSION));
-        verify(settingsViewMock, times(1)).getRuleFlowGroup();
         verify(ruleFlowGroupMock, times(1)).setValue(eq(RULE_FLOW_GROUP));
         verify(statelessMock, times(1)).setChecked(eq(simulationDescriptorMock.isStateless()));
     }
@@ -230,15 +218,10 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     @Test
     public void setDMNSettings() {
         settingsPresenter.setDMNSettings(simulationDescriptorMock);
-        verify(settingsViewMock, times(1)).getRuleSettings();
         verify(ruleSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.NONE));
-        verify(settingsViewMock, times(1)).getDmnSettings();
         verify(dmnSettingsStyleMock, times(1)).setDisplay(eq(Style.Display.INLINE));
-        verify(settingsViewMock, times(1)).getDmnName();
         verify(dmnNameMock, times(1)).setValue(eq(DMN_NAME));
-        verify(settingsViewMock, times(1)).getDmnNamespace();
         verify(dmnNamespaceMock, times(1)).setValue(eq(DMN_NAMESPACE));
-        verify(settingsViewMock, times(2)).getDmnFilePathErrorLabel();
         verify(dmnFilePathErrorLabelStyleMock, times(1)).setDisplay(eq(Style.Display.NONE));
         verify(dmnFilePathErrorLabelMock, times(1)).setInnerText(eq(""));
         verify(settingsScenarioSimulationDropdownMock, times(1)).registerOnMissingValueHandler(isA(Command.class));
@@ -251,8 +234,6 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
         when(skipFromBuildMock.isChecked()).thenReturn(true);
         settingsPresenter.saveRuleSettings();
         verify(simulationDescriptorMock, times(1)).setDmoSession(eq(DMO_SESSION));
-        verify(settingsViewMock, times(1)).getDmoSession();
-        verify(settingsViewMock, times(1)).getRuleFlowGroup();
         verify(simulationDescriptorMock, times(1)).setRuleFlowGroup(eq(RULE_FLOW_GROUP));
         verify(simulationDescriptorMock, times(1)).setStateless(eq(false));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenterTest.java
@@ -38,6 +38,8 @@ import static org.drools.workbench.screens.scenariosimulation.client.TestPropert
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FILE_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.RULE_FLOW_GROUP;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.reset;
@@ -113,6 +115,20 @@ public class SettingsPresenterTest extends AbstractSettingsTest {
     @Test
     public void getTitle() {
         assertEquals(ScenarioSimulationEditorConstants.INSTANCE.settings(), settingsPresenter.getTitle());
+    }
+
+    @Test
+    public void setSaveEnabledTrue() {
+        settingsPresenter.setSaveEnabled(true);
+        assertTrue(settingsPresenter.saveEnabled);
+        verify(settingsViewMock, times(1)).restoreSaveButton();
+    }
+
+    @Test
+    public void setSaveEnabledFalse() {
+        settingsPresenter.setSaveEnabled(false);
+        assertFalse(settingsPresenter.saveEnabled);
+        verify(settingsViewMock, times(1)).removeSaveButton();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsViewImplTest.java
@@ -44,6 +44,7 @@ public class SettingsViewImplTest extends AbstractSettingsTest {
         super.setup();
         this.settingsView = spy(new SettingsViewImpl() {
             {
+                this.kieSettingsContent = kieSettingsContentMock;
                 this.nameLabel = nameLabelMock;
                 this.fileName = fileNameMock;
                 this.typeLabel = typeLabelMock;
@@ -65,6 +66,18 @@ public class SettingsViewImplTest extends AbstractSettingsTest {
             }
         });
         settingsView.init(settingsPresenterMock);
+    }
+
+    @Test
+    public void removeSaveButton() {
+        settingsView.removeSaveButton();
+        verify(saveButtonMock, times(1)).removeFromParent();
+    }
+
+    @Test
+    public void restoreSaveButton() {
+        settingsView.restoreSaveButton();
+        verify(kieSettingsContentMock, times(1)).appendChild(eq(saveButtonMock));
     }
 
     @Test


### PR DESCRIPTION
@dupliaka  @yesamer @danielezonca

see https://issues.jboss.org/browse/DROOLS-4638

Logic behind the current implementation is:

1) currently, user "credential" as a concept exists only inside BC, not in Kogito
2) as such, I consider the "read/write" permission a BC-specific condition
3) so, main presenter and settings presenter should normally work without such knowledge, and their default editable status is always _true_
4) it is the BC specific component (**ScenarioSimulationEditorBusinessCentralWrapper**) - in case - to "disable" the editable status
5) I had to add the **ScenarioSimulationEditorPresenter.saveEnabled** flag because both the _SettingsPanel_ setup and the retrieval of user "read/write" permissions happen in different - more or less asynchronous - threads, so it is not sure which of the two happen before

- if credential retrieval complete before, only **ScenarioSimulationEditorPresenter.saveEnabled** is updated (since there is still no _SettingsPanel_ active) and, when _SettingsPanel_ setup is invoked, that status will be taken in consideraton
- if _SettingsPanel_ setup complete before, **ScenarioSimulationEditorPresenter** will update its **saveEnabled** flag and will update the _SettingsPanel_ presenter

6) I had to create **SettingsPresenter.saveEnabled** because - during the lifecycle of the editor - **SettingsPresenter.reset()** is invoked (that restore the settings view to the default status) and then this flag is used to know if the button has to be shown/removed

7) I choose to add/remove the "Save" button to be more consistent with the behavior of the main toolbar.

8) I had to add some indirection inside **ScenarioSimulationEditorBusinessCentralWrapper** for testing purposes.

/------/
A concern that crossed may mind working on this PR is: prevent unwanted user actions (e.g."Save" for a read-only user) only by hiding buttons is not extremely secure inside a web page.
Anyway it is a topic that - eventually - should be discussed in other place and involve the whole architecture, I think.
 