### PR TITLE
DROOLS-3957: Remove unused dependencies

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
@@ -73,10 +73,6 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-html5</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
During https://github.com/kiegroup/drools-wb/pull/1201 review I found these unused dependencies.