### PR TITLE
DROOLS-5364: Test scenario reports data type change during creation

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNUtils.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNUtils.java
@@ -43,13 +43,13 @@ public class DMNUtils {
 
     /**
      * This method returns the correct <b>type</b> name of a given <code>DMNType</code>. Basically, if a DMNType
-     * contains a baseType, it takes the type name from its baseType. This is to manage DMN Simple Types and Anonymous
-     * inner types
+     * contains a baseType and is not a collection, it takes the type name from its baseType.
+     * This is to manage DMN Simple Types and Anonymous inner types
      * @param dmnType
      * @return
      */
     public static String getDMNTypeName(DMNType dmnType) {
-        if (dmnType.getBaseType() != null) {
+        if (dmnType.getBaseType() != null && !dmnType.isCollection()) {
             return dmnType.getBaseType().getName();
         }
         return dmnType.getName();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNUtilsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNUtilsTest.java
@@ -51,6 +51,10 @@ public class DMNUtilsTest {
         CompositeTypeImpl aliasType = new CompositeTypeImpl(null, "tComposite", null, false, Collections.emptyMap(), simpleTypeAny, aliasFeelType);
         assertEquals("tSimple", DMNUtils.getDMNTypeName(aliasType));
 
+        Type aliasCollectionFeelType = new AliasFEELType("alias", BuiltInType.UNKNOWN);
+        CompositeTypeImpl aliasCollectionType = new CompositeTypeImpl(null, "tComposite", null, true, Collections.emptyMap(), simpleTypeAny, aliasCollectionFeelType);
+        assertEquals("tComposite", DMNUtils.getDMNTypeName(aliasCollectionType));
+
         Type notBuiltInType = new AliasFEELType("notBuiltIn", BuiltInType.UNKNOWN);
         SimpleTypeImpl notBuiltIn = new SimpleTypeImpl(null, "tSimple2", null, false, Collections.emptyList(), simpleTypeAny, notBuiltInType);
         assertEquals("tSimple", DMNUtils.getDMNTypeName(notBuiltIn));


### PR DESCRIPTION
@danielezonca @dupliaka Can you please review and test it?

Regression bug introduced with https://github.com/kiegroup/drools-wb/pull/1364 
(Fix for 
- https://issues.redhat.com/browse/DROOLS-5317
- https://issues.redhat.com/browse/RHDM-1153)

Basically, in case of a `isCollection()` DMNType, the previous behavior was correct (i.e. the correct name the validate is `DMNType.name`), because the `FactMapping.genericType` refers to `DMNType.getName` and not to `DMNType.getBaseType().getName()`
Therefore, in case of `isCollection() == true`, `DMNType.getName` is returned (as code did previously)