### PR TITLE
DROOLS-5308: Not able to read number of times rule fire in Scenario Coverage Report if rule name is longer than 27 characters

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageElementViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageElementViewImpl.html
@@ -15,6 +15,7 @@
   ~ limitations under the License.
   -->
 <div>
-    <dt data-field="description" style="overflow:visible; text-overflow:clip; white-space:normal">Decision 1:</dt>
-    <dd data-field="numberOfTime">122</dd>
+    <!-- It inherits kie-coverage__dl-horizontal dt style -->
+    <dt data-field="description"></dt>
+    <dd data-field="numberOfTime"></dd>
 </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/resources/org/drools/workbench/screens/scenariosimulation/client/resources/css/ScenarioSimulationEditorStyles.css
@@ -193,6 +193,7 @@ span.kie-list-view-pf-main-info__text {
     text-overflow: clip;
     white-space: normal;
     text-align: inherit;
+    word-wrap: break-word;
 }
 
 .collection-editor-expression_textarea {


### PR DESCRIPTION
@danielezonca @dupliaka Can you please test and review it?

Added word-wrap: break-word; property to inherited css rule .kie-coverage__dl-horizontal dt

![Screenshot from 2020-05-07 12-11-29](https://user-images.githubusercontent.com/16005046/81286088-cdaabb80-9060-11ea-892e-66bbcd349b54.png)

https://issues.redhat.com/browse/DROOLS-5308
https://issues.redhat.com/browse/RHPAM-2925