### PR TITLE
Avoid to skip test execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,15 +350,6 @@
                 <skip>true</skip>
               </configuration>
             </plugin>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <jacoco-agent.destfile>${jacoco.exec.file}</jacoco-agent.destfile>
-                </systemPropertyVariables>
-                <skip>${code.coverage.disabled}</skip>
-              </configuration>
-                   </plugin>
           </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
@jomarko @rsynek 
There was a configuration in `drools-wb` to skip test execution if test coverage was not enabled for that module