### PR TITLE
DROOLS-4650: Fix failing tests

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/DecisionTableAnalyzerTest.java
@@ -108,7 +108,9 @@ public class DecisionTableAnalyzerTest {
     public void testInsertActionColumn() throws Exception {
 
         ActionCol52 a = new ActionCol52();
+        a.setHeader("A");
         ActionCol52 b = new ActionCol52();
+        b.setHeader("B");
         actionColumns.add(a);
         actionColumns.add(b);
         model.setActionCols(actionColumns);
@@ -122,7 +124,9 @@ public class DecisionTableAnalyzerTest {
     public void testInsertBRLConditionColumn() throws Exception {
         BRLConditionColumn brlConditionOne = new BRLConditionColumn();
         BRLConditionVariableColumn a = new BRLConditionVariableColumn();
+        a.setHeader("A");
         BRLConditionVariableColumn b = new BRLConditionVariableColumn();
+        b.setHeader("B");
 
         BRLConditionColumn brlConditionTwo = new BRLConditionColumn();
         BRLConditionVariableColumn c = new BRLConditionVariableColumn();
@@ -159,12 +163,16 @@ public class DecisionTableAnalyzerTest {
     @Test
     public void testInsertBRLVariableColumn() throws Exception {
         ConditionCol52 a = new ConditionCol52();
+        a.setHeader("A");
         ConditionCol52 b = new ConditionCol52();
+        b.setHeader("B");
         pattern.setChildColumns(Arrays.asList(a, b));
 
         BRLConditionColumn brlCondition = new BRLConditionColumn();
         BRLConditionVariableColumn c = new BRLConditionVariableColumn();
+        c.setHeader("C");
         BRLConditionVariableColumn d = new BRLConditionVariableColumn();
+        d.setHeader("D");
         brlCondition.setChildColumns(Arrays.asList(c, d));
 
         model.getConditions().addAll(Arrays.asList(pattern, brlCondition));
@@ -176,7 +184,9 @@ public class DecisionTableAnalyzerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testInsertNonExistingColumn() throws Exception {
         ConditionCol52 a = new ConditionCol52();
+        a.setHeader("A");
         ConditionCol52 b = new ConditionCol52();
+        b.setHeader("B");
         pattern.setChildColumns(Arrays.asList(a));
 
         BRLConditionColumn brlCondition = new BRLConditionColumn();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
@@ -398,6 +398,7 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         final Pattern52 pattern = spy(boundApplicantPattern("$a"));
 
         final ConditionCol52 condition1 = spy(ageEqualsCondition());
+        condition1.setHeader("$a age is");
 
         modelSynchronizer.appendColumn(pattern,
                                        condition1);
@@ -411,12 +412,13 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
         final ConditionCol52 editedCondition = ageEqualsCondition();
         editedCondition.setWidth(condition2.getWidth());
+        editedCondition.setHeader("$a2 age is");
 
         List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn(pattern,
                                                                          condition1,
                                                                          editedPattern,
                                                                          editedCondition);
-        assertEquals(1,
+        assertEquals(2,
                      diffs.size());
         verify(pattern).diff(editedPattern);
         verify(condition1).diff(editedCondition);
@@ -1850,13 +1852,13 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         column1p2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         column1p2.setFactField("state");
         column1p2.setOperator("==");
-        column1p2.setHeader("state");
+        column1p2.setHeader("state $d");
 
         final ConditionCol52 column2p2 = new ConditionCol52();
         column2p2.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         column2p2.setFactField("country");
         column2p2.setOperator("==");
-        column2p2.setHeader("country");
+        column2p2.setHeader("country $d");
 
         modelSynchronizer.appendColumn(pattern2,
                                        column1p2);
@@ -1869,13 +1871,13 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         column1p3.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         column1p3.setFactField("state");
         column1p3.setOperator("==");
-        column1p3.setHeader("state");
+        column1p3.setHeader("state $d2");
 
         final ConditionCol52 column2p3 = new ConditionCol52();
         column2p3.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
         column2p3.setFactField("country");
         column2p3.setOperator("==");
-        column2p3.setHeader("country");
+        column2p3.setHeader("country $d2");
 
         modelSynchronizer.appendColumn(pattern3,
                                        column1p3);


### PR DESCRIPTION
As part of DROOLS-4650 we implemented equals method of columns. Some tests needed to be updated to differentiate once compared via equals.

Ensemble together with:
https://github.com/kiegroup/drools/pull/2624