### PR TITLE
[DROOLS-4676] Scenario run failed when user deletes columns

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -354,7 +354,6 @@ public class ScenarioSimulationEditorPresenter {
             simulation.replaceScenario(index, scenarioWithIndex.getScenario());
         }
         scenarioMainGridWidget.refreshContent(simulation);
-        scenarioBackgroundGridWidget.refreshContent(simulation.cloneSimulation());
         focusedContext.getStatus().setSimulation(simulation);
         scenarioSimulationDocksHandler.expandTestResultsDock();
         testRunnerReportingPanel.onTestRun(newData.getTestResultMessage());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -634,7 +634,6 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         verify(simulationMock, times(1)).replaceScenario(eq(scenarioIndex), eq(scenario));
         assertEquals(scenarioSimulationModelMock, presenter.getModel());
         verify(scenarioGridWidgetMock, times(1)).refreshContent(eq(simulationMock));
-        verify(scenarioBackgroundGridWidgetMock, times(1)).refreshContent(isA(Simulation.class));
         verify(scenarioSimulationDocksHandlerMock, times(1)).expandTestResultsDock();
         verify(dataManagementStrategyMock, times(1)).setModel(eq(scenarioSimulationModelMock));
         verify(testRunnerReportingPanelMock, times(1)).onTestRun(eq(testResultMessage));


### PR DESCRIPTION
@dupliaka @gitgabrio @danielezonca can you please review / test with high priority? 

https://issues.jboss.org/browse/DROOLS-4676