### PR TITLE
KOGITO-1566: [SCESIM Editor] DMN Type with nested objects doesn’t works correctly

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/ClientDMNType.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/ClientDMNType.java
@@ -70,4 +70,8 @@ public class ClientDMNType {
     public BuiltInType getFeelType() {
         return feelType;
     }
+
+    public void setIsComposite(final boolean isComposite) {
+        this.composite = isComposite;
+    }
 }


### PR DESCRIPTION
It may be a little time expensive to test before [this other PR](https://github.com/kiegroup/drools-wb/pull/1333) get merged. You can cherry-pick the commit from this PR in [this branch](https://github.com/yesamer/drools-wb/tree/DROOLS-5038) if you want and use the scesim testing webapp.

The idea behind this change is:
1. Create all the DMN types in a recursive way ignoring its fields
2. Resolve the DMN types fields

Using this approach you solve [the issue reported in the JIRA](https://issues.redhat.com/browse/KOGITO-1566) and also the following situation:

tPerson [structure]
-name[string]
-address[tAdress]

tAddress[structure]
-street[String]
-country[tCountry]

tCountry
-name[String]
-president[tPerson]

Notice that tPerson has a tAddress which have a tCountry which have a tPerson and so on.
This PR handles this situation because it creates all types first and then populate the fields, which will work because in this point all types is already present.