### PR TITLE
[DROOLS-4920] Removed outdated validation check

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidation.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidation.java
@@ -37,7 +37,6 @@ import static org.drools.workbench.screens.scenariosimulation.backend.server.uti
 import static org.drools.workbench.screens.scenariosimulation.model.FactMappingValidationError.createFieldChangedError;
 import static org.drools.workbench.screens.scenariosimulation.model.FactMappingValidationError.createGenericError;
 import static org.drools.workbench.screens.scenariosimulation.model.FactMappingValidationError.createNodeChangedError;
-import static org.kie.dmn.feel.lang.types.BuiltInType.CONTEXT;
 import static org.kie.dmn.feel.lang.types.BuiltInType.UNKNOWN;
 
 public class DMNScenarioValidation extends AbstractScenarioValidation {
@@ -81,14 +80,6 @@ public class DMNScenarioValidation extends AbstractScenarioValidation {
             }
 
             List<String> steps = expressionElementToString(factMapping);
-
-            // error if direct mapping (= simple type) but it is a composite
-            // NOTE: context is a special case so it is composite even if no fields are declared
-            Type rootType = getRootType((BaseDMNTypeImpl) rootDMNType);
-            if (!CONTEXT.equals(rootType) && steps.isEmpty() && rootDMNType.isComposite()) {
-                errors.add(createNodeChangedError(factMapping, rootDMNType.getName()));
-                continue;
-            }
 
             try {
                 DMNType fieldType = navigateDMNType(rootDMNType, steps);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidationTest.java
@@ -170,19 +170,7 @@ public class DMNScenarioValidationTest {
         List<FactMappingValidationError> errorsTest3 = validationSpy.validate(test3, settingsLocal, null);
         checkResult(errorsTest3);
 
-        // Test 4 - complex type changed
-        Simulation test4 = new Simulation();
-        FactMapping factMappingChanged = test4.getScesimModelDescriptor().addFactMapping(
-                FactIdentifier.create("mySimpleType", "tMYSIMPLETYPE"),
-                ExpressionIdentifier.create(VALUE, FactMappingType.GIVEN));
-        factMappingChanged.addExpressionElement("tMYSIMPLETYPE", "tMYSIMPLETYPE");
-
-        createDMNType("mySimpleType", "mySimpleType", "name");
-
-        List<FactMappingValidationError> errorsTest4 = validationSpy.validate(test4, settingsLocal, null);
-        checkResult(errorsTest4, "Node type has changed: old 'tMYSIMPLETYPE', current 'tMYSIMPLETYPE'");
-
-        // Test 5 - not existing node
+        // Test 4 - not existing node
         Simulation test5 = new Simulation();
         FactMapping factMappingNodeRemoved = test5.getScesimModelDescriptor().addFactMapping(
                 FactIdentifier.create("mySimpleType", "tMYSIMPLETYPE"),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidationTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNScenarioValidationTest.java
@@ -171,15 +171,15 @@ public class DMNScenarioValidationTest {
         checkResult(errorsTest3);
 
         // Test 4 - not existing node
-        Simulation test5 = new Simulation();
-        FactMapping factMappingNodeRemoved = test5.getScesimModelDescriptor().addFactMapping(
+        Simulation test4 = new Simulation();
+        FactMapping factMappingNodeRemoved = test4.getScesimModelDescriptor().addFactMapping(
                 FactIdentifier.create("mySimpleType", "tMYSIMPLETYPE"),
                 ExpressionIdentifier.create(VALUE, FactMappingType.GIVEN));
         factMappingNodeRemoved.addExpressionElement("tMYSIMPLETYPE", "tMYSIMPLETYPE");
 
         when(dmnModelMock.getDecisionByName(anyString())).thenReturn(null);
-        List<FactMappingValidationError> errorsTest5 = validationSpy.validate(test5, settingsLocal, null);
-        checkResult(errorsTest5, "Node type has changed: old 'tMYSIMPLETYPE', current 'node not found'");
+        List<FactMappingValidationError> errorsTest4 = validationSpy.validate(test4, settingsLocal, null);
+        checkResult(errorsTest4, "Node type has changed: old 'tMYSIMPLETYPE', current 'node not found'");
     }
 
     private void checkResult(List<FactMappingValidationError> validationErrors, String... expectedErrors) {


### PR DESCRIPTION
This PR removes a wrong validation check: top level collections were not supported by Test Scenario in the past but after the implementation of the support this check has not been properly updated.
Checking this ticket I have realized that other conditions of validation are not properly covered yet so I have created [this ticket](https://issues.redhat.com/browse/DROOLS-4988). I prefer in this PR to only fix the misleading error message

@yesamer @jomarko 

https://issues.redhat.com/browse/DROOLS-4920