### PR TITLE
DROOLS-4876: GDST: Aliases only work for Strings

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/utilities/ColumnUtilities.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/utilities/ColumnUtilities.java
@@ -145,13 +145,22 @@ public class ColumnUtilities
 
         final String[] values = ListSplitter.split("'", true, valueList);
 
-        return Stream.of(values).filter(value -> isValueValidForType(value,
+        return Stream.of(values).filter(value -> isValueValidForType(parseActualValue(value),
                                                                      convertToTypeSafeType(fieldType)))
                 .toArray(String[]::new);
     }
 
+    private String parseActualValue(final String value) {
+        if (value != null && value.indexOf("=") > 0) {
+            return value.substring(0, value.indexOf("="));
+        } else {
+            return value;
+        }
+    }
+
     private boolean isValueValidForType(String value,
                                         DataType.DataTypes type) {
+
         switch (type) {
             case STRING:
                 return true;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/utilities/ColumnUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/utilities/ColumnUtilitiesTest.java
@@ -147,6 +147,32 @@ public class ColumnUtilitiesTest {
     }
 
     @Test
+    public void testIntegerAliases() {
+        column.setFactField(FIELD_NAME);
+        column.setFieldType(DataType.TYPE_NUMERIC_INTEGER);
+        column.setValueList("1=One,2=Two");
+        final String[] valueList = utilities.getValueList(column);
+        Assertions.assertThat(valueList).containsExactly("1=One", "2=Two");
+    }
+
+    @Test
+    public void testBooleanAliases() {
+        column.setFactField(FIELD_NAME);
+        column.setFieldType(DataType.TYPE_BOOLEAN);
+        column.setValueList("true=Yes,false=No");
+        final String[] valueList = utilities.getValueList(column);
+        Assertions.assertThat(valueList).containsExactly("true=Yes", "false=No");
+    }
+
+    @Test
+    public void testBooleanAliasesInvalidValues() {
+        column.setFactField(FIELD_NAME);
+        column.setFieldType(DataType.TYPE_BOOLEAN);
+        column.setValueList("yes=Yes, no=No");
+        Assertions.assertThat(utilities.getValueList(column)).isEmpty();
+    }
+
+    @Test
     public void testGetValueSetFieldColumn() throws Exception {
         pattern.setFactType(FACT_TYPE);
         pattern.setBoundName("$a");


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-4876

The `isValueValidForType `tests with cast if the value is boolean, interger or anything, but String. For String everything goes. This change trims the checked value from the first = character. This means only the actual value is checked and not the alias.