### PR TITLE
DROOLS-4921: Scrollbars in collection editor popup do not work

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
@@ -1,5 +1,5 @@
 <div class="kie-dataTypesList-modal modal-wide" tabindex="-1" role="dialog" id="collectionEditor">
-    <div class="modal-dialog" style="width:100%" role="document" data-field="collectionEditorModalDialog">
+    <div class="modal-dialog" style="width:100%" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close" data-field="closeCollectionEditorButton">

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
@@ -30,7 +30,6 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.TextAreaElement;
 import com.google.gwt.dom.client.UListElement;
 import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.DomEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.FocusWidget;
@@ -164,7 +163,6 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
 
     public CollectionViewImpl() {
         setElement(collectionEditor);
-        addKeyDownHandler(DomEvent::stopPropagation);
     }
 
     /**
@@ -313,13 +311,11 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
     @EventHandler("createCollectionRadio")
     public void onCreateCollectionClick(ClickEvent clickEvent) {
         enableCreateCollectionContainer(true);
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("defineCollectionRadio")
     public void onDefineCollectionClick(ClickEvent clickEvent) {
         enableCreateCollectionContainer(false);
-        clickEvent.stopPropagation();
     }
 
     protected void enableCreateCollectionContainer(boolean toEnable) {
@@ -335,70 +331,34 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
         }
     }
 
-    @EventHandler("collectionEditor")
-    public void onCollectionEditorClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
-    }
-
-    @EventHandler("collectionEditorModalDialog")
-    public void onCollectionEditorModalDialogClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
-    }
-
-    @EventHandler("editorTitle")
-    public void onEditorTitleClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
-    }
-
-    @EventHandler("elementsContainer")
-    public void onElementsContainerClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
-    }
-
     @EventHandler("closeCollectionEditorButton")
     public void onCloseCollectionEditorButtonClick(ClickEvent clickEvent) {
         close();
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("cancelButton")
     public void onCancelButtonClick(ClickEvent clickEvent) {
         close();
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("removeButton")
     public void onRemoveButtonClick(ClickEvent clickEvent) {
         presenter.remove();
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("saveButton")
     public void onSaveButtonClick(ClickEvent clickEvent) {
         presenter.save();
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("addItemButton")
     public void onAddItemButton(ClickEvent clickEvent) {
         presenter.showEditingBox();
-        clickEvent.stopPropagation();
     }
 
     @EventHandler("faAngleRight")
     public void onFaAngleRightClick(ClickEvent clickEvent) {
         presenter.onToggleRowExpansion(isShown());
-        clickEvent.stopPropagation();
-    }
-
-    @EventHandler("propertyTitle")
-    public void onPropertyTitleClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
-    }
-
-    @EventHandler("addItemButtonContainer")
-    public void onAddItemButtonContainerClick(ClickEvent clickEvent) {
-        clickEvent.stopPropagation();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
@@ -72,9 +72,6 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
     @DataField("collectionEditor")
     protected DivElement collectionEditor = Document.get().createDivElement();
 
-    @DataField("collectionEditorModalDialog")
-    protected DivElement collectionEditorModalDialog = Document.get().createDivElement();
-
     @DataField("collectionEditorModalBody")
     protected DivElement collectionEditorModalBody = Document.get().createDivElement();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import org.drools.scenariosimulation.api.model.AbstractScesimData;
 import org.drools.scenariosimulation.api.model.AbstractScesimModel;
@@ -82,6 +84,10 @@ public class CollectionEditorSingletonDOMElementFactory extends BaseSingletonDOM
         this.widget.addDomHandler(event -> {event.stopPropagation();
                                             event.preventDefault();},
                                   ContextMenuEvent.getType());
+        this.widget.addDomHandler(ClickEvent::stopPropagation,
+                                  ClickEvent.getType());
+        this.widget.addDomHandler(KeyDownEvent::stopPropagation,
+                                  KeyDownEvent.getType());
         final AbstractScesimGridModel<? extends AbstractScesimModel, ? extends AbstractScesimData> model = ((ScenarioGrid) gridWidget).getModel();
         final GridData.SelectedCell selectedCellsOrigin = model.getSelectedCellsOrigin();
         final Optional<GridColumn<?>> selectedColumn = model.getColumns().stream()

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.MouseWheelEvent;
 import org.drools.scenariosimulation.api.model.AbstractScesimData;
 import org.drools.scenariosimulation.api.model.AbstractScesimModel;
 import org.drools.scenariosimulation.api.model.FactMapping;
@@ -74,6 +76,12 @@ public class CollectionEditorSingletonDOMElementFactory extends BaseSingletonDOM
             this.widget.close();
         }
         this.widget = createWidget();
+        /* Don't propagate MouseWheel and RightClick events to the Grid */
+        this.widget.addDomHandler(MouseWheelEvent::stopPropagation,
+                                  MouseWheelEvent.getType());
+        this.widget.addDomHandler(event -> {event.stopPropagation();
+                                            event.preventDefault();},
+                                  ContextMenuEvent.getType());
         final AbstractScesimGridModel<? extends AbstractScesimModel, ? extends AbstractScesimData> model = ((ScenarioGrid) gridWidget).getModel();
         final GridData.SelectedCell selectedCellsOrigin = model.getSelectedCellsOrigin();
         final Optional<GridColumn<?>> selectedColumn = model.getColumns().stream()

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImplTest.java
@@ -181,35 +181,30 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
     public void onCloseCollectionEditorButtonClick() {
         collectionEditorViewImplSpy.onCloseCollectionEditorButtonClick(clickEventMock);
         verify(collectionEditorViewImplSpy, times(1)).fireEvent(isA(CloseCompositeEvent.class));
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test
     public void onCancelButtonClick() {
         collectionEditorViewImplSpy.onCancelButtonClick(clickEventMock);
         verify(collectionEditorViewImplSpy, times(1)).close();
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test
     public void onRemoveButtonClick() {
         collectionEditorViewImplSpy.onRemoveButtonClick(clickEventMock);
         verify(collectionPresenterMock, times(1)).remove();
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test
     public void onSaveButtonClick() {
         collectionEditorViewImplSpy.onSaveButtonClick(clickEventMock);
         verify(collectionPresenterMock, times(1)).save();
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test
     public void onAddItemButton() {
         collectionEditorViewImplSpy.onAddItemButton(clickEventMock);
         verify(collectionPresenterMock, times(1)).showEditingBox();
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test
@@ -217,13 +212,11 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
         doReturn(true).when(collectionEditorViewImplSpy).isShown();
         collectionEditorViewImplSpy.onFaAngleRightClick(clickEventMock);
         verify(collectionPresenterMock, times(1)).onToggleRowExpansion(eq(true));
-        verify(clickEventMock, times(1)).stopPropagation();
         reset(collectionPresenterMock);
         reset(clickEventMock);
         doReturn(false).when(collectionEditorViewImplSpy).isShown();
         collectionEditorViewImplSpy.onFaAngleRightClick(clickEventMock);
         verify(collectionPresenterMock, times(1)).onToggleRowExpansion(eq(false));
-        verify(clickEventMock, times(1)).stopPropagation();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
@@ -21,6 +21,10 @@ import java.util.Map;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.event.dom.client.ContextMenuEvent;
+import com.google.gwt.event.dom.client.ContextMenuHandler;
+import com.google.gwt.event.dom.client.MouseWheelEvent;
+import com.google.gwt.event.dom.client.MouseWheelHandler;
 import org.drools.scenariosimulation.api.model.ScenarioSimulationModel;
 import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
 import org.drools.workbench.screens.scenariosimulation.client.collectioneditor.CollectionPresenter;
@@ -33,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type.DMN;
 import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type.RULE;
@@ -96,14 +101,15 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
         });
 
         this.collectionEditorSingletonDOMElementFactorySpy = spy(new CollectionEditorSingletonDOMElementFactory(scenarioGridPanelMock,
-                                                                                                                 scenarioGridLayerMock,
-                                                                                                                 scenarioGridMock,
-                                                                                                                 scenarioSimulationContextLocal,
-                                                                                                                 viewsProviderMock));
+                                                                                                                scenarioGridLayerMock,
+                                                                                                                scenarioGridMock,
+                                                                                                                scenarioSimulationContextLocal,
+                                                                                                                viewsProviderMock));
         factMappingMock.getGenericTypes().add(STRING_CLASS_NAME);
         factMappingMock.getGenericTypes().add(NUMBER_CLASS_NAME);
         when(factMappingMock.getFactAlias()).thenReturn(FULL_CLASS_NAME);
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get(any())).thenReturn(factModelTreeMock);
+        when(collectionEditorSingletonDOMElementFactorySpy.createWidget()).thenReturn(collectionEditorViewImpl);
         /* This FactModelTree is used to test setCollectionEditorStructureData() method (return null in any case) */
         when(factModelTreeMock.getSimpleProperties()).thenReturn(new HashMap<>());
         when(factModelTreeMock.getExpandableProperties()).thenReturn(new HashMap<>());
@@ -122,6 +128,16 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
         when(factModelTreeMock3.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2);
         when(factModelTreeMock3.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3);
         EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3.put("a", FULL_CLASS_NAME);
+    }
+
+    @Test
+    public void createDomElement() {
+        when(scenarioGridModelMock.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        when(factMappingMock.getExpressionAlias()).thenReturn(MAP_CLASS_NAME);
+        when(factMappingMock.getClassName()).thenReturn(MAP_CLASS_NAME);
+        collectionEditorSingletonDOMElementFactorySpy.createDomElement(scenarioGridLayerMock, scenarioGridMock);
+        verify(collectionEditorViewImpl, times(1)).addDomHandler(isA(MouseWheelHandler.class), eq(MouseWheelEvent.getType()));
+        verify(collectionEditorViewImpl, times(1)).addDomHandler(isA(ContextMenuHandler.class), eq(ContextMenuEvent.getType()));
     }
 
     @Test


### PR DESCRIPTION
@jomarko @danielezonca 
I simply stopped to propagate the `MouseWheelEvent` on `CollectionEditorSingletonDOMElementFactory`.
I apply the same fix for `ContextMenuEvent` (RightClick), this avoid to select the grid and to open the context menu (current behavior in master) when right-clicking on collection editor popup.

https://issues.redhat.com/browse/DROOLS-4921