### PR TITLE
DROOLS-4969: Fixed broken tests after merge of DROOLS-4969

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractDMNTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractDMNTest.java
@@ -210,8 +210,7 @@ public class AbstractDMNTest {
      */
     protected CompositeTypeImpl getCompositeCollection() {
         // Complex object retrieve
-        CompositeTypeImpl toReturn = new CompositeTypeImpl("compositeNameSpace", COMPOSITE_TYPE_NAME, null);
-        toReturn.setCollection(true);
+        CompositeTypeImpl toReturn = new CompositeTypeImpl("compositeNameSpace", COMPOSITE_TYPE_NAME, null, true);
         CompositeTypeImpl phoneNumberCompositeCollection = getPhoneNumberComposite(true);
 
         CompositeTypeImpl detailsComposite = new CompositeTypeImpl(null, "tDetails", "tDetails");


### PR DESCRIPTION
@danielezonca @jomarko @tarilabs 
Considering the changes https://github.com/kiegroup/drools/pull/2741, `isCollection` boolean must be passed to the constructor of `CompositeTypeImpl`, because it's now used to determine the object behavior. Using `setCollection()` method leads to the issue. (It should be handled or, even better, removed)