### PR TITLE
RHDM-1198: Change use date settings don't be persisted on Test Scenario Legacy

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/page/settings/ExecutionWidget.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/page/settings/ExecutionWidget.java
@@ -16,10 +16,13 @@
 
 package org.drools.workbench.screens.testscenario.client.page.settings;
 
+import java.util.Optional;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import org.drools.workbench.models.testscenarios.shared.ExecutionTrace;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
@@ -48,14 +51,10 @@ public class ExecutionWidget extends HorizontalPanel {
         dateConfigurationChoice.addItem(TestScenarioConstants.INSTANCE.UseRealDateAndTime());
         dateConfigurationChoice.addItem(TestScenarioConstants.INSTANCE.UseASimulatedDateAndTime());
         dateConfigurationChoice.setSelectedIndex(0);
-        dateConfigurationChoice.addChangeHandler(event -> {
-            if (dateConfigurationChoice.getSelectedIndex() == 0) {
-                dateTimePicker.setValue(null);
-            }
-        });
+        dateConfigurationChoice.addChangeHandler(getChangeHandler());
 
         dateTimePicker.setFormat("yyyy-MM-dd HH:mm");
-        dateTimePicker.addValueChangeHandler(event -> executionTrace.setScenarioSimulatedDate(event.getValue()));
+        dateTimePicker.addValueChangeHandler(event -> getExecutionTrace().ifPresent(e -> e.setScenarioSimulatedDate(event.getValue())));
 
         add(dateConfigurationChoice);
         add(dateTimePicker);
@@ -73,5 +72,18 @@ public class ExecutionWidget extends HorizontalPanel {
             dateTimePicker.setValue(null);
             dateConfigurationChoice.setSelectedIndex(0);
         }
+    }
+
+    ChangeHandler getChangeHandler() {
+        return event -> {
+            if (dateConfigurationChoice.getSelectedIndex() == 0) {
+                dateTimePicker.setValue(null);
+                getExecutionTrace().ifPresent(e -> e.setScenarioSimulatedDate(null));
+            }
+        };
+    }
+
+    Optional<ExecutionTrace> getExecutionTrace() {
+        return Optional.ofNullable(executionTrace);
     }
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/page/settings/ExecutionWidgetTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/page/settings/ExecutionWidgetTest.java
@@ -17,7 +17,10 @@
 package org.drools.workbench.screens.testscenario.client.page.settings;
 
 import java.util.Date;
+import java.util.Optional;
 
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.models.testscenarios.shared.ExecutionTrace;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
@@ -28,6 +31,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,23 +54,29 @@ public class ExecutionWidgetTest {
     private ExecutionWidget executionWidget;
 
     @Before
-    public void setUp() throws Exception {
-        executionWidget = new ExecutionWidget(dateTimePicker, dateConfigurationChoices);
+    public void setUp() {
+        executionWidget = spy(new ExecutionWidget(dateTimePicker, dateConfigurationChoices));
     }
 
     @Test
-    public void testSetup() throws Exception {
+    public void testSetup() {
+
+        final ChangeHandler changeHandler = mock(ChangeHandler.class);
+
+        doReturn(changeHandler).when(executionWidget).getChangeHandler();
+
         executionWidget.setup();
 
         verify(dateConfigurationChoices).addItem(TestScenarioConstants.INSTANCE.UseRealDateAndTime());
         verify(dateConfigurationChoices).addItem(TestScenarioConstants.INSTANCE.UseASimulatedDateAndTime());
         verify(dateConfigurationChoices).setSelectedIndex(0);
+        verify(dateConfigurationChoices).addChangeHandler(changeHandler);
 
         verify(dateTimePicker).setFormat("yyyy-MM-dd HH:mm");
     }
 
-    @Test()
-    public void testShowTimePickerNotUsedBefore() throws Exception {
+    @Test
+    public void testShowTimePickerNotUsedBefore() {
         when(executionTrace.getScenarioSimulatedDate()).thenReturn(null);
 
         executionWidget.show(executionTrace);
@@ -71,8 +85,8 @@ public class ExecutionWidgetTest {
         verify(dateTimePicker).setValue(null);
     }
 
-    @Test()
-    public void testShowTimePickerUsedBefore() throws Exception {
+    @Test
+    public void testShowTimePickerUsedBefore() {
         final Date date = new Date();
         when(executionTrace.getScenarioSimulatedDate()).thenReturn(date);
 
@@ -80,5 +94,33 @@ public class ExecutionWidgetTest {
 
         verify(dateConfigurationChoices).setSelectedIndex(1);
         verify(dateTimePicker).setValue(date);
+    }
+
+    @Test
+    public void testGetChangeHandlerWhenSelectedIndexIsZero() {
+
+        final ChangeEvent changeEvent = mock(ChangeEvent.class);
+
+        doReturn(Optional.of(executionTrace)).when(executionWidget).getExecutionTrace();
+        when(dateConfigurationChoices.getSelectedIndex()).thenReturn(0);
+
+        executionWidget.getChangeHandler().onChange(changeEvent);
+
+        verify(dateTimePicker).setValue(null);
+        verify(executionTrace).setScenarioSimulatedDate(null);
+    }
+
+    @Test
+    public void testGetChangeHandlerWhenSelectedIndexIsNotZero() {
+
+        final ChangeEvent changeEvent = mock(ChangeEvent.class);
+
+        doReturn(Optional.of(executionTrace)).when(executionWidget).getExecutionTrace();
+        when(dateConfigurationChoices.getSelectedIndex()).thenReturn(1);
+
+        executionWidget.getChangeHandler().onChange(changeEvent);
+
+        verify(dateTimePicker, never()).setValue(any());
+        verify(executionTrace, never()).setScenarioSimulatedDate(any());
     }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/RHDM-1198

Before:
![before](https://user-images.githubusercontent.com/1079279/72736453-7d285480-3b7c-11ea-8fcb-ab670dba7597.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/72736459-7f8aae80-3b7c-11ea-8b04-9246a5539bae.gif)
