### PR TITLE
DROOLS-5327: Fix guided rule template multiselect dropdown for numbers

### DIFF
--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
@@ -118,78 +118,11 @@ public class TemplateDataCellFactory
                                                                                  String dataType) {
         final boolean isSingleValueOperator = !OperatorsOracle.operatorRequiresList(operator);
 
-        if (dataType.equals(DataType.TYPE_NUMERIC) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
-                                                                                                                                    fieldName,
-                                                                                                                                    operator,
-                                                                                                                                    oracle,
-                                                                                                                                    dropDownManager,
-                                                                                                                                    isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGDECIMAL) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
-                                                                                                                                    fieldName,
-                                                                                                                                    operator,
-                                                                                                                                    oracle,
-                                                                                                                                    dropDownManager,
-                                                                                                                                    isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGINTEGER) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<BigInteger, BigInteger> pudd = new ProxyPopupNumericBigIntegerDropDownEditCell(factType,
-                                                                                                                                    fieldName,
-                                                                                                                                    operator,
-                                                                                                                                    oracle,
-                                                                                                                                    dropDownManager,
-                                                                                                                                    isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BYTE) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Byte, Byte> pudd = new ProxyPopupNumericByteDropDownEditCell(factType,
-                                                                                                                  fieldName,
-                                                                                                                  operator,
-                                                                                                                  oracle,
-                                                                                                                  dropDownManager,
-                                                                                                                  isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_DOUBLE) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Double, Double> pudd = new ProxyPopupNumericDoubleDropDownEditCell(factType,
-                                                                                                                        fieldName,
-                                                                                                                        operator,
-                                                                                                                        oracle,
-                                                                                                                        dropDownManager,
-                                                                                                                        isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_FLOAT) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Float, Float> pudd = new ProxyPopupNumericFloatDropDownEditCell(factType,
-                                                                                                                     fieldName,
-                                                                                                                     operator,
-                                                                                                                     oracle,
-                                                                                                                     dropDownManager,
-                                                                                                                     isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_INTEGER) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Integer, Integer> pudd = new ProxyPopupNumericIntegerDropDownEditCell(factType,
-                                                                                                                           fieldName,
-                                                                                                                           operator,
-                                                                                                                           oracle,
-                                                                                                                           dropDownManager,
-                                                                                                                           isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_LONG) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Long, Long> pudd = new ProxyPopupNumericLongDropDownEditCell(factType,
-                                                                                                                  fieldName,
-                                                                                                                  operator,
-                                                                                                                  oracle,
-                                                                                                                  dropDownManager,
-                                                                                                                  isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_SHORT) && isSingleValueOperator) {
-            final AbstractProxyPopupDropDownEditCell<Short, Short> pudd = new ProxyPopupNumericShortDropDownEditCell(factType,
-                                                                                                                     fieldName,
-                                                                                                                     operator,
-                                                                                                                     oracle,
-                                                                                                                     dropDownManager,
-                                                                                                                     isReadOnly);
-            return decoratedGridCellValueAdaptor(pudd);
+        if (DataType.isNumeric(dataType) && isSingleValueOperator) {
+            return makeNumericSelectionEnumCell(factType,
+                                         fieldName,
+                                         operator,
+                                         dataType);
         } else if (dataType.equals(DataType.TYPE_BOOLEAN) && isSingleValueOperator) {
             return makeBooleanCell();
         } else if (dataType.equals(DataType.TYPE_DATE) && isSingleValueOperator) {
@@ -209,6 +142,87 @@ public class TemplateDataCellFactory
                                                                                                                dropDownManager,
                                                                                                                isReadOnly);
             return decoratedGridCellValueAdaptor(pudd);
+        }
+    }
+
+    DecoratedGridCellValueAdaptor<? extends Comparable<?>> makeNumericSelectionEnumCell(String factType,
+                                                                                        String fieldName,
+                                                                                        String operator,
+                                                                                        String dataType) {
+        if (dataType.equals(DataType.TYPE_NUMERIC)) {
+            final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
+                                                                                                                                    fieldName,
+                                                                                                                                    operator,
+                                                                                                                                    oracle,
+                                                                                                                                    dropDownManager,
+                                                                                                                                    isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGDECIMAL)) {
+            final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
+                                                                                                                                    fieldName,
+                                                                                                                                    operator,
+                                                                                                                                    oracle,
+                                                                                                                                    dropDownManager,
+                                                                                                                                    isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGINTEGER)) {
+            final AbstractProxyPopupDropDownEditCell<BigInteger, BigInteger> pudd = new ProxyPopupNumericBigIntegerDropDownEditCell(factType,
+                                                                                                                                    fieldName,
+                                                                                                                                    operator,
+                                                                                                                                    oracle,
+                                                                                                                                    dropDownManager,
+                                                                                                                                    isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BYTE)) {
+            final AbstractProxyPopupDropDownEditCell<Byte, Byte> pudd = new ProxyPopupNumericByteDropDownEditCell(factType,
+                                                                                                                  fieldName,
+                                                                                                                  operator,
+                                                                                                                  oracle,
+                                                                                                                  dropDownManager,
+                                                                                                                  isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_DOUBLE)) {
+            final AbstractProxyPopupDropDownEditCell<Double, Double> pudd = new ProxyPopupNumericDoubleDropDownEditCell(factType,
+                                                                                                                        fieldName,
+                                                                                                                        operator,
+                                                                                                                        oracle,
+                                                                                                                        dropDownManager,
+                                                                                                                        isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_FLOAT)) {
+            final AbstractProxyPopupDropDownEditCell<Float, Float> pudd = new ProxyPopupNumericFloatDropDownEditCell(factType,
+                                                                                                                     fieldName,
+                                                                                                                     operator,
+                                                                                                                     oracle,
+                                                                                                                     dropDownManager,
+                                                                                                                     isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_INTEGER)) {
+            final AbstractProxyPopupDropDownEditCell<Integer, Integer> pudd = new ProxyPopupNumericIntegerDropDownEditCell(factType,
+                                                                                                                           fieldName,
+                                                                                                                           operator,
+                                                                                                                           oracle,
+                                                                                                                           dropDownManager,
+                                                                                                                           isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_LONG)) {
+            final AbstractProxyPopupDropDownEditCell<Long, Long> pudd = new ProxyPopupNumericLongDropDownEditCell(factType,
+                                                                                                                  fieldName,
+                                                                                                                  operator,
+                                                                                                                  oracle,
+                                                                                                                  dropDownManager,
+                                                                                                                  isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_SHORT)) {
+            final AbstractProxyPopupDropDownEditCell<Short, Short> pudd = new ProxyPopupNumericShortDropDownEditCell(factType,
+                                                                                                                     fieldName,
+                                                                                                                     operator,
+                                                                                                                     oracle,
+                                                                                                                     dropDownManager,
+                                                                                                                     isReadOnly);
+            return decoratedGridCellValueAdaptor(pudd);
+        } else {
+            throw new IllegalStateException("Unknown numeric data type: " + dataType);
         }
     }
 

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/main/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactory.java
@@ -116,91 +116,83 @@ public class TemplateDataCellFactory
                                                                                  String fieldName,
                                                                                  String operator,
                                                                                  String dataType) {
+        final boolean isSingleValueOperator = !OperatorsOracle.operatorRequiresList(operator);
 
-        if (dataType.equals(DataType.TYPE_NUMERIC)) {
+        if (dataType.equals(DataType.TYPE_NUMERIC) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
                                                                                                                                     fieldName,
                                                                                                                                     operator,
                                                                                                                                     oracle,
                                                                                                                                     dropDownManager,
                                                                                                                                     isReadOnly);
-            return new DecoratedGridCellValueAdaptor<BigDecimal>(pudd,
-                                                                 eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGDECIMAL)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGDECIMAL) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<BigDecimal, BigDecimal> pudd = new ProxyPopupNumericBigDecimalDropDownEditCell(factType,
                                                                                                                                     fieldName,
                                                                                                                                     operator,
                                                                                                                                     oracle,
                                                                                                                                     dropDownManager,
                                                                                                                                     isReadOnly);
-            return new DecoratedGridCellValueAdaptor<BigDecimal>(pudd,
-                                                                 eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGINTEGER)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BIGINTEGER) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<BigInteger, BigInteger> pudd = new ProxyPopupNumericBigIntegerDropDownEditCell(factType,
                                                                                                                                     fieldName,
                                                                                                                                     operator,
                                                                                                                                     oracle,
                                                                                                                                     dropDownManager,
                                                                                                                                     isReadOnly);
-            return new DecoratedGridCellValueAdaptor<BigInteger>(pudd,
-                                                                 eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_BYTE)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_BYTE) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Byte, Byte> pudd = new ProxyPopupNumericByteDropDownEditCell(factType,
                                                                                                                   fieldName,
                                                                                                                   operator,
                                                                                                                   oracle,
                                                                                                                   dropDownManager,
                                                                                                                   isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Byte>(pudd,
-                                                           eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_DOUBLE)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_DOUBLE) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Double, Double> pudd = new ProxyPopupNumericDoubleDropDownEditCell(factType,
                                                                                                                         fieldName,
                                                                                                                         operator,
                                                                                                                         oracle,
                                                                                                                         dropDownManager,
                                                                                                                         isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Double>(pudd,
-                                                             eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_FLOAT)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_FLOAT) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Float, Float> pudd = new ProxyPopupNumericFloatDropDownEditCell(factType,
                                                                                                                      fieldName,
                                                                                                                      operator,
                                                                                                                      oracle,
                                                                                                                      dropDownManager,
                                                                                                                      isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Float>(pudd,
-                                                            eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_INTEGER)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_INTEGER) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Integer, Integer> pudd = new ProxyPopupNumericIntegerDropDownEditCell(factType,
                                                                                                                            fieldName,
                                                                                                                            operator,
                                                                                                                            oracle,
                                                                                                                            dropDownManager,
                                                                                                                            isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Integer>(pudd,
-                                                              eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_LONG)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_LONG) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Long, Long> pudd = new ProxyPopupNumericLongDropDownEditCell(factType,
                                                                                                                   fieldName,
                                                                                                                   operator,
                                                                                                                   oracle,
                                                                                                                   dropDownManager,
                                                                                                                   isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Long>(pudd,
-                                                           eventBus);
-        } else if (dataType.equals(DataType.TYPE_NUMERIC_SHORT)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_NUMERIC_SHORT) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Short, Short> pudd = new ProxyPopupNumericShortDropDownEditCell(factType,
                                                                                                                      fieldName,
                                                                                                                      operator,
                                                                                                                      oracle,
                                                                                                                      dropDownManager,
                                                                                                                      isReadOnly);
-            return new DecoratedGridCellValueAdaptor<Short>(pudd,
-                                                            eventBus);
-        } else if (dataType.equals(DataType.TYPE_BOOLEAN)) {
+            return decoratedGridCellValueAdaptor(pudd);
+        } else if (dataType.equals(DataType.TYPE_BOOLEAN) && isSingleValueOperator) {
             return makeBooleanCell();
-        } else if (dataType.equals(DataType.TYPE_DATE)) {
+        } else if (dataType.equals(DataType.TYPE_DATE) && isSingleValueOperator) {
             final AbstractProxyPopupDropDownEditCell<Date, Date> pudd = new ProxyPopupDateDropDownEditCell(factType,
                                                                                                            fieldName,
                                                                                                            operator,
@@ -208,8 +200,7 @@ public class TemplateDataCellFactory
                                                                                                            dropDownManager,
                                                                                                            isReadOnly,
                                                                                                            DATE_FORMAT);
-            return new DecoratedGridCellValueAdaptor<Date>(pudd,
-                                                           eventBus);
+            return decoratedGridCellValueAdaptor(pudd);
         } else {
             final AbstractProxyPopupDropDownEditCell<String, String> pudd = new ProxyPopupTextDropDownEditCell(factType,
                                                                                                                fieldName,
@@ -217,9 +208,16 @@ public class TemplateDataCellFactory
                                                                                                                oracle,
                                                                                                                dropDownManager,
                                                                                                                isReadOnly);
-            return new DecoratedGridCellValueAdaptor<String>(pudd,
-                                                             eventBus);
+            return decoratedGridCellValueAdaptor(pudd);
         }
+    }
+
+    /**
+     * Created for testing purpose. Allows to check if data type was taken into account by cell factory.
+     */
+    DecoratedGridCellValueAdaptor decoratedGridCellValueAdaptor(final AbstractProxyPopupDropDownEditCell pudd) {
+        return new DecoratedGridCellValueAdaptor<>(pudd,
+                                                   eventBus);
     }
 
     /**

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
@@ -26,8 +26,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.AbstractProxyPopupDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericBigDecimalDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericDoubleDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericIntegerDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupTextDropDownEditCell;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -51,6 +59,9 @@ public class TemplateDataCellFactoryTest {
 
     @Mock
     private TemplateDataColumn column;
+
+    @Captor
+    private ArgumentCaptor<AbstractProxyPopupDropDownEditCell> puddCaptor;
 
     private TemplateDataCellFactory testedFactory;
 
@@ -154,19 +165,66 @@ public class TemplateDataCellFactoryTest {
      * Even if the operator is for a list the enumerations should override.
      */
     public void testEnumHasPriorityOverListOperator() throws Exception {
+        testEnumAndOperator(DataType.TYPE_STRING, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorDouble() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_DOUBLE, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorBigDecimal() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGDECIMAL, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericIntegerDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorDouble() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_DOUBLE, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericDoubleDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorBigDecimal() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGDECIMAL, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericBigDecimalDropDownEditCell);
+    }
+
+    private void testEnumAndOperator(final String dataType, final String operator) throws Exception {
         final String factType = "org.kiegroup.Car";
-        final String factField = "color";
-        final String dataType = DataType.DataTypes.STRING.name();
+        final String factField = "carAttribute";
 
         doReturn(true).when(oracle).hasEnums(factType, factField);
         doReturn(factType).when(column).getFactType();
         doReturn(factField).when(column).getFactField();
         doReturn(dataType).when(column).getDataType();
-        doReturn("in").when(column).getOperator();
+        doReturn(operator).when(column).getOperator();
 
         testedFactory.getCell(column);
 
-        verify(testedFactory).makeSelectionEnumCell(factType, factField, "in", dataType);
+        verify(testedFactory).makeSelectionEnumCell(factType, factField, operator, dataType);
         verify(testedFactory, never()).makeTextCellWrapper();
     }
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-client/src/test/java/org/drools/workbench/screens/guided/template/client/editor/TemplateDataCellFactoryTest.java
@@ -28,8 +28,13 @@ import org.kie.soup.project.datamodel.oracle.DataType;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.AbstractProxyPopupDropDownEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericBigDecimalDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericBigIntegerDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericByteDropDownEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericDoubleDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericFloatDropDownEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericIntegerDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericLongDropDownEditCell;
+import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupNumericShortDropDownEditCell;
 import org.kie.workbench.common.widgets.decoratedgrid.client.widget.cells.ProxyPopupTextDropDownEditCell;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -171,15 +176,8 @@ public class TemplateDataCellFactoryTest {
     }
 
     @Test
-    public void testEnumHasPriorityOverListOperatorInteger() throws Exception {
-        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "in");
-        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
-        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
-    }
-
-    @Test
-    public void testEnumHasPriorityOverListOperatorDouble() throws Exception {
-        testEnumAndOperator(DataType.TYPE_NUMERIC_DOUBLE, "in");
+    public void testEnumHasPriorityOverListOperatorNumeric() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC, "in");
         verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
         assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
     }
@@ -192,10 +190,80 @@ public class TemplateDataCellFactoryTest {
     }
 
     @Test
-    public void testEnumHasPriorityButSimpleOperatorInteger() throws Exception {
-        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "==");
+    public void testEnumHasPriorityOverListOperatorBigInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGINTEGER, "in");
         verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
-        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericIntegerDropDownEditCell);
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorByte() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BYTE, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorDouble() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_DOUBLE, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorFloat() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_FLOAT, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorLong() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_LONG, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityOverListOperatorShort() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_SHORT, "in");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupTextDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorNumeric() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericBigDecimalDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorBigDecimal() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGDECIMAL, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericBigDecimalDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorBigInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGINTEGER, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericBigIntegerDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorByte() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_BYTE, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericByteDropDownEditCell);
     }
 
     @Test
@@ -206,10 +274,41 @@ public class TemplateDataCellFactoryTest {
     }
 
     @Test
-    public void testEnumHasPriorityButSimpleOperatorBigDecimal() throws Exception {
-        testEnumAndOperator(DataType.TYPE_NUMERIC_BIGDECIMAL, "==");
+    public void testEnumHasPriorityButSimpleOperatorFloat() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_FLOAT, "==");
         verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
-        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericBigDecimalDropDownEditCell);
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericFloatDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorInteger() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_INTEGER, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericIntegerDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorLong() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_LONG, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericLongDropDownEditCell);
+    }
+
+    @Test
+    public void testEnumHasPriorityButSimpleOperatorShort() throws Exception {
+        testEnumAndOperator(DataType.TYPE_NUMERIC_SHORT, "==");
+        verify(testedFactory).decoratedGridCellValueAdaptor(puddCaptor.capture());
+        assertTrue(puddCaptor.getValue() instanceof ProxyPopupNumericShortDropDownEditCell);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIllegalNumericType() {
+        final String factType = "org.kiegroup.Car";
+        final String factField = "carAttribute";
+        final String dataType = DataType.TYPE_DATE;
+        final String operator = "in";
+
+        testedFactory.makeNumericSelectionEnumCell(factType, factField, dataType, operator);
     }
 
     private void testEnumAndOperator(final String dataType, final String operator) throws Exception {


### PR DESCRIPTION
Users were not able to select multiple numbers for 'in', 'not in' operators on the guided rule template 'Data' tab.

For more details see: https://issues.redhat.com/browse/DROOLS-5327