### PR TITLE
DROOLS-4995: Error popups when collection editor dialog is open

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.html
@@ -1,4 +1,5 @@
 <div class="kie-dataTypesList-modal modal-wide" tabindex="-1" role="dialog" id="collectionEditor">
+    <div class="modal-backdrop in"></div>
     <div class="modal-dialog" style="width:100%" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -58,9 +59,15 @@
                 </button>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-dismiss="modal" data-field="saveButton">
+                    <span class="fa fa-save" style="margin-right: 5px;"></span>
+                    <span data-field="saveButtonSpanText"></span>
+                </button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal" data-field="removeButton">
+                    <span class="fa fa-remove" style="margin-right: 5px;"></span>
+                    <span data-field="removeButtonSpanText"></span>
+                </button>
                 <button type="button" class="btn btn-default" data-dismiss="modal" data-field="cancelButton"></button>
-                <button type="button" class="btn btn-danger" data-dismiss="modal" data-field="removeButton"></button>
-                <button type="button" class="btn btn-primary" data-dismiss="modal" data-field="saveButton"></button>
             </div>
         </div>
     </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImpl.java
@@ -93,8 +93,14 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
     @DataField("removeButton")
     protected ButtonElement removeButton = Document.get().createPushButtonElement();
 
+    @DataField("removeButtonSpanText")
+    protected SpanElement removeButtonSpanText = Document.get().createSpanElement();
+
     @DataField("saveButton")
     protected ButtonElement saveButton = Document.get().createPushButtonElement();
+
+    @DataField("saveButtonSpanText")
+    protected SpanElement saveButtonSpanText = Document.get().createSpanElement();
 
     @DataField("addItemButton")
     protected ButtonElement addItemButton = Document.get().createPushButtonElement();
@@ -204,9 +210,9 @@ public class CollectionViewImpl extends FocusWidget implements HasCloseComposite
 
     protected void commonInit(ScenarioSimulationModel.Type type) {
         scenarioType = type ;
-        saveButton.setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
         cancelButton.setInnerText(ScenarioSimulationEditorConstants.INSTANCE.cancelButton());
-        removeButton.setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
+        saveButtonSpanText.setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
+        removeButtonSpanText.setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
         enableCreateCollectionContainer(true);
         if (RULE.equals(scenarioType)) {
             initAndRegisterHandlerForExpressionTextArea();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/CollectionViewImplTest.java
@@ -71,9 +71,13 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
     @Mock
     private ButtonElement saveButtonMock;
     @Mock
+    private SpanElement saveButtonSpanTextMock;
+    @Mock
     private ButtonElement cancelButtonMock;
     @Mock
     private ButtonElement removeButtonMock;
+    @Mock
+    private SpanElement removeButtonSpanTextMock;
     @Mock
     private ButtonElement addItemButtonMock;
     @Mock
@@ -121,6 +125,8 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
                 this.addItemButton = addItemButtonMock;
                 this.createCollectionRadio = createCollectionRadioMock;
                 this.defineCollectionRadio = defineCollectionRadioMock;
+                this.removeButtonSpanText = removeButtonSpanTextMock;
+                this.saveButtonSpanText = saveButtonSpanTextMock;
             }
         });
     }
@@ -159,9 +165,9 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
     public void commonInit_RuleScenario() {
         collectionEditorViewImplSpy.commonInit(ScenarioSimulationModel.Type.RULE);
         assertEquals(ScenarioSimulationModel.Type.RULE, collectionEditorViewImplSpy.scenarioType);
-        verify(saveButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
+        verify(saveButtonSpanTextMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
         verify(cancelButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.cancelButton());
-        verify(removeButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
+        verify(removeButtonSpanTextMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
         verify(collectionEditorViewImplSpy, times(1)).enableCreateCollectionContainer(eq(true));
         verify(collectionEditorViewImplSpy, times(1)).initAndRegisterHandlerForExpressionTextArea();
     }
@@ -170,9 +176,9 @@ public class CollectionViewImplTest extends AbstractCollectionEditorTest {
     public void commonInit_DMNScenario() {
         collectionEditorViewImplSpy.commonInit(ScenarioSimulationModel.Type.DMN);
         assertEquals(ScenarioSimulationModel.Type.DMN, collectionEditorViewImplSpy.scenarioType);
-        verify(saveButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
+        verify(saveButtonSpanTextMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.saveButton());
         verify(cancelButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.cancelButton());
-        verify(removeButtonMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
+        verify(removeButtonSpanTextMock, times(1)).setInnerText(ScenarioSimulationEditorConstants.INSTANCE.removeButton());
         verify(collectionEditorViewImplSpy, times(1)).enableCreateCollectionContainer(eq(true));
         verify(collectionEditorViewImplSpy, never()).initAndRegisterHandlerForExpressionTextArea();
     }


### PR DESCRIPTION
@dupliaka @danielezonca Can you please test and review?

To solve the issue I added a backdrop behind the modal, in this way it's not possible to interact with the rest of the page. 
I applied some changes on the collection editor buttons as well, changing their order and adding icons. 
The result:
![Screenshot from 2020-06-04 19-13-25](https://user-images.githubusercontent.com/16005046/83845894-fe3a4f80-a709-11ea-8694-65900888c770.png)

https://issues.redhat.com/browse/DROOLS-4995