### PR TITLE
KOGITO-2189: Columns widths are not correctly saved in Scesim Editor KOGITO

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -241,11 +241,6 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     }
 
     @Override
-    public void wrappedSave(String commitMessage) {
-        save(commitMessage);
-    }
-
-    @Override
     public Integer getOriginalHash() {
         return originalHash;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
@@ -41,8 +41,6 @@ public interface ScenarioSimulationEditorWrapper {
 
     void onRunScenario(RemoteCallback<SimulationRunResult> refreshModelCallback, ScenarioSimulationHasBusyIndicatorDefaultErrorCallback scenarioSimulationHasBusyIndicatorDefaultErrorCallback, ScesimModelDescriptor simulationDescriptor, Settings settings, List<ScenarioWithIndex> toRun, Background background);
 
-    void wrappedSave(final String commitMessage);
-
     Integer getOriginalHash();
 
     void wrappedRegisterDock(final String id, final IsWidget widget);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -147,7 +147,7 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
 
     @Override
     public Promise<String> getContent() {
-        return transform(scenarioSimulationEditorPresenter.getModel());
+        return promises.create(this::prepareContent);
     }
 
     @Override
@@ -186,6 +186,19 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
                 unmarshallContent(content);
             }
             success.onInvoke((Object) null);
+        } catch (Exception e) {
+            /* If any exception occurs, promise returns a failure */
+            scenarioSimulationEditorPresenter.sendNotification(e.getMessage(), NotificationEvent.NotificationType.ERROR);
+            failure.onInvoke(e.getMessage());
+        }
+    }
+
+    public void prepareContent(Promise.PromiseExecutorCallbackFn.ResolveCallbackFn<String> success,
+                               Promise.PromiseExecutorCallbackFn.RejectCallbackFn failure) {
+        try {
+            synchronizeColumnsDimension(scenarioSimulationEditorPresenter.getContext().getScenarioGridPanelByGridWidget(GridWidget.SIMULATION),
+                                        scenarioSimulationEditorPresenter.getContext().getScenarioGridPanelByGridWidget(GridWidget.BACKGROUND));
+            marshallContent(scenarioSimulationEditorPresenter.getModel(), success);
         } catch (Exception e) {
             /* If any exception occurs, promise returns a failure */
             scenarioSimulationEditorPresenter.sendNotification(e.getMessage(), NotificationEvent.NotificationType.ERROR);
@@ -337,18 +350,8 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
     }
 
     @Override
-    public void wrappedSave(String commitMessage) {
-        synchronizeColumnsDimension(scenarioSimulationEditorPresenter.getContext().getScenarioGridPanelByGridWidget(GridWidget.SIMULATION),
-                                    scenarioSimulationEditorPresenter.getContext().getScenarioGridPanelByGridWidget(GridWidget.BACKGROUND));
-    }
-
-    @Override
     public Integer getOriginalHash() {
         return super.getOriginalContentHash();
-    }
-
-    protected Promise<String> transform(final ScenarioSimulationModel resource) {
-        return promises.create((resolveCallbackFn, rejectCallbackFn) -> marshallContent(resource, resolveCallbackFn));
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
@@ -189,6 +189,11 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
             }
 
             @Override
+            protected void marshallContent(ScenarioSimulationModel scenarioSimulationModel, Promise.PromiseExecutorCallbackFn.ResolveCallbackFn<String> resolveCallbackFn) {
+                // JSInterops logic, can't be tested
+            }
+
+            @Override
             protected void resetEditorPages() {
                 //Do nothing
             }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
@@ -145,6 +146,8 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
     private ArgumentCaptor<RemoteCallback> remoteCallbackArgumentCaptor;
     @Captor
     private ArgumentCaptor<Path> pathArgumentCaptor;
+    @Captor
+    private ArgumentCaptor<Promise.PromiseExecutorCallbackFn> promiseExecutorCallbackFnArgumentCaptor;
 
     private ScenarioSimulationEditorKogitoWrapper scenarioSimulationEditorKogitoWrapperSpy;
     private Path path = PathFactory.newPath("file.scesim", "path/");
@@ -202,8 +205,10 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
     @Test
     public void getContent() {
         scenarioSimulationEditorKogitoWrapperSpy.getContent();
-        verify(scenarioSimulationEditorPresenterMock, times(1)).getModel();
-        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).transform(eq(scenarioSimulationModelMock));
+        verify(promisesMock, times(1)).create(promiseExecutorCallbackFnArgumentCaptor.capture());
+        promiseExecutorCallbackFnArgumentCaptor.getValue().onInvoke(resolveCallBackMock, rejectCallbackFnMock);
+        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).prepareContent(eq(resolveCallBackMock),
+                                                                                                       eq(rejectCallbackFnMock));
     }
 
     @Test
@@ -214,6 +219,22 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
         verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).unmarshallContent(eq("value"));
         assertEquals("file.scesim", pathArgumentCaptor.getValue().getFileName());
         assertEquals("path/", pathArgumentCaptor.getValue().toURI());
+    }
+
+    @Test
+    public void prepareContent() {
+        scenarioSimulationEditorKogitoWrapperSpy.prepareContent(resolveCallBackMock, rejectCallbackFnMock);
+        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).synchronizeColumnsDimension(eq(simulationGridPanelMock), eq(backgroundGridPanelMock));
+        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).marshallContent(eq(scenarioSimulationModelMock), eq(resolveCallBackMock));
+    }
+
+    @Test
+    public void prepareContent_Exception() {
+        scenarioSimulationEditorKogitoWrapperSpy.prepareContent(resolveCallBackMock, rejectCallbackFnMock);
+        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).synchronizeColumnsDimension(eq(simulationGridPanelMock), eq(backgroundGridPanelMock));
+        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).marshallContent(eq(scenarioSimulationModelMock), eq(resolveCallBackMock));
+        willThrow(Exception.class).given(scenarioSimulationEditorKogitoWrapperSpy).marshallContent(any(), any());
+        verify(scenarioSimulationEditorPresenterMock, times(1)).sendNotification(anyString(), eq(NotificationEvent.NotificationType.ERROR));
     }
 
     @Test
@@ -282,19 +303,6 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
     public void onEditTabSelected() {
         scenarioSimulationEditorKogitoWrapperSpy.onEditTabSelected();
         verify(scenarioSimulationEditorPresenterMock, times(1)).onEditTabSelected();
-    }
-
-    @Test
-    public void wrappedSave() {
-        scenarioSimulationEditorKogitoWrapperSpy.wrappedSave("commit");
-        verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).synchronizeColumnsDimension(eq(simulationGridPanelMock),
-                                                                                                                    eq(backgroundGridPanelMock));
-    }
-
-    @Test
-    public void transform() {
-        scenarioSimulationEditorKogitoWrapperSpy.transform(scenarioSimulationModelMock);
-        verify(promisesMock, times(1)).create(isA(Promise.PromiseExecutorCallbackFn.class));
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapperTest.java
@@ -231,14 +231,15 @@ public class ScenarioSimulationEditorKogitoWrapperTest {
         scenarioSimulationEditorKogitoWrapperSpy.prepareContent(resolveCallBackMock, rejectCallbackFnMock);
         verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).synchronizeColumnsDimension(eq(simulationGridPanelMock), eq(backgroundGridPanelMock));
         verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).marshallContent(eq(scenarioSimulationModelMock), eq(resolveCallBackMock));
+        verify(scenarioSimulationEditorPresenterMock, never()).sendNotification(any(), any());
     }
 
     @Test
     public void prepareContent_Exception() {
+        willThrow(Exception.class).given(scenarioSimulationEditorKogitoWrapperSpy).marshallContent(any(), any());
         scenarioSimulationEditorKogitoWrapperSpy.prepareContent(resolveCallBackMock, rejectCallbackFnMock);
         verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).synchronizeColumnsDimension(eq(simulationGridPanelMock), eq(backgroundGridPanelMock));
         verify(scenarioSimulationEditorKogitoWrapperSpy, times(1)).marshallContent(eq(scenarioSimulationModelMock), eq(resolveCallBackMock));
-        willThrow(Exception.class).given(scenarioSimulationEditorKogitoWrapperSpy).marshallContent(any(), any());
         verify(scenarioSimulationEditorPresenterMock, times(1)).sendNotification(anyString(), eq(NotificationEvent.NotificationType.ERROR));
     }
 


### PR DESCRIPTION
@danielezonca @dupliaka can you please review and test it?

I noticed that `columnWidth` changes were not saved in VSCode Kogito Editor. Scope of this PR is to let this mechanism works.

`wrappedSave` method was removed because not called anywhere.

https://issues.redhat.com/browse/KOGITO-2189