### PR TITLE
[DROOLS-4804] Disabling TestTools when switching grids

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -200,15 +200,9 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
     @Override
     public void setGridWidget(GridWidget gridWidget) {
         this.gridWidget = gridWidget;
-        switch (gridWidget) {
-            case BACKGROUND:
-                hideInstances();
-                break;
-            case SIMULATION:
-                showInstanceListContainerSeparator(true);
-                break;
-            default:
-                throw new IllegalArgumentException("Illegal GridWidget " + gridWidget);
+        onDisableEditorTab();
+        if (GridWidget.BACKGROUND.equals(gridWidget)) {
+            hideInstances();
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -225,13 +225,14 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
     @Test
     public void setGridWidgetSIMULATION() {
         testToolsPresenterSpy.setGridWidget(GridWidget.SIMULATION);
-        verify(testToolsPresenterSpy, times(1)).showInstanceListContainerSeparator(eq(true));
+        verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, never()).hideInstances();
     }
 
     @Test
     public void setGridWidgetBACKGROUND() {
         testToolsPresenterSpy.setGridWidget(GridWidget.BACKGROUND);
+        verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, times(1)).hideInstances();
         verify(testToolsPresenterSpy, never()).showInstanceListContainerSeparator(eq(true));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -234,7 +234,6 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
         testToolsPresenterSpy.setGridWidget(GridWidget.BACKGROUND);
         verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, times(1)).hideInstances();
-        verify(testToolsPresenterSpy, never()).showInstanceListContainerSeparator(eq(true));
     }
 
     @Test


### PR DESCRIPTION
@dupliaka @gitgabrio @danielezonca Can you please test and review it?

Very simple, to solve the reported issues, the tool panel it's now disabled after a grid switching.
We agreed to improve the search functionality in a separate ticket.

https://issues.jboss.org/browse/DROOLS-4804