### PR TITLE
AF-2410: default:// as main file system

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/DecisionTableXLSServiceImplTest.java
@@ -117,7 +117,7 @@ public class DecisionTableXLSServiceImplTest {
         when( authenticationService.getUser() ).thenReturn( user );
         when( user.getIdentifier() ).thenReturn( "user" );
 
-        when( path.toURI() ).thenReturn( "default://p0/src/main/resources/dtable.xls" );
+        when( path.toURI() ).thenReturn( "file://p0/src/main/resources/dtable.xls" );
         when( inputstream.read( anyObject() ) ).thenReturn( -1 );
         when( ioService.newOutputStream( any( org.uberfire.java.nio.file.Path.class ),
                                          commentedOptionArgumentCaptor.capture() ) ).thenReturn( outputStream );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
@@ -183,7 +183,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
                                                                            guidedDTableType,
                                                                            drlType,
                                                                            globalsType));
-        when(path.toURI()).thenReturn("default://src/main/resources/p0/source.xls");
+        when(path.toURI()).thenReturn("file://src/main/resources/p0/source.xls");
         when(path.getFileName()).thenReturn("source.xls");
         when(dataModelService.getDataModel(eq(path))).thenReturn(dmo);
 
@@ -192,7 +192,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
 
         when(moduleService.resolveModule(any(Path.class))).thenReturn(module);
         when(module.getImportsPath()).thenReturn(expectedProjectImportsPath);
-        when(expectedProjectImportsPath.toURI()).thenReturn("default://project.imports");
+        when(expectedProjectImportsPath.toURI()).thenReturn("file://project.imports");
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorGraphDeleteHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorGraphDeleteHelperTest.java
@@ -122,7 +122,7 @@ public class GuidedDecisionTableEditorGraphDeleteHelperTest {
     @Test
     public void checkRemoveReferencesNoFiles() {
         when( path.getFileName() ).thenReturn( "dtable.gdst" );
-        when( path.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( path.toURI() ).thenReturn( "file://test/dtable.gdst" );
 
         helper.postProcess( path );
 
@@ -135,12 +135,12 @@ public class GuidedDecisionTableEditorGraphDeleteHelperTest {
     public void checkRemoveReferencesWithDecisionTableGraphs() throws URISyntaxException {
         final org.uberfire.java.nio.file.Path dtGraphPath = mock( org.uberfire.java.nio.file.Path.class );
         when( dtGraphPath.getFileName() ).thenReturn( mock( org.uberfire.java.nio.file.Path.class ) );
-        when( dtGraphPath.toUri() ).thenReturn( new URI( "default://test/dtable-set." + dtableGraphType.getSuffix() ) );
+        when( dtGraphPath.toUri() ).thenReturn( new URI( "file://test/dtable-set." + dtableGraphType.getSuffix() ) );
         when( dtGraphPath.getFileSystem() ).thenReturn( fileSystem );
         paths.add( dtGraphPath );
 
         when( path.getFileName() ).thenReturn( "dtable.gdst" );
-        when( path.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( path.toURI() ).thenReturn( "file://test/dtable.gdst" );
 
         final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel();
         model.getEntries().add( new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry( path,
@@ -175,12 +175,12 @@ public class GuidedDecisionTableEditorGraphDeleteHelperTest {
     public void checkRemoveReferencesWithoutDecisionTableGraphs() throws URISyntaxException {
         final org.uberfire.java.nio.file.Path dtPath = mock( org.uberfire.java.nio.file.Path.class );
         when( dtPath.getFileName() ).thenReturn( mock( org.uberfire.java.nio.file.Path.class ) );
-        when( dtPath.toUri() ).thenReturn( new URI( "default://test/dtable." + dtableType.getSuffix() ) );
+        when( dtPath.toUri() ).thenReturn( new URI( "file://test/dtable." + dtableType.getSuffix() ) );
         when( dtPath.getFileSystem() ).thenReturn( fileSystem );
         paths.add( dtPath );
 
         when( path.getFileName() ).thenReturn( "dtable.gdst" );
-        when( path.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( path.toURI() ).thenReturn( "file://test/dtable.gdst" );
 
         helper.postProcess( path );
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorGraphRenameHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorGraphRenameHelperTest.java
@@ -125,7 +125,7 @@ public class GuidedDecisionTableEditorGraphRenameHelperTest {
     @Test
     public void checkUpdateReferencesNoFiles() {
         when( source.getFileName() ).thenReturn( "dtable.gdst" );
-        when( source.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( source.toURI() ).thenReturn( "file://test/dtable.gdst" );
 
         helper.postProcess( source,
                             destination );
@@ -140,14 +140,14 @@ public class GuidedDecisionTableEditorGraphRenameHelperTest {
     public void checkUpdateReferencesWithDecisionTableGraphs() throws URISyntaxException {
         final org.uberfire.java.nio.file.Path dtGraphPath = mock( org.uberfire.java.nio.file.Path.class );
         when( dtGraphPath.getFileName() ).thenReturn( mock( org.uberfire.java.nio.file.Path.class ) );
-        when( dtGraphPath.toUri() ).thenReturn( new URI( "default://test/dtable-set." + dtableGraphType.getSuffix() ) );
+        when( dtGraphPath.toUri() ).thenReturn( new URI( "file://test/dtable-set." + dtableGraphType.getSuffix() ) );
         when( dtGraphPath.getFileSystem() ).thenReturn( fileSystem );
         paths.add( dtGraphPath );
 
         when( source.getFileName() ).thenReturn( "dtable.gdst" );
-        when( source.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( source.toURI() ).thenReturn( "file://test/dtable.gdst" );
         when( destination.getFileName() ).thenReturn( "dtable-renamed.gdst" );
-        when( destination.toURI() ).thenReturn( "default://test/dtable-renamed.gdst" );
+        when( destination.toURI() ).thenReturn( "file://test/dtable-renamed.gdst" );
 
         final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel();
         model.getEntries().add( new GuidedDecisionTableEditorGraphModel.GuidedDecisionTableGraphEntry( source,
@@ -191,7 +191,7 @@ public class GuidedDecisionTableEditorGraphRenameHelperTest {
         paths.add( dtPath );
 
         when( source.getFileName() ).thenReturn( "dtable.gdst" );
-        when( source.toURI() ).thenReturn( "default://test/dtable.gdst" );
+        when( source.toURI() ).thenReturn( "file://test/dtable.gdst" );
 
         helper.postProcess( source,
                             destination );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorServiceImplTest.java
@@ -176,7 +176,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
         when(moduleService.resolvePackage(any(Path.class))).thenReturn(pkg);
         when(pkg.getPackageName()).thenReturn("mypackage");
         when(pkg.getPackageMainResourcesPath()).thenReturn(PathFactory.newPath("mypackage",
-                                                                               "default://project/src/main/resources"));
+                                                                               "file://project/src/main/resources"));
 
         when(fileSystem.provider()).thenReturn(fileSystemProvider);
         when(fileSystemProvider.readAttributes(any(org.uberfire.java.nio.file.Path.class),
@@ -191,7 +191,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
         final GuidedDecisionTable52 content = new GuidedDecisionTable52();
         final String comment = "comment";
 
-        when(context.toURI()).thenReturn("default://project/src/main/resources/mypackage");
+        when(context.toURI()).thenReturn("file://project/src/main/resources/mypackage");
 
         final Path p = service.create(context,
                                       fileName,
@@ -211,7 +211,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
     @Test
     public void checkLoad() {
         final Path path = mock(Path.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable.gdst");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable.gdst");
 
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn("");
 
@@ -238,7 +238,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
                 false);
         }});
         final Set<PortableWorkDefinition> workItemDefinitions = new HashSet<>();
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable.gdst");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable.gdst");
         when(dataModelService.getDataModel(eq(path))).thenReturn(oracle);
         when(workItemsService.loadWorkItemDefinitions(eq(path))).thenReturn(workItemDefinitions);
 
@@ -267,7 +267,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
         final GuidedDecisionTable52 model = new GuidedDecisionTable52();
         final Metadata metadata = mock(Metadata.class);
         final String comment = "comment";
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable.gdst");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable.gdst");
 
         service.save(path,
                      model,
@@ -292,8 +292,8 @@ public class GuidedDecisionTableEditorServiceImplTest {
         final GuidedDecisionTable52 model = new GuidedDecisionTable52();
         final Metadata metadata = mock(Metadata.class);
         final String comment = "comment";
-        final String headPathUri = "default://project/src/main/resources/mypackage/dtable.gdst";
-        final String versionPathUri = "default://0123456789@project/src/main/resources/mypackage/dtable.gdst";
+        final String headPathUri = "file://project/src/main/resources/mypackage/dtable.gdst";
+        final String versionPathUri = "file://0123456789@project/src/main/resources/mypackage/dtable.gdst";
         when(path.toURI()).thenReturn(headPathUri);
         when(path.getFileName()).thenReturn("dtable.gdst");
 
@@ -308,7 +308,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
         when(versionRecordService.load(any(org.uberfire.java.nio.file.Path.class))).thenReturn(versions);
 
         //Setup Decision Table Graph
-        final URI dtGraphPathUri = URI.create("default://project/src/main/resources/mypackage/graph1.gdst-set");
+        final URI dtGraphPathUri = URI.create("file://project/src/main/resources/mypackage/graph1.gdst-set");
         final org.uberfire.java.nio.file.Path dtGraphPath = mock(org.uberfire.java.nio.file.Path.class);
         when(dtGraphPath.toUri()).thenReturn(dtGraphPathUri);
         when(dtGraphPath.getFileName()).thenReturn(dtGraphPath);
@@ -422,7 +422,7 @@ public class GuidedDecisionTableEditorServiceImplTest {
         final GuidedDecisionTable52 model = new GuidedDecisionTable52();
         final SourceService mockSourceService = mock(SourceService.class);
 
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage");
         when(mockSourceServices.getServiceFor(any(org.uberfire.java.nio.file.Path.class))).thenReturn(mockSourceService);
 
         service.toSource(path,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableGraphEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableGraphEditorServiceImplTest.java
@@ -150,7 +150,7 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
 
         when(moduleService.resolvePackage(any(Path.class))).thenReturn(pkg);
         when(pkg.getPackageMainResourcesPath()).thenReturn(PathFactory.newPath("project",
-                                                                               "default://project/src/main/resources"));
+                                                                               "file://project/src/main/resources"));
 
         resolvedPaths.clear();
         when(ioService.newDirectoryStream(any(org.uberfire.java.nio.file.Path.class))).thenReturn(new MockDirectoryStream(resolvedPaths));
@@ -163,7 +163,7 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
         final GuidedDecisionTableEditorGraphModel content = new GuidedDecisionTableEditorGraphModel();
         final String comment = "comment";
 
-        when(context.toURI()).thenReturn("default://project/src/main/resources/mypackage");
+        when(context.toURI()).thenReturn("file://project/src/main/resources/mypackage");
 
         final Path p = service.create(context,
                                       fileName,
@@ -181,7 +181,7 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
     @Test
     public void checkLoad() {
         final Path path = mock(Path.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
 
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn("");
 
@@ -196,7 +196,7 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
     public void checkConstructContent() {
         final Path path = mock(Path.class);
         final Overview overview = mock(Overview.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
 
         final GuidedDecisionTableEditorGraphContent content = service.constructContent(path,
                                                                                        overview);
@@ -216,7 +216,7 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
         final GuidedDecisionTableEditorGraphModel model = new GuidedDecisionTableEditorGraphModel();
         final Metadata metadata = mock(Metadata.class);
         final String comment = "comment";
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/dtable." + dtGraphResourceType.getSuffix());
 
         service.save(path,
                      model,
@@ -297,12 +297,12 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
     @Test
     public void testListDecisionTablesInPackage() {
         final Path path = mock(Path.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/dtable1.gdst");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/dtable1.gdst");
 
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/dtable1.gdst"));
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/dtable2.gdst"));
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/dtable3.gdst"));
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/pupa.smurf"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/dtable1.gdst"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/dtable2.gdst"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/dtable3.gdst"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/pupa.smurf"));
 
         final List<Path> paths = service.listDecisionTablesInPackage(path);
 
@@ -320,10 +320,10 @@ public class GuidedDecisionTableGraphEditorServiceImplTest {
     @Test
     public void testListDecisionTablesInPackageExcludesDotFiles() {
         final Path path = mock(Path.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/dtable1.gdst");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/dtable1.gdst");
 
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/dtable1.gdst"));
-        resolvedPaths.add(makeNioPath("default://project/src/main/resources/.dtable1.gdst"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/dtable1.gdst"));
+        resolvedPaths.add(makeNioPath("file://project/src/main/resources/.dtable1.gdst"));
 
         final List<Path> paths = service.listDecisionTablesInPackage(path);
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelperTest.java
@@ -94,8 +94,8 @@ public class GuidedRuleEditorCopyHelperTest {
     public void testRDRLFile() {
         final Path pathSource = mock(Path.class);
         final Path pathDestination = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/src/main/resources/MyFile.rdrl");
-        when(pathDestination.toURI()).thenReturn("default://p0/src/main/resources/MyNewFile.rdrl");
+        when(pathSource.toURI()).thenReturn("file://p0/src/main/resources/MyFile.rdrl");
+        when(pathDestination.toURI()).thenReturn("file://p0/src/main/resources/MyNewFile.rdrl");
         when(pathDestination.getFileName()).thenReturn("MyNewFile.rdrl");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(drl);
 
@@ -117,8 +117,8 @@ public class GuidedRuleEditorCopyHelperTest {
     public void testRDSLRFile() {
         final Path pathSource = mock(Path.class);
         final Path pathDestination = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/src/main/resources/MyFile.rdslr");
-        when(pathDestination.toURI()).thenReturn("default://p0/src/main/resources/MyNewFile.rdslr");
+        when(pathSource.toURI()).thenReturn("file://p0/src/main/resources/MyFile.rdslr");
+        when(pathDestination.toURI()).thenReturn("file://p0/src/main/resources/MyNewFile.rdslr");
         when(pathDestination.getFileName()).thenReturn("MyNewFile.rdslr");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(dslr);
 

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelperTest.java
@@ -94,8 +94,8 @@ public class GuidedRuleEditorRenameHelperTest {
     public void testRDRLFile() {
         final Path pathSource = mock(Path.class);
         final Path pathDestination = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/src/main/resources/MyFile.rdrl");
-        when(pathDestination.toURI()).thenReturn("default://p0/src/main/resources/MyNewFile.rdrl");
+        when(pathSource.toURI()).thenReturn("file://p0/src/main/resources/MyFile.rdrl");
+        when(pathDestination.toURI()).thenReturn("file://p0/src/main/resources/MyNewFile.rdrl");
         when(pathDestination.getFileName()).thenReturn("MyNewFile.rdrl");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(drl);
 
@@ -117,8 +117,8 @@ public class GuidedRuleEditorRenameHelperTest {
     public void testRDSLRFile() {
         final Path pathSource = mock(Path.class);
         final Path pathDestination = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/src/main/resources/MyFile.rdslr");
-        when(pathDestination.toURI()).thenReturn("default://p0/src/main/resources/MyNewFile.rdslr");
+        when(pathSource.toURI()).thenReturn("file://p0/src/main/resources/MyFile.rdslr");
+        when(pathDestination.toURI()).thenReturn("file://p0/src/main/resources/MyNewFile.rdslr");
         when(pathDestination.getFileName()).thenReturn("MyNewFile.rdslr");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(dslr);
 

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceImplTest.java
@@ -118,7 +118,7 @@ public class GuidedRuleEditorServiceImplTest {
                 .addExtension(DSLActionSentence.INSTANCE, Collections.singletonList(dslSentence))
                 .addExtension(DSLConditionSentence.INSTANCE, Collections.singletonList(dslSentence))
                 .build();
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/rule.rdrl");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/rule.rdrl");
         when(dataModelService.getDataModel(any())).thenReturn(oracle);
 
         final GuidedEditorContent content = service.constructContent(path,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorServiceImplTest.java
@@ -93,7 +93,7 @@ public class GuidedRuleTemplateEditorServiceImplTest {
         final Path path = mock(Path.class);
         final Overview overview = mock(Overview.class);
         final PackageDataModelOracle oracle = mock(PackageDataModelOracle.class);
-        when(path.toURI()).thenReturn("default://project/src/main/resources/mypackage/rule.template");
+        when(path.toURI()).thenReturn("file://project/src/main/resources/mypackage/rule.template");
         when(dataModelService.getDataModel(any())).thenReturn(oracle);
         when(oracle.getPackageGlobals()).thenReturn(new HashMap<String, String>() {{
             put("number",

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider


### PR DESCRIPTION
## Intention

* Disable JGit specific features when JGit is not the default FS
* Add a switch to choose between Monitoring and Simplified Monitoring

## Simplified Monitoring 
Simplified monitoring is the K8S FS based solution. This can't use JGit specific parts so they are disabled (Like _Pages_)

Possible values:
* -Dorg.appformer.server.simplified.monitoring.enabled=true/false

## Related PRs:
* https://github.com/kiegroup/appformer/pull/882
* https://github.com/kiegroup/kie-wb-common/pull/3128
* https://github.com/kiegroup/drools-wb/pull/1363
* https://github.com/kiegroup/jbpm-designer/pull/881