### PR TITLE
Reverting drools-wb-dtable-xls-editor-backend dependency cleanup

### DIFF
--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
@@ -171,6 +171,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.screens</groupId>
+      <artifactId>kie-wb-common-data-modeller-backend</artifactId>
+      <!-- Dependency for DecisionTableXLSServiceImplCDITest -->
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-decisiontables</artifactId>
       <exclusions>


### PR DESCRIPTION
This PR reverts changes of https://github.com/kiegroup/drools-wb/pull/1287
The given dependency is used by DecisionTableXLSServiceImplCDITest