### PR TITLE
DROOLS-5250 (ex KOGITO-1685): Wrong label name for multiple nested elements

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategy.java
@@ -190,11 +190,12 @@ public class DMNSimulationSettingsCreationStrategy implements SimulationSettings
                 if (previousSteps.isEmpty()) {
                     previousSteps.add(factModelTree.getFactName());
                 }
-                previousSteps.add(entry.getKey());
+                ArrayList<String> currentSteps = new ArrayList<>(previousSteps);
+                currentSteps.add(entry.getKey());
 
                 if (!alreadyVisited.contains(nestedModelTree.getFactName())) {
                     alreadyVisited.add(factModelTree.getFactName());
-                    internalAddToScenario(factMappingExtractor, nestedModelTree, previousSteps, hiddenValues, alreadyVisited);
+                    internalAddToScenario(factMappingExtractor, nestedModelTree, currentSteps, hiddenValues, alreadyVisited);
                 }
             }
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategyTest.java
@@ -182,6 +182,56 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
     }
 
     @Test
+    public void addToScenarioMultipleNested() {
+        FactMapping factMappingMock = mock(FactMapping.class);
+        DMNSimulationSettingsCreationStrategy.FactMappingExtractor factMappingExtractorMock = mock(DMNSimulationSettingsCreationStrategy.FactMappingExtractor.class);
+        when(factMappingExtractorMock.getFactMapping(any(), anyString(), any(), anyString())).thenReturn(factMappingMock);
+
+        Map<String, FactModelTree> hiddenFacts = new HashMap<>();
+
+        FactModelTree factModelTree = new FactModelTree("myFact", "", new HashMap<>(), Collections.emptyMap());
+        factModelTree.addExpandableProperty("nestedProperty", "tNested");
+        factModelTree.addExpandableProperty("nestedProperty2", "tNested2");
+
+        FactModelTree nested1 = new FactModelTree("tNested1", "", new HashMap<>(), Collections.emptyMap());
+        FactModelTree nested2 = new FactModelTree("tNested2", "", new HashMap<>(), Collections.emptyMap());
+        String propertyType = String.class.getCanonicalName();
+        String propertyName = "stingProperty";
+        nested1.addSimpleProperty(propertyName, propertyType);
+        String propertyType2 = Boolean.class.getCanonicalName();
+        String propertyName2 = "booleanProperty";
+        nested2.addSimpleProperty(propertyName2, propertyType2);
+
+        hiddenFacts.put("tNested", nested1);
+        hiddenFacts.put("tNested2", nested2);
+
+        dmnSimulationCreationStrategy.addFactMapping(factMappingExtractorMock,
+                                                     factModelTree,
+                                                     new ArrayList<>(),
+                                                     hiddenFacts);
+
+        verify(factMappingExtractorMock, times(1))
+                .getFactMapping(
+                        eq(nested1),
+                        eq(propertyName),
+                        eq(Arrays.asList("myFact", "nestedProperty")),
+                        eq(propertyType));
+        verify(factMappingExtractorMock, times(1))
+                .getFactMapping(
+                        eq(nested2),
+                        eq(propertyName2),
+                        eq(Arrays.asList("myFact", "nestedProperty2")),
+                        eq(propertyType2));
+
+        verify(factMappingExtractorMock, times(2))
+                .getFactMapping(
+                        any(),
+                        any(),
+                        any(),
+                        any());
+    }
+
+    @Test
     public void addEmptyColumnIfNeeded() {
         Simulation simulation = new Simulation();
         ScenarioWithIndex scenarioWithIndex = new ScenarioWithIndex(1, simulation.addData());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
@@ -359,7 +359,7 @@ public class KogitoScenarioSimulationBuilder {
         }
     }
 
-    private void addFactMapping(final FactMappingExtractor factMappingExtractor,
+    protected void addFactMapping(final FactMappingExtractor factMappingExtractor,
                                 final FactModelTree factModelTree,
                                 final List<String> previousSteps,
                                 final Map<String, FactModelTree> hiddenValues) {
@@ -416,7 +416,7 @@ public class KogitoScenarioSimulationBuilder {
         }
     }
 
-    private static class FactMappingExtractor {
+    protected static class FactMappingExtractor {
 
         private final FactIdentifier factIdentifier;
         private final int row;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
@@ -360,9 +360,9 @@ public class KogitoScenarioSimulationBuilder {
     }
 
     protected void addFactMapping(final FactMappingExtractor factMappingExtractor,
-                                final FactModelTree factModelTree,
-                                final List<String> previousSteps,
-                                final Map<String, FactModelTree> hiddenValues) {
+                                  final FactModelTree factModelTree,
+                                  final List<String> previousSteps,
+                                  final Map<String, FactModelTree> hiddenValues) {
         internalAddToScenario(factMappingExtractor,
                               factModelTree,
                               previousSteps,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
@@ -404,11 +404,13 @@ public class KogitoScenarioSimulationBuilder {
                 if (previousSteps.isEmpty()) {
                     previousSteps.add(factModelTree.getFactName());
                 }
-                previousSteps.add(entry.getKey());
+
+                ArrayList<String> currentSteps = new ArrayList<>(previousSteps);
+                currentSteps.add(entry.getKey());
 
                 if (!alreadyVisited.contains(nestedModelTree.getFactName())) {
                     alreadyVisited.add(factModelTree.getFactName());
-                    internalAddToScenario(factMappingExtractor, nestedModelTree, previousSteps, hiddenValues, alreadyVisited);
+                    internalAddToScenario(factMappingExtractor, nestedModelTree, currentSteps, hiddenValues, alreadyVisited);
                 }
             }
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilderTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilderTest.java
@@ -15,15 +15,21 @@
  */
 package org.drools.workbench.screens.scenariosimulation.kogito.client.dmn;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.scenariosimulation.api.model.ExpressionIdentifier;
 import org.drools.scenariosimulation.api.model.FactIdentifier;
+import org.drools.scenariosimulation.api.model.FactMapping;
 import org.drools.scenariosimulation.api.model.FactMappingType;
 import org.drools.scenariosimulation.api.model.FactMappingValueType;
 import org.drools.scenariosimulation.api.model.ScesimModelDescriptor;
 import org.drools.scenariosimulation.api.model.Simulation;
+import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTuple;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +37,14 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class KogitoScenarioSimulationBuilderTest {
@@ -120,6 +133,92 @@ public class KogitoScenarioSimulationBuilderTest {
         assertEquals(114, KogitoScenarioSimulationBuilder.getColumnWidth(ExpressionIdentifier.NAME.Expected.toString()), 0);
         assertEquals(114, KogitoScenarioSimulationBuilder.getColumnWidth(ExpressionIdentifier.NAME.Given.toString()), 0);
         assertEquals(114, KogitoScenarioSimulationBuilder.getColumnWidth("test"), 0);
+    }
+
+    @Test
+    public void addToScenarioRecursive() {
+        FactMapping factMappingMock = mock(FactMapping.class);
+        KogitoScenarioSimulationBuilder.FactMappingExtractor factMappingExtractorMock = mock(KogitoScenarioSimulationBuilder.FactMappingExtractor.class);
+        when(factMappingExtractorMock.getFactMapping(any(), anyString(), any(), anyString())).thenReturn(factMappingMock);
+
+        Map<String, FactModelTree> hiddenFacts = new HashMap<>();
+
+        FactModelTree factModelTree = new FactModelTree("myFact", "", new HashMap<>(), Collections.emptyMap());
+        factModelTree.addExpandableProperty("recursiveProperty", "recursive");
+        String propertyType = String.class.getCanonicalName();
+        String propertyName = "simpleProperty";
+        factModelTree.addSimpleProperty(propertyName, propertyType);
+
+        hiddenFacts.put("recursive", factModelTree);
+
+        kogitoScenarioSimulationBuilderSpy.addFactMapping(factMappingExtractorMock,
+                                                          factModelTree,
+                                                          new ArrayList<>(),
+                                                          hiddenFacts);
+
+        verify(factMappingExtractorMock, times(1))
+                .getFactMapping(
+                        eq(factModelTree),
+                        eq(propertyName),
+                        eq(Arrays.asList("myFact", "recursiveProperty")),
+                        eq(propertyType));
+
+        verify(factMappingExtractorMock, times(2))
+                .getFactMapping(
+                        any(),
+                        any(),
+                        any(),
+                        any());
+    }
+
+    @Test
+    public void addToScenarioMultipleNested() {
+        FactMapping factMappingMock = mock(FactMapping.class);
+        KogitoScenarioSimulationBuilder.FactMappingExtractor factMappingExtractorMock = mock(KogitoScenarioSimulationBuilder.FactMappingExtractor.class);
+        when(factMappingExtractorMock.getFactMapping(any(), anyString(), any(), anyString())).thenReturn(factMappingMock);
+
+        Map<String, FactModelTree> hiddenFacts = new HashMap<>();
+
+        FactModelTree factModelTree = new FactModelTree("myFact", "", new HashMap<>(), Collections.emptyMap());
+        factModelTree.addExpandableProperty("nestedProperty", "tNested");
+        factModelTree.addExpandableProperty("nestedProperty2", "tNested2");
+
+        FactModelTree nested1 = new FactModelTree("tNested1", "", new HashMap<>(), Collections.emptyMap());
+        FactModelTree nested2 = new FactModelTree("tNested2", "", new HashMap<>(), Collections.emptyMap());
+        String propertyType = String.class.getCanonicalName();
+        String propertyName = "stingProperty";
+        nested1.addSimpleProperty(propertyName, propertyType);
+        String propertyType2 = Boolean.class.getCanonicalName();
+        String propertyName2 = "booleanProperty";
+        nested2.addSimpleProperty(propertyName2, propertyType2);
+
+        hiddenFacts.put("tNested", nested1);
+        hiddenFacts.put("tNested2", nested2);
+
+        kogitoScenarioSimulationBuilderSpy.addFactMapping(factMappingExtractorMock,
+                                                          factModelTree,
+                                                          new ArrayList<>(),
+                                                          hiddenFacts);
+
+        verify(factMappingExtractorMock, times(1))
+                .getFactMapping(
+                        eq(nested1),
+                        eq(propertyName),
+                        eq(Arrays.asList("myFact", "nestedProperty")),
+                        eq(propertyType));
+        verify(factMappingExtractorMock, times(1))
+                .getFactMapping(
+                        eq(nested2),
+                        eq(propertyName2),
+                        eq(Arrays.asList("myFact", "nestedProperty2")),
+                        eq(propertyType2));
+
+        verify(factMappingExtractorMock, times(2))
+                .getFactMapping(
+                        any(),
+                        any(),
+                        any(),
+                        any());
     }
 
 }


### PR DESCRIPTION
@danielezonca @dupliaka Can you please review and test?

![](https://issues.redhat.com/secure/attachment/12469272/12469272_image-2020-04-03-11-47-11-708.png)

Basically, the label  of nested properties was wrong in the case of multiple nested element. 
This is because, multiple nested properties shared the same list used to determine the label and the `expressionElement` list. 
To solve the issue, I simply created a new list of previous step for any nested property.

The fix is applied for both KOGITO and BC. Considering they are not sharing this part of code (in BC is on server side), the fix is applied in 2 different points

https://issues.redhat.com/browse/DROOLS-5250