### PR TITLE
[DROOLS-4518] Style improvements for CoverageScenario panel

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStylesCss.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStylesCss.java
@@ -111,4 +111,7 @@ public interface ScenarioSimulationEditorStylesCss extends CssResource {
 
     @ClassName("list-group-item-container-fact-property")
     String listGroupItemContainerFactProperty();
+
+    @ClassName("kie-coverage__dl-horizontal")
+    String kieCoverageDlHorizontal();
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
@@ -35,6 +35,8 @@ import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 @Dependent
 public class CoverageReportDonutPresenter {
 
+    private static final String COVERAGE = "coverage";
+
     protected Elemental2DomUtil elemental2DomUtil;
     protected DisplayerLocator displayerLocator;
     protected DisplayerCoordinator displayerCoordinator;
@@ -82,13 +84,14 @@ public class CoverageReportDonutPresenter {
      * - Remove all labels inside any arc of the chart. This is required because the chat current dimension is very
      *   tiny, drawing these labels in wrongly way.
      * To achieve these requirements without a native support of the component, it navigates the <code>container</code>
-     * DOM to retrieve manually the text tags elements which handle the labels and modifying it
+     * DOM to retrieve manually the text tags elements which handle the labels. Then, it add the holeLabel to its proper
+     * text tag, and remove all not required labels.
      * *
      * @param holeLabel The label to assign in the Donut's hole
      */
     public void manageChartLabels(String holeLabel) {
         NodeList<Element> listE = container.getElementsByTagName("text");
-        for (int i=0; i < listE.getLength(); i++){
+        for (int i = 0; i < listE.getLength(); i++) {
             Element element = listE.getAt(i);
             String className = element.getAttribute("class");
             if (Objects.equals("c3-chart-arcs-title", className)) {
@@ -108,10 +111,10 @@ public class CoverageReportDonutPresenter {
                                                         .subType_Donut()
                                                         .margins(1, 1, 1, 1)
                                                         .legendOff()
-                                                        .column("coverage").format("coverage", "#")
+                                                        .column(COVERAGE).format(COVERAGE, "#")
                                                         .dataset(DataSetFactory.newDataSetBuilder()
                                                                          .label("STATUS")
-                                                                         .number("coverage")
+                                                                         .number(COVERAGE)
                                                                          .row(ScenarioSimulationEditorConstants.INSTANCE.executed(),
                                                                               executed)
                                                                          .row(ScenarioSimulationEditorConstants.INSTANCE.notCovered(),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
@@ -81,10 +81,10 @@ public class CoverageReportDonutPresenter {
     /**
      * Scope of this method is to manage the labels inside the Donut chart. The requirements are:
      * - Add a label in the center of the chart, i.e. the hole of the Donut;
-     * - Remove all labels inside any arc of the chart. This is required because the chat current dimension is very
-     *   tiny, drawing these labels in wrongly way.
+     * - Remove all labels inside any arc of the chart. This is required because the chart current dimension is very
+     *   small and leading to draw these labels in wrongly way.
      * To achieve these requirements without a native support of the component, it navigates the <code>container</code>
-     * DOM to retrieve manually the text tags elements which handle the labels. Then, it add the holeLabel to its proper
+     * DOM to retrieve manually the text tags elements which handle the labels. Then, it adds the holeLabel to its proper
      * text tag, and remove all not required labels.
      * *
      * @param holeLabel The label to assign in the Donut's hole

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
@@ -108,7 +108,7 @@ public class CoverageReportDonutPresenter {
                                                         .subType_Donut()
                                                         .margins(1, 1, 1, 1)
                                                         .legendOff()
-
+                                                        .column("coverage").format("coverage", "#")
                                                         .dataset(DataSetFactory.newDataSetBuilder()
                                                                          .label("STATUS")
                                                                          .number("coverage")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
@@ -16,10 +16,14 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
+import java.util.Objects;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import elemental2.dom.Element;
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.NodeList;
 import org.dashbuilder.dataset.DataSetFactory;
 import org.dashbuilder.displayer.DisplayerSettingsFactory;
 import org.dashbuilder.displayer.client.Displayer;
@@ -72,16 +76,39 @@ public class CoverageReportDonutPresenter {
                                                 displayer.asWidget());
     }
 
+    /**
+     * Scope of this method is to manage the labels inside the Donut chart. The requirements are:
+     * - Add a label in the center of the chart, i.e. the hole of the Donut;
+     * - Remove all labels inside any arc of the chart. This is required because the chat current dimension is very
+     *   tiny, drawing these labels in wrongly way.
+     * To achieve these requirements without a native support of the component, it navigates the <code>container</code>
+     * DOM to retrieve manually the text tags elements which handle the labels and modifying it
+     * *
+     * @param holeLabel The label to assign in the Donut's hole
+     */
+    public void manageChartLabels(String holeLabel) {
+        NodeList<Element> listE = container.getElementsByTagName("text");
+        for (int i=0; i < listE.getLength(); i++){
+            Element element = listE.getAt(i);
+            String className = element.getAttribute("class");
+            if (Objects.equals("c3-chart-arcs-title", className)) {
+                element.innerHTML = holeLabel;
+            } else if (element.innerHTML != null && element.innerHTML.endsWith("%") && className.isEmpty()) {
+                String style = element.getAttribute("style");
+                element.setAttribute("style", style.concat("display:none;"));
+            }
+        }
+    }
+
     protected Displayer makeDisplayer(final int executed,
                                       final int notCovered) {
         return displayerLocator.lookupDisplayer(DisplayerSettingsFactory.newPieChartSettings()
-                                                        .height(100)
-                                                        .width(80)
-                                                        .titleVisible(true)
+                                                        .height(120)
+                                                        .width(120)
                                                         .subType_Donut()
                                                         .margins(1, 1, 1, 1)
                                                         .legendOff()
-                                                        .column("coverage").format("coverage", "#")
+
                                                         .dataset(DataSetFactory.newDataSetBuilder()
                                                                          .label("STATUS")
                                                                          .number("coverage")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenter.java
@@ -16,8 +16,6 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
-import java.util.Objects;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -61,7 +59,8 @@ public class CoverageReportDonutPresenter {
     }
 
     public void showCoverageReport(final int executed,
-                                   final int notCovered) {
+                                   final int notCovered,
+                                   final String coveragePercentage) {
 
         if (displayer != null) {
             elemental2DomUtil.removeAllElementChildren(container);
@@ -69,7 +68,8 @@ public class CoverageReportDonutPresenter {
         }
 
         displayer = makeDisplayer(executed,
-                                  notCovered);
+                                  notCovered,
+                                  coveragePercentage);
 
         displayerCoordinator.addDisplayer(displayer);
         displayerCoordinator.drawAll();
@@ -79,24 +79,18 @@ public class CoverageReportDonutPresenter {
     }
 
     /**
-     * Scope of this method is to manage the labels inside the Donut chart. The requirements are:
-     * - Add a label in the center of the chart, i.e. the hole of the Donut;
+     * Scope of this method is to manage the labels inside the Donut chart. The requirements is to:
      * - Remove all labels inside any arc of the chart. This is required because the chart current dimension is very
      *   small and leading to draw these labels in wrongly way.
      * To achieve these requirements without a native support of the component, it navigates the <code>container</code>
-     * DOM to retrieve manually the text tags elements which handle the labels. Then, it adds the holeLabel to its proper
-     * text tag, and remove all not required labels.
-     * *
-     * @param holeLabel The label to assign in the Donut's hole
+     * DOM to retrieve manually the text tags elements which handle the labels.
      */
-    public void manageChartLabels(String holeLabel) {
+    public void manageChartLabels() {
         NodeList<Element> listE = container.getElementsByTagName("text");
         for (int i = 0; i < listE.getLength(); i++) {
             Element element = listE.getAt(i);
             String className = element.getAttribute("class");
-            if (Objects.equals("c3-chart-arcs-title", className)) {
-                element.innerHTML = holeLabel;
-            } else if (element.innerHTML != null && element.innerHTML.endsWith("%") && className.isEmpty()) {
+             if (element.innerHTML != null && element.innerHTML.endsWith("%") && className.isEmpty()) {
                 String style = element.getAttribute("style");
                 element.setAttribute("style", style.concat("display:none;"));
             }
@@ -104,11 +98,12 @@ public class CoverageReportDonutPresenter {
     }
 
     protected Displayer makeDisplayer(final int executed,
-                                      final int notCovered) {
+                                      final int notCovered,
+                                      final String coveragePercentage) {
         return displayerLocator.lookupDisplayer(DisplayerSettingsFactory.newPieChartSettings()
                                                         .height(120)
                                                         .width(120)
-                                                        .subType_Donut()
+                                                        .subType_Donut(coveragePercentage)
                                                         .margins(1, 1, 1, 1)
                                                         .legendOff()
                                                         .column(COVERAGE).format(COVERAGE, "#")

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
@@ -34,18 +34,18 @@ import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.mvp.Command;
 
 import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type.DMN;
-import static org.drools.workbench.screens.scenariosimulation.client.rightpanel.CoverageReportPresenter.DEFAULT_PREFERRED_WIDHT;
+import static org.drools.workbench.screens.scenariosimulation.client.rightpanel.CoverageReportPresenter.DEFAULT_PREFERRED_WIDTH;
 import static org.drools.workbench.screens.scenariosimulation.client.rightpanel.CoverageReportPresenter.IDENTIFIER;
 
 @ApplicationScoped
-@WorkbenchScreen(identifier = IDENTIFIER, preferredWidth = DEFAULT_PREFERRED_WIDHT)
+@WorkbenchScreen(identifier = IDENTIFIER, preferredWidth = DEFAULT_PREFERRED_WIDTH)
 public class CoverageReportPresenter extends AbstractSubDockPresenter<CoverageReportView> implements CoverageReportView.Presenter {
 
-    public static final int DEFAULT_PREFERRED_WIDHT = 300;
+    public static final int DEFAULT_PREFERRED_WIDTH = 300;
+    public static final String IDENTIFIER = "org.drools.scenariosimulation.CoverageReport";
 
     private static final NumberFormat numberFormat = NumberFormat.getFormat("00.00");
-
-    public static final String IDENTIFIER = "org.drools.scenariosimulation.CoverageReport";
+    private static final NumberFormat numberFormatNoDecimal = NumberFormat.getFormat("##0");
 
     protected CoverageReportDonutPresenter coverageReportDonutPresenter;
 
@@ -146,13 +146,13 @@ public class CoverageReportPresenter extends AbstractSubDockPresenter<CoverageRe
     protected void populateSummary(int available, int executed, double coveragePercentage) {
         view.setReportAvailable(available + "");
         view.setReportExecuted(executed + "");
-        String coveragePercentageFormatted = numberFormat.format(coveragePercentage);
-        view.setReportCoverage(coveragePercentageFormatted + "%");
+        String coveragePercentageFormatted = numberFormat.format(coveragePercentage) ;
+        view.setReportCoverage(coveragePercentageFormatted+ "%");
 
         // donut chart
-        coverageReportDonutPresenter
-                .showCoverageReport(executed,
-                                    available - executed);
+        coverageReportDonutPresenter.showCoverageReport(executed,
+                                                        available - executed);
+        coverageReportDonutPresenter.manageChartLabels(numberFormatNoDecimal.format(coveragePercentage) + "%");
     }
 
     protected void populateList(Map<String, Integer> outputCounter) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
@@ -151,8 +151,9 @@ public class CoverageReportPresenter extends AbstractSubDockPresenter<CoverageRe
 
         // donut chart
         coverageReportDonutPresenter.showCoverageReport(executed,
-                                                        available - executed);
-        coverageReportDonutPresenter.manageChartLabels(numberFormatNoDecimal.format(coveragePercentage) + "%");
+                                                        available - executed,
+                                                        numberFormatNoDecimal.format(coveragePercentage) + "%");
+        coverageReportDonutPresenter.manageChartLabels();
     }
 
     protected void populateList(Map<String, Integer> outputCounter) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenter.java
@@ -146,8 +146,8 @@ public class CoverageReportPresenter extends AbstractSubDockPresenter<CoverageRe
     protected void populateSummary(int available, int executed, double coveragePercentage) {
         view.setReportAvailable(available + "");
         view.setReportExecuted(executed + "");
-        String coveragePercentageFormatted = numberFormat.format(coveragePercentage) ;
-        view.setReportCoverage(coveragePercentageFormatted+ "%");
+        String coveragePercentageFormatted = numberFormat.format(coveragePercentage);
+        view.setReportCoverage(coveragePercentageFormatted + "%");
 
         // donut chart
         coverageReportDonutPresenter.showCoverageReport(executed,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportViewImpl.html
@@ -52,7 +52,7 @@
             <div class="col-xs-12 col-md-12">
                 <hr class="kie-dock__divider"/>
                 <span data-field="numberOfTimesElementEvaluated"></span>
-                <div style="margin-top: 20px; height: 100px">
+                <div style="margin-top: 10px; height: 100px">
                     <div style="height: 100%; overflow: auto">
                         <dl data-field="list" class="dl-horizontal kie-coverage__dl-horizontal"></dl>
                     </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportViewImpl.html
@@ -32,11 +32,11 @@
         <div class="row" data-field="summarySection">
             <div class="col-xs-12 col-md-8">
                 <dl class="dl-horizontal kie-coverage__dl-horizontal clearfix">
-                    <dt data-field="reportAvailableLabel" style="overflow:visible; text-overflow:clip; white-space:normal"></dt>
+                    <dt data-field="reportAvailableLabel"></dt>
                     <dd data-field="reportAvailable"></dd>
-                    <dt data-field="reportExecutedLabel" style="overflow:visible; text-overflow:clip; white-space:normal"></dt>
+                    <dt data-field="reportExecutedLabel"></dt>
                     <dd data-field="reportExecuted"></dd>
-                    <dt data-field="reportCoverageLabel" style="overflow:visible; text-overflow:clip; white-space:normal"></dt>
+                    <dt data-field="reportCoverageLabel"></dt>
                     <dd data-field="reportCoverage"></dd>
                 </dl>
             </div>
@@ -45,7 +45,6 @@
                 <!------- DONUT CHART -->
                 <div id="kieCoverageChart1" data-field="donutChart" class="example-donut-chart-utilization"></div>
                 <!------- END OF DONUT CHART -->
-
             </div>
         </div>
 
@@ -53,7 +52,6 @@
             <div class="col-xs-12 col-md-12">
                 <hr class="kie-dock__divider"/>
                 <span data-field="numberOfTimesElementEvaluated"></span>
-                <br/>
                 <div style="margin-top: 20px; height: 100px">
                     <div style="height: 100%; overflow: auto">
                         <dl data-field="list" class="dl-horizontal kie-coverage__dl-horizontal"></dl>
@@ -65,10 +63,7 @@
         <div class="row" data-field="scenarioListSection">
             <div class="col-xs-12 col-md-12">
                 <hr class="kie-dock__divider"/>
-                <br/>
-
-                <ul class="list-group" data-field="scenarioList">
-                </ul>
+                <ul class="list-group" data-field="scenarioList"></ul>
             </div>
         </div>
     </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenter.java
@@ -56,9 +56,10 @@ public class CoverageScenarioListPresenter implements CoverageScenarioListView.P
         String customText = Type.DMN.equals(type) ?
                 ScenarioSimulationEditorConstants.INSTANCE.decisionsEvaluated() :
                 ScenarioSimulationEditorConstants.INSTANCE.rulesFired();
+        String itemLabel = customText + " " + scenarioWithIndex.getIndex() + ": " +
+                scenarioWithIndex.getScesimData().getDescription();
 
-        coverageScenarioListView.getFaAngleRight().textContent = "  " + customText
-                + " " + scenarioWithIndex.getIndex() + ": " + scenarioWithIndex.getScesimData().getDescription();
+        coverageScenarioListView.setItemLabel(itemLabel);
 
         scenarioElement.appendChild(createInternalList(resultCounter, coverageScenarioListView.getScenarioContentList()));
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListView.java
@@ -18,7 +18,6 @@ package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
 import java.util.Map;
 
-import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLLIElement;
 import elemental2.dom.HTMLUListElement;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type;
@@ -32,9 +31,9 @@ public interface CoverageScenarioListView {
 
     HTMLUListElement getScenarioContentList();
 
-    HTMLElement getFaAngleRight();
-
     boolean isVisible();
+
+    void setItemLabel(String itemLabel);
 
     void setVisible(boolean visible);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.html
@@ -17,6 +17,7 @@
 
 <li class="list-group-item" data-field="scenarioElement">
     <span class="fa fa-angle-right" data-field="faAngleRight"></span>
+    <span data-field="itemLabelElement"></span>
     <ul class="list-group" data-field="scenarioContentList"></ul>
 </li>
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
@@ -16,8 +16,6 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
-import javax.enterprise.context.Dependent;
-
 import com.google.gwt.event.dom.client.ClickEvent;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
@@ -34,7 +32,6 @@ import static org.drools.workbench.screens.scenariosimulation.client.utils.Const
 /**
  * This class is used to represent a single scenario with all its own decisions/rules
  */
-@Dependent
 @Templated
 public class CoverageScenarioListViewImpl implements CoverageScenarioListView {
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
@@ -73,13 +73,13 @@ public class CoverageScenarioListViewImpl implements CoverageScenarioListView {
     }
 
     @Override
-    public boolean isVisible() {
-        return !scenarioContentList.classList.contains(HIDDEN);
+    public void setItemLabel(String itemLabel) {
+        itemLabelElement.textContent = itemLabel;
     }
 
     @Override
-    public void setItemLabel(String itemLabel) {
-        itemLabelElement.textContent = itemLabel;
+    public boolean isVisible() {
+        return !scenarioContentList.classList.contains(HIDDEN);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListViewImpl.java
@@ -16,6 +16,8 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
@@ -32,6 +34,7 @@ import static org.drools.workbench.screens.scenariosimulation.client.utils.Const
 /**
  * This class is used to represent a single scenario with all its own decisions/rules
  */
+@Dependent
 @Templated
 public class CoverageScenarioListViewImpl implements CoverageScenarioListView {
 
@@ -43,6 +46,9 @@ public class CoverageScenarioListViewImpl implements CoverageScenarioListView {
 
     @DataField
     protected HTMLElement faAngleRight = (HTMLElement) DomGlobal.document.createElement("span");
+
+    @DataField
+    protected HTMLElement itemLabelElement = (HTMLElement) DomGlobal.document.createElement("span");
 
     private Presenter presenter;
 
@@ -67,13 +73,13 @@ public class CoverageScenarioListViewImpl implements CoverageScenarioListView {
     }
 
     @Override
-    public HTMLElement getFaAngleRight() {
-        return faAngleRight;
+    public boolean isVisible() {
+        return !scenarioContentList.classList.contains(HIDDEN);
     }
 
     @Override
-    public boolean isVisible() {
-        return !scenarioContentList.classList.contains(HIDDEN);
+    public void setItemLabel(String itemLabel) {
+        itemLabelElement.textContent = itemLabel;
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css
@@ -187,3 +187,10 @@ span.kie-list-view-pf-main-info__text {
     padding-left: 0;
     margin-bottom: 0;
 }
+
+.kie-coverage__dl-horizontal dt {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    text-align: inherit;
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportDonutPresenterTest.java
@@ -61,12 +61,12 @@ public class CoverageReportDonutPresenterTest {
         HTMLDivElement container = mock(HTMLDivElement.class);
         donutPresenter.init(container);
 
-        donutPresenter.showCoverageReport(1, 1);
+        donutPresenter.showCoverageReport(1, 1, "holeLabel");
 
         verify(elemental2DomUtil, never()).removeAllElementChildren(any());
         verify(displayerCoordinator, never()).removeDisplayer(any());
 
-        donutPresenter.showCoverageReport(2, 2);
+        donutPresenter.showCoverageReport(2, 2, "holeLabel");
 
         verify(elemental2DomUtil).removeAllElementChildren(any());
         verify(displayerCoordinator).removeDisplayer(any());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
@@ -176,7 +176,8 @@ public class CoverageReportPresenterTest {
         verify(coverageReportViewMock, times(1)).setReportCoverage(endsWith("%"));
         int delta = availableLocal - executedLocal;
         verify(coverageReportDonutPresenterMock, times(1)).showCoverageReport(eq(executedLocal),
-                                                                              eq(delta));
+                                                                                                   eq(delta));
+        verify(coverageReportDonutPresenterMock, times(1)).manageChartLabels(endsWith("%"));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
@@ -176,7 +176,7 @@ public class CoverageReportPresenterTest {
         verify(coverageReportViewMock, times(1)).setReportCoverage(endsWith("%"));
         int delta = availableLocal - executedLocal;
         verify(coverageReportDonutPresenterMock, times(1)).showCoverageReport(eq(executedLocal),
-                                                                                                   eq(delta));
+                                                                              eq(delta));
         verify(coverageReportDonutPresenterMock, times(1)).manageChartLabels(endsWith("%"));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageReportPresenterTest.java
@@ -176,8 +176,9 @@ public class CoverageReportPresenterTest {
         verify(coverageReportViewMock, times(1)).setReportCoverage(endsWith("%"));
         int delta = availableLocal - executedLocal;
         verify(coverageReportDonutPresenterMock, times(1)).showCoverageReport(eq(executedLocal),
-                                                                              eq(delta));
-        verify(coverageReportDonutPresenterMock, times(1)).manageChartLabels(endsWith("%"));
+                                                                              eq(delta),
+                                                                              endsWith("%"));
+        verify(coverageReportDonutPresenterMock, times(1)).manageChartLabels();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.HTMLLIElement;
+import elemental2.dom.HTMLUListElement;
+import org.drools.scenariosimulation.api.model.Scenario;
+import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
+import org.drools.scenariosimulation.api.model.ScenarioWithIndex;
+import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
+import org.drools.workbench.screens.scenariosimulation.client.utils.ViewsProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class CoverageScenarioListPresenterTest {
+
+    @Mock
+    private ViewsProvider viewsProviderMock;
+
+    @Mock
+    private CoverageScenarioListView coverageScenarioListViewMock;
+
+    @Mock
+    private HTMLLIElement scenarioElementMock;
+
+    @Mock
+    private HTMLUListElement scenarioContentListMock;
+
+    @Mock
+    private HTMLUListElement scenarioList;
+
+    private CoverageScenarioListPresenter coverageScenarioListPresenterSpy;
+
+    @Before
+    public void setup() {
+        coverageScenarioListPresenterSpy = spy(CoverageScenarioListPresenter.class);
+        coverageScenarioListPresenterSpy.viewsProvider = viewsProviderMock;
+        coverageScenarioListPresenterSpy.initScenarioList(scenarioList);
+        when(viewsProviderMock.getCoverageScenarioListView()).thenReturn(coverageScenarioListViewMock);
+        when(coverageScenarioListViewMock.getScenarioElement()).thenReturn(scenarioElementMock);
+        when(coverageScenarioListViewMock.getScenarioElement()).thenReturn(scenarioElementMock);
+        when(coverageScenarioListViewMock.getScenarioContentList()).thenReturn(scenarioContentListMock);
+    }
+
+    @Test
+    public void addScesimDataGroup_DMN() {
+        int scenarioIndex = 1;
+        String scenarioDescription = "description";
+        String expectedLabel = ScenarioSimulationEditorConstants.INSTANCE.decisionsEvaluated() + " " + scenarioIndex + ": " + scenarioDescription;
+        commonAddScesimDataGroup(ScenarioSimulationModel.Type.DMN, scenarioIndex, scenarioDescription, expectedLabel);
+    }
+
+    @Test
+    public void addScesimDataGroup_RULE() {
+        int scenarioIndex = 1;
+        String scenarioDescription = "description";
+        String expectedLabel = ScenarioSimulationEditorConstants.INSTANCE.rulesFired() + " " + scenarioIndex + ": " + scenarioDescription;
+        commonAddScesimDataGroup(ScenarioSimulationModel.Type.RULE, scenarioIndex, scenarioDescription, expectedLabel);
+    }
+
+    private void commonAddScesimDataGroup(ScenarioSimulationModel.Type type, int scenarioIndex, String scenarioDescription, String expectedLabel) {
+;        Scenario scenario = new Scenario();
+        scenario.setDescription(scenarioDescription);
+        ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(scenarioIndex, scenario);
+        Map<String, Integer> resultCounter = new HashMap<>();
+        coverageScenarioListPresenterSpy.addScesimDataGroup(scenarioWithIndex, resultCounter, type);
+        verify(viewsProviderMock, times(1)).getCoverageScenarioListView();
+        verify(coverageScenarioListViewMock, times(1)).setPresenter(eq(coverageScenarioListPresenterSpy));
+        verify(coverageScenarioListViewMock, times(1)).setVisible(eq(false));
+        verify(coverageScenarioListViewMock, times(1)).getScenarioElement();
+        verify(coverageScenarioListViewMock, times(1)).setItemLabel(eq(expectedLabel));
+        verify(scenarioElementMock, times(1)).appendChild(isA(HTMLUListElement.class));
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/CoverageScenarioListPresenterTest.java
@@ -86,7 +86,7 @@ public class CoverageScenarioListPresenterTest {
     }
 
     private void commonAddScesimDataGroup(ScenarioSimulationModel.Type type, int scenarioIndex, String scenarioDescription, String expectedLabel) {
-;        Scenario scenario = new Scenario();
+        Scenario scenario = new Scenario();
         scenario.setDescription(scenarioDescription);
         ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(scenarioIndex, scenario);
         Map<String, Integer> resultCounter = new HashMap<>();


### PR DESCRIPTION
@dupliaka @gitgabrio @danielezonca Can you please test it and review it?

This PR contains some CSS styles change for CoverageScenarioPanel.
The considerable part is the requirement to put the percentage of decision tested INSIDE the hole of the Donut chart.

Related PR: https://github.com/kiegroup/appformer/pull/860

https://issues.jboss.org/browse/DROOLS-4518

![Screenshot from 2019-11-28 10-56-31](https://user-images.githubusercontent.com/16005046/69812281-13c93c80-11f0-11ea-87d5-4a22288dbcea.png)
