### PR TITLE
KOGITO-2000: Filter DMN files inside target/ directory

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
@@ -19,8 +19,6 @@
     <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
     <gwt.helper.includes>Client,Marshaller,KogitoEditor,WebappBase</gwt.helper.includes>
     <gwt.helper.rootDirectories>${project.parent.basedir}/</gwt.helper.rootDirectories>
-    <!-- Excluding the entire webapp and workarounds folders from coverage statistics. -->
-    <sonar.coverage.exclusions>webapp/**/*, workarounds/**.java</sonar.coverage.exclusions>
   </properties>
 
   <dependencies>
@@ -29,8 +27,6 @@
       <artifactId>log4j-over-slf4j</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- MANSTIS - EVERYTHING BELOW THIS HAS BEEN _SANITISED_! -->
 
     <!-- Errai -->
     <dependency>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/pom.xml
@@ -20,7 +20,7 @@
     <gwt.helper.includes>Client,Marshaller,KogitoEditor,WebappBase</gwt.helper.includes>
     <gwt.helper.rootDirectories>${project.parent.basedir}/</gwt.helper.rootDirectories>
     <!-- Excluding the entire webapp and workarounds folders from coverage statistics. -->
-    <sonar.coverage.exclusions>webapp/**/*, ,**/workarounds/**.java</sonar.coverage.exclusions>
+    <sonar.coverage.exclusions>webapp/**/*, workarounds/**.java</sonar.coverage.exclusions>
   </properties>
 
   <dependencies>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -34,7 +34,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 @Dependent
 public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl implements ScenarioSimulationKogitoCreationAssetsDropdownProvider {
 
-    protected static final String DMN_FILE_EXTENSION = "**/*.dmn";
+    protected static final String DMN_FILE_EXTENSION = "src/**/*.*dmn";
 
     @Inject
     protected KogitoResourceContentService resourceContentService;
@@ -52,18 +52,10 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
         return response -> {
             List<KieAssetsDropdownItem> toAccept = response.stream()
                     .map(this::getKieAssetsDropdownItem)
-                    .filter(this::filterTargetDirectory)
                     .sorted(Comparator.comparing(KieAssetsDropdownItem::getText, String.CASE_INSENSITIVE_ORDER))
                     .collect(Collectors.toList());
             assetListConsumer.accept(toAccept);
         };
-    }
-
-    protected boolean filterTargetDirectory(KieAssetsDropdownItem kieAssetsDropdownItem) {
-        String fullPath = kieAssetsDropdownItem.getValue().replaceAll("\\\\", "/");
-        int idx = fullPath.lastIndexOf('/');
-        final String pathString = idx >= 0 ? fullPath.substring(0, idx + 1) : "";
-        return !pathString.contains("target/");
     }
 
     protected ErrorCallback<Object> getErrorCallback() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -34,7 +34,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 @Dependent
 public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl implements ScenarioSimulationKogitoCreationAssetsDropdownProvider {
 
-    protected static final String DMN_FILE_EXTENSION = "src/**/*.*dmn";
+    protected static final String DMN_FILE_EXTENSION = "src/**/*.dmn";
 
     @Inject
     protected KogitoResourceContentService resourceContentService;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -52,10 +52,18 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
         return response -> {
             List<KieAssetsDropdownItem> toAccept = response.stream()
                     .map(this::getKieAssetsDropdownItem)
+                    .filter(this::filterTargetDirectory)
                     .sorted(Comparator.comparing(KieAssetsDropdownItem::getText, String.CASE_INSENSITIVE_ORDER))
                     .collect(Collectors.toList());
             assetListConsumer.accept(toAccept);
         };
+    }
+
+    protected boolean filterTargetDirectory(KieAssetsDropdownItem kieAssetsDropdownItem) {
+        String fullPath = kieAssetsDropdownItem.getValue().replaceAll("\\\\", "/");
+        int idx = fullPath.lastIndexOf('/');
+        final String pathString = idx >= 0 ? fullPath.substring(0, idx + 1) : "";
+        return !pathString.contains("target/");
     }
 
     protected ErrorCallback<Object> getErrorCallback() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -34,7 +34,7 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 @Dependent
 public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl implements ScenarioSimulationKogitoCreationAssetsDropdownProvider {
 
-    protected static final String DMN_FILE_EXTENSION = "src/**/*.dmn";
+    protected static final String DMN_FILE_SEARCH_PATTERN = "src/**/*.dmn";
 
     @Inject
     protected KogitoResourceContentService resourceContentService;
@@ -43,7 +43,7 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
 
     @Override
     public void getItems(Consumer<List<KieAssetsDropdownItem>> assetListConsumer) {
-        resourceContentService.getFilteredItems(DMN_FILE_EXTENSION,
+        resourceContentService.getFilteredItems(DMN_FILE_SEARCH_PATTERN,
                                                 getRemoteCallback(assetListConsumer),
                                                 getErrorCallback());
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -103,7 +103,7 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
     }
 
     @Test
-    public void getRemoteCallBackFilterTargetClassesDirectory() {
+    public void getRemoteCallBackFilterTargetDirectory() {
         RemoteCallback<List<String>> remoteCallBack = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getRemoteCallback(assetConsumer);
         remoteCallBack.callback(Arrays.asList("/test/project/target/classes/file1", "path/B", "target/file1", "a", "C:\\test\\project\\target\\classes\\file1"));
         verify(assetConsumer, times(1)).accept(dropDownListCaptor.capture());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -102,6 +102,19 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
                      dropDownListCaptor.getValue().stream().map(KieAssetsDropdownItem::getValue).collect(Collectors.toList()));
     }
 
+    @Test
+    public void getRemoteCallBackFilterTargetClassesDirectory() {
+        RemoteCallback<List<String>> remoteCallBack = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getRemoteCallback(assetConsumer);
+        remoteCallBack.callback(Arrays.asList("/test/project/target/classes/file1", "path/B", "target/file1", "a", "C:\\test\\project\\target\\classes\\file1"));
+        verify(assetConsumer, times(1)).accept(dropDownListCaptor.capture());
+        assertEquals(2, dropDownListCaptor.getValue().size());
+        assertEquals("a", dropDownListCaptor.getValue().get(0).getText());
+        assertEquals("a", dropDownListCaptor.getValue().get(0).getSubText());
+        assertEquals("a", dropDownListCaptor.getValue().get(0).getValue());
+        assertEquals("B", dropDownListCaptor.getValue().get(1).getText());
+        assertEquals("path/B", dropDownListCaptor.getValue().get(1).getSubText());
+        assertEquals("path/B", dropDownListCaptor.getValue().get(1).getValue());
+    }
 
     @Test
     public void getErrorCallback() {
@@ -167,4 +180,75 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
         assertEquals(fullPath, item.getSubText());
         assertEquals(fileName, item.getText());
     }
+
+    @Test
+    public void filterTargetDirectoryFileWithoutPath() {
+        String fullPath = "filename.etc";
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertTrue(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileWithLongPath() {
+        String path = "long/path/";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertTrue(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetDirectory() {
+        String path = "target/";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetClassesDirectory() {
+        String path = "target/classes/";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetClassesSubDirectory() {
+        String path = "target/classes/folder/";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetDirectoryWindows() {
+        String path = "C:\\target\\";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetClassesDirectoryWindows() {
+        String path = "C:\\target\\classes\\";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
+    @Test
+    public void filterTargetDirectoryFileInTargetClassesSubDirectoryWindows() {
+        String path = "C:\\target\\classes\\folder\\";
+        String fileName = "filename.etc";
+        String fullPath = path + fileName;
+        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
+        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
+    }
+
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -72,7 +72,7 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
     @Test
     public void getItems() {
         scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getItems(assetConsumer);
-        verify(kogitoResourceContentServiceMock, times(1)).getFilteredItems(eq(ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.DMN_FILE_EXTENSION),
+        verify(kogitoResourceContentServiceMock, times(1)).getFilteredItems(eq(ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.DMN_FILE_SEARCH_PATTERN),
                                                                                                  isA(RemoteCallback.class),
                                                                                                  isA(ErrorCallback.class));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -103,20 +103,6 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
     }
 
     @Test
-    public void getRemoteCallBackFilterTargetDirectory() {
-        RemoteCallback<List<String>> remoteCallBack = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getRemoteCallback(assetConsumer);
-        remoteCallBack.callback(Arrays.asList("/test/project/target/classes/file1", "path/B", "target/file1", "a", "C:\\test\\project\\target\\classes\\file1"));
-        verify(assetConsumer, times(1)).accept(dropDownListCaptor.capture());
-        assertEquals(2, dropDownListCaptor.getValue().size());
-        assertEquals("a", dropDownListCaptor.getValue().get(0).getText());
-        assertEquals("a", dropDownListCaptor.getValue().get(0).getSubText());
-        assertEquals("a", dropDownListCaptor.getValue().get(0).getValue());
-        assertEquals("B", dropDownListCaptor.getValue().get(1).getText());
-        assertEquals("path/B", dropDownListCaptor.getValue().get(1).getSubText());
-        assertEquals("path/B", dropDownListCaptor.getValue().get(1).getValue());
-    }
-
-    @Test
     public void getErrorCallback() {
         ErrorCallback<Object> errorCallback = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getErrorCallback();
         assertFalse(errorCallback.error("message", new Throwable("ex")));
@@ -180,75 +166,4 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
         assertEquals(fullPath, item.getSubText());
         assertEquals(fileName, item.getText());
     }
-
-    @Test
-    public void filterTargetDirectoryFileWithoutPath() {
-        String fullPath = "filename.etc";
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertTrue(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileWithLongPath() {
-        String path = "long/path/";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertTrue(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetDirectory() {
-        String path = "target/";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetClassesDirectory() {
-        String path = "target/classes/";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetClassesSubDirectory() {
-        String path = "target/classes/folder/";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetDirectoryWindows() {
-        String path = "C:\\target\\";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetClassesDirectoryWindows() {
-        String path = "C:\\target\\classes\\";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
-    @Test
-    public void filterTargetDirectoryFileInTargetClassesSubDirectoryWindows() {
-        String path = "C:\\target\\classes\\folder\\";
-        String fileName = "filename.etc";
-        String fullPath = path + fileName;
-        KieAssetsDropdownItem item = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getKieAssetsDropdownItem(fullPath);
-        assertFalse(scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.filterTargetDirectory(item));
-    }
-
 }


### PR DESCRIPTION
@danielezonca @dupliaka Can you please test and review it?

Added a filter which discard all dmn files inside a `target/` path (and subfolder level).

https://issues.redhat.com/browse/KOGITO-2000