### PR TITLE
[DROOLS-4827] Refactoring Test Tool data population

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategy.java
@@ -39,7 +39,7 @@ public class BusinessCentralDMNDataManagementStrategy extends AbstractDMNDataMan
                                           final GridWidget gridWidget,
                                           String dmnFilePath) {
         dmnTypeService.call(getSuccessCallback(testToolsPresenter, context, gridWidget),
-                            getErrorCallback(testToolsPresenter))
+                            getErrorCallback())
                 .retrieveFactModelTuple(currentPath, dmnFilePath);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategyTest.java
@@ -87,7 +87,7 @@ public class BusinessCentralDMNDataManagementStrategyTest extends AbstractScenar
             }
 
             @Override
-            protected ErrorCallback<Message> getErrorCallback(TestToolsView.Presenter testToolsPresenter) {
+            protected ErrorCallback<Message> getErrorCallback() {
                 return errorCallbackMock;
             }
         });

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -652,7 +652,6 @@ public class ScenarioSimulationEditorPresenter {
         context.setTestToolsPresenter(presenter);
         presenter.setEventBus(eventBus);
         GridWidget gridWidget = scenarioBackgroundGridWidget.isSelected() ? GridWidget.BACKGROUND : GridWidget.SIMULATION;
-        presenter.setGridWidget(gridWidget);
         dataManagementStrategy.populateTestTools(presenter, context, gridWidget);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategy.java
@@ -15,8 +15,6 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.editor.strategies;
 
-import java.util.TreeMap;
-
 import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
@@ -104,9 +102,8 @@ public abstract class AbstractDMNDataManagementStrategy extends AbstractDataMana
         }
     }
 
-    protected ErrorCallback<Message> getErrorCallback(TestToolsView.Presenter testToolsPresenter) {
+    protected ErrorCallback<Message> getErrorCallback() {
         return (error, exception) -> {
-            testToolsPresenter.setDataObjectFieldsMap(new TreeMap<>());
             ErrorPopup.showMessage(exception.getMessage());
             return false;
         };

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -36,6 +36,7 @@ import org.drools.scenariosimulation.api.model.ScesimModelDescriptor;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
 import org.drools.workbench.screens.scenariosimulation.client.models.AbstractScesimGridModel;
+import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenterData;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsView;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
@@ -139,35 +140,34 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
         final SortedMap<String, FactModelTree> complexDataObjects = new TreeMap<>(partitionBy.get(false).stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         final SortedMap<String, FactModelTree> simpleDataObjects = new TreeMap<>(partitionBy.get(true).stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
-
-        // Update right panel
-        testToolsPresenter.setDataObjectFieldsMap(complexDataObjects);
-        testToolsPresenter.setSimpleJavaTypeFieldsMap(simpleDataObjects);
-        testToolsPresenter.setHiddenFieldsMap(factModelTuple.getHiddenFacts());
-        testToolsPresenter.hideProperties(propertiesToHide);
         // Update context
         SortedMap<String, FactModelTree> dataObjectFieldsMap = new TreeMap<>();
         dataObjectFieldsMap.putAll(visibleFacts);
         dataObjectFieldsMap.putAll(factModelTuple.getHiddenFacts());
         context.setDataObjectFieldsMap(dataObjectFieldsMap);
-        testToolsPresenter.hideInstances();
         // Update model
+        // Avoid Collections.emptySortedMap() due to "The method emptySortedMap() is undefined for the type Collections" error
+        SortedMap<String, FactModelTree> instanceFieldsMap = new TreeMap<>();
+        SortedMap<String, FactModelTree> simpleJavaTypeInstanceFieldsMap = new TreeMap<>();
         if (GridWidget.SIMULATION.equals(gridWidget)) {
-            final SortedMap<String, FactModelTree> instanceFieldsMap = getInstanceMap(complexDataObjects);
-            final SortedMap<String, FactModelTree> simpleJavaTypeInstanceFieldsMap = getInstanceMap(simpleDataObjects);
-            testToolsPresenter.setInstanceFieldsMap(instanceFieldsMap);
-            testToolsPresenter.setSimpleJavaInstanceFieldsMap(simpleJavaTypeInstanceFieldsMap);
+            instanceFieldsMap = getInstanceMap(complexDataObjects);
+            simpleJavaTypeInstanceFieldsMap = getInstanceMap(simpleDataObjects);
             Set<String> dataObjectsInstancesName = new HashSet<>(visibleFacts.keySet());
             dataObjectsInstancesName.addAll(instanceFieldsMap.keySet());
             context.setDataObjectsInstancesName(dataObjectsInstancesName);
             Set<String> simpleJavaTypeInstancesName = new HashSet<>(simpleDataObjects.keySet());
             simpleJavaTypeInstancesName.addAll(simpleJavaTypeInstanceFieldsMap.keySet());
             context.getAbstractScesimGridModelByGridWidget(gridWidget).setSimpleJavaTypeInstancesName(simpleJavaTypeInstancesName);
-        } else {
-            // Avoid Collections.emptySortedMap() due to "The method emptySortedMap() is undefined for the type Collections" error
-            testToolsPresenter.setInstanceFieldsMap(new TreeMap<>());
-            testToolsPresenter.setSimpleJavaInstanceFieldsMap(new TreeMap<>());
         }
+        // Update right panel
+        TestToolsPresenterData testToolsPresenterData = new TestToolsPresenterData(complexDataObjects,
+                                                                                   simpleDataObjects,
+                                                                                   instanceFieldsMap,
+                                                                                   simpleJavaTypeInstanceFieldsMap,
+                                                                                   factModelTuple.getHiddenFacts(),
+                                                                                   propertiesToHide,
+                                                                                   gridWidget);
+        testToolsPresenter.populateTestTools(testToolsPresenterData);
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -143,42 +143,47 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
     }
 
     @Override
-    public void setDataObjectFieldsMap(SortedMap<String, FactModelTree> dataObjectFieldsMap) {
+    public void populateTestTools(TestToolsPresenterData data) {
+        setDataObjectFieldsMap(data.getDataObjectFieldsMap());
+        setSimpleJavaTypeFieldsMap(data.getSimpleJavaTypeFieldsMap());
+        setInstanceFieldsMap(data.getInstanceFieldsMap());
+        setSimpleJavaInstanceFieldsMap(data.getSimpleJavaInstanceFieldsMap());
+        setHiddenFieldsMap(data.getHiddenFieldsMap());
+        hideProperties(data.getPropertiesToHide());
+        setGridWidget(data.getGridWidget());
+    }
+
+    protected void setDataObjectFieldsMap(SortedMap<String, FactModelTree> dataObjectFieldsMap) {
         clearDataObjectList();
         this.dataObjectFieldsMap = dataObjectFieldsMap;
         this.dataObjectFieldsMap.forEach(this::addDataObjectListGroupItemView);
     }
 
-    @Override
-    public void setSimpleJavaTypeFieldsMap(SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap) {
+    protected void setSimpleJavaTypeFieldsMap(SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap) {
         clearSimpleJavaTypeList();
         this.simpleJavaTypeFieldsMap = simpleJavaTypeFieldsMap;
         this.simpleJavaTypeFieldsMap.forEach(this::addSimpleJavaTypeListGroupItemView);
     }
 
-    @Override
-    public void setInstanceFieldsMap(SortedMap<String, FactModelTree> instanceFieldsMap) {
+    protected void setInstanceFieldsMap(SortedMap<String, FactModelTree> instanceFieldsMap) {
         clearInstanceList();
         this.instanceFieldsMap = instanceFieldsMap;
         this.instanceFieldsMap.forEach(this::addInstanceListGroupItemView);
         updateInstanceListSeparator();
     }
 
-    @Override
-    public void setSimpleJavaInstanceFieldsMap(SortedMap<String, FactModelTree> simpleJavaInstanceFieldsMap) {
+    protected void setSimpleJavaInstanceFieldsMap(SortedMap<String, FactModelTree> simpleJavaInstanceFieldsMap) {
         clearSimpleJavaInstanceFieldList();
         this.simpleJavaInstanceFieldsMap = simpleJavaInstanceFieldsMap;
         this.simpleJavaInstanceFieldsMap.forEach(this::addSimpleJavaInstanceListGroupItemView);
         updateInstanceListSeparator();
     }
 
-    @Override
-    public void setHiddenFieldsMap(SortedMap<String, FactModelTree> hiddenFieldsMap) {
+    protected void setHiddenFieldsMap(SortedMap<String, FactModelTree> hiddenFieldsMap) {
         this.hiddenFieldsMap = hiddenFieldsMap;
     }
 
-    @Override
-    public void hideProperties(Map<String, List<List<String>>> propertiesToHide) {
+    protected void hideProperties(Map<String, List<List<String>>> propertiesToHide) {
         listGroupItemPresenter.showAll();
         propertiesToHide.entrySet().stream().forEach(
                 stringListEntry -> stringListEntry.getValue()
@@ -197,8 +202,7 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
         this.eventBus = eventBus;
     }
 
-    @Override
-    public void setGridWidget(GridWidget gridWidget) {
+    protected void setGridWidget(GridWidget gridWidget) {
         this.gridWidget = gridWidget;
         onDisableEditorTab();
         if (GridWidget.BACKGROUND.equals(gridWidget)) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenter.java
@@ -200,15 +200,9 @@ public class TestToolsPresenter extends AbstractSubDockPresenter<TestToolsView> 
     @Override
     public void setGridWidget(GridWidget gridWidget) {
         this.gridWidget = gridWidget;
-        switch (gridWidget) {
-            case BACKGROUND:
-                hideInstances();
-                break;
-            case SIMULATION:
-                showInstanceListContainerSeparator(true);
-                break;
-            default:
-                throw new IllegalArgumentException("Illegal GridWidget " + gridWidget);
+        onDisableEditorTab();
+        if (GridWidget.BACKGROUND.equals(gridWidget)) {
+            hideInstances();
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterData.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterData.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
+import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
+import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
+
+public class TestToolsPresenterData {
+
+    private SortedMap<String, FactModelTree> dataObjectFieldsMap;
+    private SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap;
+    private SortedMap<String, FactModelTree> instanceFieldsMap;
+    private SortedMap<String, FactModelTree> simpleJavaInstanceFieldsMap;
+    private SortedMap<String, FactModelTree> hiddenFieldsMap;
+    private Map<String, List<List<String>>> propertiesToHide;
+    private GridWidget gridWidget;
+
+    public TestToolsPresenterData(SortedMap<String, FactModelTree> dataObjectFieldsMap,
+                                  SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap,
+                                  SortedMap<String, FactModelTree> instanceFieldsMap,
+                                  SortedMap<String, FactModelTree> simpleJavaInstanceFieldsMap,
+                                  SortedMap<String, FactModelTree> hiddenFieldsMap,
+                                  Map<String, List<List<String>>> propertiesToHide, GridWidget gridWidget) {
+        this.dataObjectFieldsMap = dataObjectFieldsMap;
+        this.simpleJavaTypeFieldsMap = simpleJavaTypeFieldsMap;
+        this.instanceFieldsMap = instanceFieldsMap;
+        this.simpleJavaInstanceFieldsMap = simpleJavaInstanceFieldsMap;
+        this.hiddenFieldsMap = hiddenFieldsMap;
+        this.propertiesToHide = propertiesToHide;
+        this.gridWidget = gridWidget;
+    }
+
+    public SortedMap<String, FactModelTree> getDataObjectFieldsMap() {
+        return dataObjectFieldsMap;
+    }
+
+    public void setDataObjectFieldsMap(SortedMap<String, FactModelTree> dataObjectFieldsMap) {
+        this.dataObjectFieldsMap = dataObjectFieldsMap;
+    }
+
+    public SortedMap<String, FactModelTree> getSimpleJavaTypeFieldsMap() {
+        return simpleJavaTypeFieldsMap;
+    }
+
+    public void setSimpleJavaTypeFieldsMap(SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap) {
+        this.simpleJavaTypeFieldsMap = simpleJavaTypeFieldsMap;
+    }
+
+    public SortedMap<String, FactModelTree> getInstanceFieldsMap() {
+        return instanceFieldsMap;
+    }
+
+    public void setInstanceFieldsMap(SortedMap<String, FactModelTree> instanceFieldsMap) {
+        this.instanceFieldsMap = instanceFieldsMap;
+    }
+
+    public SortedMap<String, FactModelTree> getSimpleJavaInstanceFieldsMap() {
+        return simpleJavaInstanceFieldsMap;
+    }
+
+    public void setSimpleJavaInstanceFieldsMap(SortedMap<String, FactModelTree> simpleJavaInstanceFieldsMap) {
+        this.simpleJavaInstanceFieldsMap = simpleJavaInstanceFieldsMap;
+    }
+
+    public SortedMap<String, FactModelTree> getHiddenFieldsMap() {
+        return hiddenFieldsMap;
+    }
+
+    public void setHiddenFieldsMap(SortedMap<String, FactModelTree> hiddenFieldsMap) {
+        this.hiddenFieldsMap = hiddenFieldsMap;
+    }
+
+    public Map<String, List<List<String>>> getPropertiesToHide() {
+        return propertiesToHide;
+    }
+
+    public void setPropertiesToHide(Map<String, List<List<String>>> propertiesToHide) {
+        this.propertiesToHide = propertiesToHide;
+    }
+
+    public GridWidget getGridWidget() {
+        return gridWidget;
+    }
+
+    public void setGridWidget(GridWidget gridWidget) {
+        this.gridWidget = gridWidget;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsView.java
@@ -17,13 +17,10 @@
 package org.drools.workbench.screens.scenariosimulation.client.rightpanel;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.SortedMap;
 
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.event.shared.EventBus;
-import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 
 public interface TestToolsView extends SubDockView<TestToolsView.Presenter> {
@@ -94,6 +91,8 @@ public interface TestToolsView extends SubDockView<TestToolsView.Presenter> {
 
         void onClearStatus();
 
+        void populateTestTools(TestToolsPresenterData data);
+
         void onShowClearButton();
 
         /**
@@ -127,26 +126,12 @@ public interface TestToolsView extends SubDockView<TestToolsView.Presenter> {
 
         void addSimpleJavaInstanceListGroupItemView(String factName, FactModelTree factModelTree);
 
-        void setDataObjectFieldsMap(SortedMap<String, FactModelTree> dataObjectFieldsMap);
-
-        void setSimpleJavaTypeFieldsMap(SortedMap<String, FactModelTree> simpleJavaTypeFieldsMap);
-
-        void setHiddenFieldsMap(SortedMap<String, FactModelTree> hiddenFieldsMap);
-
-        void setInstanceFieldsMap(SortedMap<String, FactModelTree> factTypeFieldsMap);
-
-        void hideProperties(Map<String, List<List<String>>> propertiesToHide);
-
-        void setSimpleJavaInstanceFieldsMap(SortedMap<String, FactModelTree> factTypeFieldsMap);
-
         /**
          * Method to hide all the <b>instance-related</b> html
          */
         void hideInstances();
 
         void setEventBus(EventBus eventBus);
-
-        void setGridWidget(GridWidget gridWidget);
 
         void showInstanceListContainerSeparator(boolean show);
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategyTest.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -141,9 +140,7 @@ public class AbstractDMNDataManagementStrategyTest extends AbstractScenarioSimul
         abstractDMNDataManagementStrategySpy.getSuccessCallbackMethod(factModelTupleLocal, testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
         verify(abstractDMNDataManagementStrategySpy, times(1)).getPropertiesToHide(eq(scenarioGridModelMock));
         verify(abstractDMNDataManagementStrategySpy, times(1)).storeData(eq(factModelTupleLocal), eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
+        verify(abstractDMNDataManagementStrategySpy, times(1)).showErrorsAndCleanupState(eq(factModelTupleLocal));
         assertEquals(factModelTupleLocal, factModelTreeHolderlocal.getFactModelTuple());
-        verify(testToolsPresenterMock, times(1)).setDataObjectFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setSimpleJavaTypeFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setHiddenFieldsMap(eq(hiddenFactsLocal));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
@@ -30,6 +30,7 @@ import org.drools.workbench.screens.scenariosimulation.client.TestProperties;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.editor.AbstractScenarioSimulationEditorTest;
 import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
+import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenterData;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsView;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridColumn;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModelContent;
@@ -38,6 +39,8 @@ import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.Fact
 import org.jgroups.util.Util;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.uberfire.backend.vfs.ObservablePath;
 
 import static org.junit.Assert.assertEquals;
@@ -57,6 +60,9 @@ import static org.mockito.Mockito.verify;
 public class AbstractDataManagementStrategyTest extends AbstractScenarioSimulationEditorTest {
 
     protected AbstractDataManagementStrategy abstractDataManagementStrategySpy;
+
+    @Captor
+    ArgumentCaptor<TestToolsPresenterData> testToolsPresenterDataArgumentCaptor;
 
     public void setup() {
         super.setup();
@@ -141,12 +147,15 @@ public class AbstractDataManagementStrategyTest extends AbstractScenarioSimulati
         doReturn(simulationMock).when(scenarioSimulationContextSpy).getAbstractScesimModelByGridWidget(GridWidget.SIMULATION);
         final FactModelTuple factModelTuple = getFactTuple();
         abstractDataManagementStrategySpy.storeData(factModelTuple, testToolsPresenterMock, scenarioSimulationContextSpy, GridWidget.SIMULATION);
-        verify(testToolsPresenterMock, times(1)).setDataObjectFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setSimpleJavaTypeFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setInstanceFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setSimpleJavaInstanceFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setHiddenFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).hideProperties(isA(Map.class));
+        verify(testToolsPresenterMock, times(1)).populateTestTools(testToolsPresenterDataArgumentCaptor.capture());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getDataObjectFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getHiddenFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getInstanceFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getPropertiesToHide());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getSimpleJavaInstanceFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getSimpleJavaTypeFieldsMap());
+        assertEquals(GridWidget.SIMULATION, testToolsPresenterDataArgumentCaptor.getValue().getGridWidget());
         verify(scenarioSimulationContextSpy, times(1)).setDataObjectFieldsMap(isA(SortedMap.class));
         verify(scenarioSimulationContextSpy, times(1)).setDataObjectsInstancesName(isA(Set.class));
         verify(scenarioGridModelMock, times(1)).setSimpleJavaTypeInstancesName(isA(Set.class));
@@ -158,12 +167,15 @@ public class AbstractDataManagementStrategyTest extends AbstractScenarioSimulati
         doReturn(backgroundMock).when(scenarioSimulationContextSpy).getAbstractScesimModelByGridWidget(GridWidget.BACKGROUND);
         final FactModelTuple factModelTuple = getFactTuple();
         abstractDataManagementStrategySpy.storeData(factModelTuple, testToolsPresenterMock, scenarioSimulationContextSpy, GridWidget.BACKGROUND);
-        verify(testToolsPresenterMock, times(1)).setDataObjectFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setSimpleJavaTypeFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setInstanceFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setSimpleJavaInstanceFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).setHiddenFieldsMap(isA(SortedMap.class));
-        verify(testToolsPresenterMock, times(1)).hideProperties(isA(Map.class));
+        verify(testToolsPresenterMock, times(1)).populateTestTools(testToolsPresenterDataArgumentCaptor.capture());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getDataObjectFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getHiddenFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getInstanceFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getPropertiesToHide());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getSimpleJavaInstanceFieldsMap());
+        assertNotNull(testToolsPresenterDataArgumentCaptor.getValue().getSimpleJavaTypeFieldsMap());
+        assertEquals(GridWidget.BACKGROUND, testToolsPresenterDataArgumentCaptor.getValue().getGridWidget());
         verify(scenarioSimulationContextSpy, times(1)).setDataObjectFieldsMap(isA(SortedMap.class));
         verify(scenarioSimulationContextSpy, never()).setDataObjectsInstancesName(isA(Set.class));
         verify(backgroundGridModelMock, never()).setSimpleJavaTypeInstancesName(isA(Set.class));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -225,13 +225,14 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
     @Test
     public void setGridWidgetSIMULATION() {
         testToolsPresenterSpy.setGridWidget(GridWidget.SIMULATION);
-        verify(testToolsPresenterSpy, times(1)).showInstanceListContainerSeparator(eq(true));
+        verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, never()).hideInstances();
     }
 
     @Test
     public void setGridWidgetBACKGROUND() {
         testToolsPresenterSpy.setGridWidget(GridWidget.BACKGROUND);
+        verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, times(1)).hideInstances();
         verify(testToolsPresenterSpy, never()).showInstanceListContainerSeparator(eq(true));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -234,7 +234,6 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
         testToolsPresenterSpy.setGridWidget(GridWidget.BACKGROUND);
         verify(testToolsPresenterSpy, times(1)).onDisableEditorTab();
         verify(testToolsPresenterSpy, times(1)).hideInstances();
-        verify(testToolsPresenterSpy, never()).showInstanceListContainerSeparator(eq(true));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -20,7 +20,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -214,6 +217,32 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
     public void onShowClearButton() {
         testToolsPresenterSpy.onShowClearButton();
         verify(testToolsViewMock, times(1)).showClearButton();
+    }
+
+    @Test
+    public void populateTestTools() {
+
+        SortedMap<String, FactModelTree> dataObjects = new TreeMap<>();
+        SortedMap<String, FactModelTree> simpleJava = new TreeMap<>();
+        SortedMap<String, FactModelTree> instanceField = new TreeMap<>();
+        SortedMap<String, FactModelTree> simpleJavaInstance = new TreeMap<>();
+        SortedMap<String, FactModelTree> hiddenFields = new TreeMap<>();
+        Map<String, List<List<String>>> hideProperties = new HashMap<>();
+        TestToolsPresenterData data = new TestToolsPresenterData(dataObjects,
+                                                                 simpleJava,
+                                                                 instanceField,
+                                                                 simpleJavaInstance,
+                                                                 hiddenFields,
+                                                                 hideProperties,
+                                                                 GridWidget.SIMULATION);
+        testToolsPresenterSpy.populateTestTools(data);
+        verify(testToolsPresenterSpy, times(1)).setDataObjectFieldsMap(eq(dataObjects));
+        verify(testToolsPresenterSpy, times(1)).setSimpleJavaTypeFieldsMap(eq(simpleJava));
+        verify(testToolsPresenterSpy, times(1)).setInstanceFieldsMap(eq(instanceField));
+        verify(testToolsPresenterSpy, times(1)).setSimpleJavaInstanceFieldsMap(eq(simpleJavaInstance));
+        verify(testToolsPresenterSpy, times(1)).setHiddenFieldsMap(eq(hiddenFields));
+        verify(testToolsPresenterSpy, times(1)).hideProperties(eq(hideProperties));
+        verify(testToolsPresenterSpy, times(1)).setGridWidget(eq(GridWidget.SIMULATION));
     }
 
     @Test


### PR DESCRIPTION
@dupliaka @gitgabrio @danielezonca can you please test and review it?

Technical refactoring, no changes on existing functionalities. The aim is to unify the TestTools data population in a single method.

https://issues.jboss.org/browse/DROOLS-4827