### PR TITLE
[7.39.x] DROOLS-5317: Scenario Simulation shows misleading data type if DMN applies a constraint 

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/PropertyTypeNameTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/PropertyTypeNameTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.model.typedescriptor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class PropertyTypeNameTest {
+
+    @Test
+    public void propertyTypeNameEmpty() {
+        String typeName = "typeName";
+        String baseTypeName = "baseTypeName";
+        FactModelTree.PropertyTypeName propertyTypeNameTest = new FactModelTree.PropertyTypeName();
+        assertNull(propertyTypeNameTest.getTypeName());
+        assertFalse(propertyTypeNameTest.getBaseTypeName().isPresent());
+        propertyTypeNameTest.setTypeName(typeName);
+        assertEquals(typeName, propertyTypeNameTest.getPropertyTypeNameToVisualize());
+        propertyTypeNameTest.setBaseTypeName(baseTypeName);
+        assertTrue(propertyTypeNameTest.getBaseTypeName().isPresent());
+        assertEquals(typeName, propertyTypeNameTest.getTypeName());
+        assertEquals(baseTypeName, propertyTypeNameTest.getPropertyTypeNameToVisualize());
+    }
+
+    @Test
+    public void propertyTypeNameNoBaseType() {
+        String typeName = "typeName";
+        FactModelTree.PropertyTypeName propertyTypeNameTest = new FactModelTree.PropertyTypeName(typeName);
+        assertFalse(propertyTypeNameTest.getBaseTypeName().isPresent());
+        assertEquals(typeName, propertyTypeNameTest.getTypeName());
+        assertEquals(typeName, propertyTypeNameTest.getPropertyTypeNameToVisualize());
+    }
+
+    @Test
+    public void propertyTypeNameWithBaseType() {
+        String typeName = "typeName";
+        String baseTypeName = "baseTypeName";
+        FactModelTree.PropertyTypeName propertyTypeNameTest = new FactModelTree.PropertyTypeName(typeName, baseTypeName);
+        assertTrue(propertyTypeNameTest.getBaseTypeName().isPresent());
+        assertEquals(typeName, propertyTypeNameTest.getTypeName());
+        assertEquals(baseTypeName, propertyTypeNameTest.getPropertyTypeNameToVisualize());
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategy.java
@@ -165,22 +165,21 @@ public class DMNSimulationSettingsCreationStrategy implements SimulationSettings
         List<String> previousSteps = new ArrayList<>(readOnlyPreviousSteps);
         // if is a simple type it generates a single column
         if (factModelTree.isSimple()) {
-
-            String factType = factModelTree.getSimpleProperties().get(VALUE);
-            factMappingExtractor.getFactMapping(factModelTree, VALUE, previousSteps, factType);
+            FactModelTree.PropertyTypeName factType = factModelTree.getSimpleProperties().get(VALUE);
+            factMappingExtractor.getFactMapping(factModelTree, VALUE, previousSteps, factType.getTypeName());
         }
         // otherwise it adds a column for each simple properties direct or nested
         else {
-            for (Map.Entry<String, String> entry : factModelTree.getSimpleProperties().entrySet()) {
+            for (Map.Entry<String, FactModelTree.PropertyTypeName> entry : factModelTree.getSimpleProperties().entrySet()) {
                 String factName = entry.getKey();
-                String factType = entry.getValue();
+                String factTypeName = entry.getValue().getTypeName();
 
-                FactMapping factMapping = factMappingExtractor.getFactMapping(factModelTree, factName, previousSteps, factType);
+                FactMapping factMapping = factMappingExtractor.getFactMapping(factModelTree, factName, previousSteps, factTypeName);
 
-                if (ScenarioSimulationSharedUtils.isList(factType)) {
+                if (ScenarioSimulationSharedUtils.isList(factTypeName)) {
                     factMapping.setGenericTypes(factModelTree.getGenericTypeInfo(factName));
                 }
-                factMapping.addExpressionElement(factName, factType);
+                factMapping.addExpressionElement(factName, factTypeName);
             }
 
             for (Map.Entry<String, String> entry : factModelTree.getExpandableProperties().entrySet()) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractDMNTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/AbstractDMNTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-public class AbstractDMNTest {
+public abstract class AbstractDMNTest {
 
     protected DMNModel dmnModelLocal;
 
@@ -123,6 +123,14 @@ public class AbstractDMNTest {
     }
 
     /**
+     * Returns a <b>single</b> <code>SimpleTypeImpl</code>
+     * @return
+     */
+    protected SimpleTypeImpl getSimpleNoCollectionWithBaseType() {
+        return new SimpleTypeImpl("simpleNameSpace", "simpleType", null, false, null, getSimpleNoCollection(), null);
+    }
+
+    /**
      * Returns a <b>string collection</b> <code>SimpleTypeImpl</code>
      * @return
      */
@@ -143,6 +151,16 @@ public class AbstractDMNTest {
         SimpleTypeImpl simpleCollectionString = new SimpleTypeImpl("simpleNameSpace", name, null, true, null, null, null);
         simpleCollectionString.setBaseType(typeOfCollection);
         return simpleCollectionString;
+    }
+
+    protected CompositeTypeImpl  getSingleCompositeWithBaseTypeField() {
+        // Complex object retrieve
+        CompositeTypeImpl toReturn = new CompositeTypeImpl("compositeNameSpace", COMPOSITE_TYPE_NAME, null);
+
+        toReturn.addField("gender", getSimpleNoCollectionWithBaseType());
+        toReturn.addField("name", new SimpleTypeImpl(null, SIMPLE_TYPE_NAME, null));
+
+        return toReturn;
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -36,6 +36,7 @@ import org.uberfire.backend.vfs.Path;
 
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.VALUE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -100,7 +101,9 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE));
+        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
         assertTrue(retrieved.getExpandableProperties().isEmpty());
         assertTrue(retrieved.getGenericTypesMap().isEmpty());
     }
@@ -115,13 +118,36 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE));
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
         assertTrue(retrieved.getExpandableProperties().isEmpty());
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey(VALUE));
         assertNotNull(retrieved.getGenericTypesMap().get(VALUE));
         assertEquals(1, retrieved.getGenericTypesMap().get(VALUE).size());
         assertEquals(simpleCollectionString.getName(), retrieved.getGenericTypesMap().get(VALUE).get(0));
+    }
+
+    @Test
+    public void createTopLevelFactModelTreeCompositeNoCollectionBaseType() throws WrongDMNTypeException {
+        // Single property retrieve
+        DMNType composite = getSingleCompositeWithBaseTypeField();
+        FactModelTree retrieved = dmnTypeServiceImpl.createTopLevelFactModelTree("testPath", composite, new TreeMap<>(), FactModelTree.Type.INPUT);
+        assertNotNull(retrieved);
+        assertEquals("testPath", retrieved.getFactName());
+        assertEquals(2, retrieved.getSimpleProperties().size());
+        assertTrue(retrieved.getSimpleProperties().containsKey("name"));
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("name").getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get("name").getBaseTypeName().isPresent());
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("name").getPropertyTypeNameToVisualize());
+        //
+        assertTrue(retrieved.getSimpleProperties().containsKey("gender"));
+        assertEquals("simpleType", retrieved.getSimpleProperties().get("gender").getTypeName());
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("gender").getBaseTypeName().get());
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("gender").getPropertyTypeNameToVisualize());
+        assertTrue(retrieved.getExpandableProperties().isEmpty());
+        assertTrue(retrieved.getGenericTypesMap().isEmpty());
     }
 
     @Test
@@ -133,9 +159,13 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(2, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey("friends"));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends"));
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends").getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get("friends").getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends").getPropertyTypeNameToVisualize());
         assertTrue(retrieved.getSimpleProperties().containsKey("name"));
-        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("name"));
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("name").getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get("name").getBaseTypeName().isPresent());
+        assertEquals(SIMPLE_TYPE_NAME, retrieved.getSimpleProperties().get("name").getPropertyTypeNameToVisualize());
         //
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey("friends"));
@@ -158,7 +188,9 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE));
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
         assertTrue(retrieved.getExpandableProperties().isEmpty());
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey(VALUE));
@@ -321,6 +353,12 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
      */
     private void verifySimpleDMNType(FactModelTree mappedFactModelTree, DMNType originalType) {
         assertTrue(mappedFactModelTree.getSimpleProperties().containsKey(VALUE)); // otherwise a simple one
-        assertEquals(originalType.getName(), mappedFactModelTree.getSimpleProperties().get(VALUE));
+        assertEquals(originalType.getName(), mappedFactModelTree.getSimpleProperties().get(VALUE).getTypeName());
+        assertEquals(originalType.getName(), mappedFactModelTree.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        if (originalType.getBaseType() != null) {
+            assertTrue(mappedFactModelTree.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+            assertEquals(originalType.getBaseType().getName(), mappedFactModelTree.getSimpleProperties().get(VALUE).getBaseTypeName().get());
+            assertEquals(originalType.getBaseType().getName(), mappedFactModelTree.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/util/DMNSimulationSettingsCreationStrategyTest.java
@@ -123,7 +123,7 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
     }
 
     @Test
-    public void createSettings() throws Exception {
+    public void createSettings() {
         final String dmnFilePath = "test";
         final Path pathMock = mock(Path.class);
         final Settings retrieved = dmnSimulationCreationStrategy.createSettings(pathMock, dmnFilePath);
@@ -157,7 +157,7 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
         factModelTree.addExpandableProperty("recursiveProperty", "recursive");
         String propertyType = String.class.getCanonicalName();
         String propertyName = "simpleProperty";
-        factModelTree.addSimpleProperty(propertyName, propertyType);
+        factModelTree.addSimpleProperty(propertyName, new FactModelTree.PropertyTypeName(propertyType));
 
         hiddenFacts.put("recursive", factModelTree);
 
@@ -197,10 +197,10 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
         FactModelTree nested2 = new FactModelTree("tNested2", "", new HashMap<>(), Collections.emptyMap());
         String propertyType = String.class.getCanonicalName();
         String propertyName = "stingProperty";
-        nested1.addSimpleProperty(propertyName, propertyType);
+        nested1.addSimpleProperty(propertyName, new FactModelTree.PropertyTypeName(propertyType));
         String propertyType2 = Boolean.class.getCanonicalName();
         String propertyName2 = "booleanProperty";
-        nested2.addSimpleProperty(propertyName2, propertyType2);
+        nested2.addSimpleProperty(propertyName2, new FactModelTree.PropertyTypeName(propertyType2));
 
         hiddenFacts.put("tNested", nested1);
         hiddenFacts.put("tNested2", nested2);
@@ -323,9 +323,9 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
     }
 
     private FactModelTree createFactModelTree(String name, String path, DMNType type, SortedMap<String, FactModelTree> hiddenFacts, FactModelTree.Type fmType) {
-        Map<String, String> simpleFields = new HashMap<>();
+        Map<String, FactModelTree.PropertyTypeName> simpleFields = new HashMap<>();
         if (!type.isComposite()) {
-            simpleFields.put(VALUE, type.getName());
+            simpleFields.put(VALUE, new FactModelTree.PropertyTypeName(type.getName()));
             FactModelTree simpleFactModelTree = new FactModelTree(name, "", simpleFields, new HashMap<>(), fmType);
             simpleFactModelTree.setSimple(true);
             return simpleFactModelTree;
@@ -333,7 +333,10 @@ public class DMNSimulationSettingsCreationStrategyTest extends AbstractDMNTest {
         FactModelTree factModelTree = new FactModelTree(name, "", simpleFields, new HashMap<>(), fmType);
         for (Map.Entry<String, DMNType> entry : type.getFields().entrySet()) {
             if (!entry.getValue().isComposite()) {
-                simpleFields.put(entry.getKey(), entry.getValue().getName());
+                FactModelTree.PropertyTypeName propertyTypeName = entry.getValue().getBaseType() != null ?
+                        new FactModelTree.PropertyTypeName(entry.getValue().getName(), entry.getValue().getBaseType().getName()) :
+                        new FactModelTree.PropertyTypeName(entry.getValue().getName());
+                simpleFields.put(entry.getKey(), propertyTypeName);
             } else {
                 String expandableId = path + "." + entry.getKey();
                 factModelTree.addExpandableProperty(entry.getKey(), expandableId);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMODataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMODataManagementStrategy.java
@@ -154,7 +154,7 @@ public abstract class AbstractDMODataManagementStrategy extends AbstractDataMana
      * will always be a <code>java.lang.String</code>
      */
     public FactModelTree getFactModelTree(String factName, Map<String, String> superTypeMap, ModelField[] modelFields) {
-        Map<String, String> simpleProperties = new HashMap<>();
+        Map<String, FactModelTree.PropertyTypeName> simpleProperties = new HashMap<>();
         Map<String, List<String>> genericTypesMap = new HashMap<>();
         String factPackageName = packageName;
         String fullFactClassName = getFQCNByFactName(factName);
@@ -162,14 +162,14 @@ public abstract class AbstractDMODataManagementStrategy extends AbstractDataMana
             factPackageName = fullFactClassName.substring(0, fullFactClassName.lastIndexOf('.'));
         }
         if (ScenarioSimulationSharedUtils.isEnumCanonicalName(superTypeMap.get(factName))) {
-            simpleProperties.put(ConstantsHolder.VALUE, fullFactClassName);
+            simpleProperties.put(ConstantsHolder.VALUE, new FactModelTree.PropertyTypeName(fullFactClassName));
             return getSimpleClassFactModelTree(factName, fullFactClassName);
         }
 
         for (ModelField modelField : modelFields) {
             if (!modelField.getName().equals("this")) {
                 String className = defineClassNameField(modelField.getClassName(), superTypeMap);
-                simpleProperties.put(modelField.getName(), className);
+                simpleProperties.put(modelField.getName(), new FactModelTree.PropertyTypeName(className));
                 if (ScenarioSimulationSharedUtils.isCollection(className)) {
                     populateGenericTypeMap(genericTypesMap, factName, modelField.getName(), ScenarioSimulationSharedUtils.isList(className));
                 }
@@ -257,9 +257,9 @@ public abstract class AbstractDMODataManagementStrategy extends AbstractDataMana
     public void populateFactModelTree(FactModelTree toPopulate, final SortedMap<String, FactModelTree> factTypeFieldsMap) {
         List<String> toRemove = new ArrayList<>();
         toPopulate.getSimpleProperties().forEach((key, value) -> {
-            if (factTypeFieldsMap.containsKey(value)) {
+            if (factTypeFieldsMap.containsKey(value.getTypeName())) {
                 toRemove.add(key);
-                toPopulate.addExpandableProperty(key, factTypeFieldsMap.get(value).getFactName());
+                toPopulate.addExpandableProperty(key, factTypeFieldsMap.get(value.getTypeName()).getFactName());
             }
         });
         toRemove.forEach(toPopulate::removeSimpleProperty);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategy.java
@@ -59,10 +59,9 @@ public abstract class AbstractDataManagementStrategy implements DataManagementSt
 
     public static FactModelTree getSimpleClassFactModelTree(String simpleClass, String canonicalName) {
         String key = simpleClass;
-        Map<String, String> simpleProperties = new HashMap<>();
-        String fullName = canonicalName;
-        simpleProperties.put(VALUE, fullName);
-        String packageName = fullName.substring(0, fullName.lastIndexOf('.'));
+        Map<String, FactModelTree.PropertyTypeName> simpleProperties = new HashMap<>();
+        simpleProperties.put(VALUE, new FactModelTree.PropertyTypeName(canonicalName));
+        String packageName = canonicalName.substring(0, canonicalName.lastIndexOf('.'));
         FactModelTree toReturn = new FactModelTree(key, packageName, simpleProperties, new HashMap<>());
         toReturn.setSimple(true);
         return toReturn;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
@@ -162,7 +163,9 @@ public class CollectionEditorSingletonDOMElementFactory extends BaseSingletonDOM
             toReturn = new HashMap<>();
             toReturn.put(VALUE, typeName);
         } else {
-            toReturn = scenarioSimulationContext.getDataObjectFieldsMap().get(typeName).getSimpleProperties();
+            toReturn = scenarioSimulationContext.getDataObjectFieldsMap().get(typeName).getSimpleProperties()
+                    .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                                                                  e -> e.getValue().getTypeName()));
         }
         return toReturn;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenter.java
@@ -35,13 +35,12 @@ public class FieldItemPresenter implements FieldItemView.Presenter {
 
     protected Map<String, FieldItemView> fieldItemMap = new HashMap<>();
 
-
     @Override
-    public LIElement getLIElement(String parentPath, String factName, String fieldName, String className) {
+    public LIElement getLIElement(String parentPath, String factName, String fieldName, String className, String classTypeName) {
         String key = parentPath  + "." + fieldName;
         if (!fieldItemMap.containsKey(key)) {
             FieldItemView fieldItemView = viewsProvider.getFieldItemView();
-            fieldItemView.setFieldData(parentPath, factName, fieldName, className);
+            fieldItemView.setFieldData(parentPath, factName, fieldName, className, classTypeName);
             fieldItemView.setPresenter(this);
             fieldItemMap.put(key, fieldItemView);
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemView.java
@@ -27,9 +27,10 @@ public interface FieldItemView {
          * @param factName
          * @param fieldName
          * @param className
+         * @param classTypeName
          * @return
          */
-        LIElement getLIElement(String parentPath, String factName, String fieldName, String className);
+        LIElement getLIElement(String parentPath, String factName, String fieldName, String className, String classTypeName);
 
         void onFieldElementClick(FieldItemView selected);
 
@@ -50,6 +51,8 @@ public interface FieldItemView {
 
     String getClassName();
 
+    String getClassTypeName();
+
     void setPresenter(FieldItemView.Presenter fieldItemPresenter);
 
     /**
@@ -62,8 +65,9 @@ public interface FieldItemView {
      * @param factName
      * @param fieldName
      * @param className
+     * @param classTypeName
      */
-    void setFieldData(String fullPath, String factName, String fieldName, String className);
+    void setFieldData(String fullPath, String factName, String fieldName, String className, String classTypeName);
 
     LIElement getLIElement();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewImpl.java
@@ -49,14 +49,15 @@ public class FieldItemViewImpl implements FieldItemView {
     private String factName;
     private String fieldName;
     private String className;
+    private String classTypeName;
 
     @Override
-    public void setFieldData(String fullPath, String factName, String fieldName, String className) {
+    public void setFieldData(String fullPath, String factName, String fieldName, String className, String classTypeName) {
         String innerHtml = new StringBuilder()
                 .append("<a>")
                 .append(fieldName)
                 .append("</a> [")
-                .append(className)
+                .append(classTypeName)
                 .append("]")
                 .toString();
         fieldNameElement.setInnerHTML(innerHtml);
@@ -68,6 +69,7 @@ public class FieldItemViewImpl implements FieldItemView {
         this.fieldName = fieldName;
         this.className = className;
         this.fullPath = fullPath;
+        this.classTypeName = classTypeName;
     }
 
     @Override
@@ -88,6 +90,11 @@ public class FieldItemViewImpl implements FieldItemView {
     @Override
     public String getClassName() {
         return className;
+    }
+
+    @Override
+    public String getClassTypeName() {
+        return classTypeName;
     }
 
     @Override
@@ -154,12 +161,13 @@ public class FieldItemViewImpl implements FieldItemView {
         return Objects.equals(getFullPath(), that.getFullPath()) &&
                 Objects.equals(getFactName(), that.getFactName()) &&
                 Objects.equals(getFieldName(), that.getFieldName()) &&
-                Objects.equals(getClassName(), that.getClassName());
+                Objects.equals(getClassName(), that.getClassName()) &&
+                Objects.equals(getClassTypeName(), that.getClassTypeName());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getFullPath(), getFactName(), getFieldName(), getClassName());
+        return Objects.hash(getFullPath(), getFactName(), getFieldName(), getClassName(), getClassTypeName());
     }
 
     @Override
@@ -169,6 +177,7 @@ public class FieldItemViewImpl implements FieldItemView {
                 ", factName='" + factName + '\'' +
                 ", fieldName='" + fieldName + '\'' +
                 ", className='" + className + '\'' +
+                ", classNameShown='" + classTypeName + '\'' +
                 '}';
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenter.java
@@ -198,7 +198,8 @@ public class ListGroupItemPresenter implements ListGroupItemView.Presenter {
             toPopulate.setFactNameAndType(factName, factModelTree.getFactName()); // the name of the property differ from the type of the factModelTree: this means that we are populating children of the class
         }
         String fullPath = parentPath.isEmpty() ? factName : parentPath + "." + factName;
-        factModelTree.getSimpleProperties().forEach((key, value) -> toPopulate.addFactField(fieldItemPresenter.getLIElement(fullPath, factName, key, value)));
+        factModelTree.getSimpleProperties().forEach((key, value) ->
+                toPopulate.addFactField(fieldItemPresenter.getLIElement(fullPath, factName, key, value.getTypeName(), value.getPropertyTypeNameToVisualize())));
         factModelTree.getExpandableProperties().forEach(
                 (key, value) -> toPopulate.addExpandableFactField(getDivElement(fullPath, key, value)));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/TestProperties.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.drools.scenariosimulation.api.model.FactMappingType;
+import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
@@ -133,10 +134,10 @@ public class TestProperties {
 
     public static final String STRING_CLASS_NAME = String.class.getCanonicalName();
     public static final String NUMBER_CLASS_NAME = Number.class.getCanonicalName();
-    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE = new HashMap<>();
-    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1 = new HashMap<>();
-    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2 = new HashMap<>();
-    public static final Map<String, String> EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3 = new HashMap<>();
+    public static final Map<String, FactModelTree.PropertyTypeName> EXPECTED_MAP_FOR_SIMPLE_TYPE = new HashMap<>();
+    public static final Map<String, FactModelTree.PropertyTypeName> EXPECTED_MAP_FOR_SIMPLE_TYPE_2 = new HashMap<>();
+    public static final Map<String, String> EXPECTED_MAP_FOR_EXPANDABLE_TYPE = new HashMap<>();
+    public static final Map<String, String> EXPECTED_MAP_FOR_EXPANDABLE_TYPE_2 = new HashMap<>();
 
     public static final Double GRID_WIDTH = 100.0;
     public static final Double HEADER_HEIGHT = 10.0;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/SetHeaderCellValueCommandTest.java
@@ -108,12 +108,12 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioGridCommandTe
 
     @Test
     public void recursivelyFindIsPropertyType() {
-        Map<String, String> bookSimpleProperties = new HashMap<>();
-        bookSimpleProperties.put("name", "String");
+        Map<String, FactModelTree.PropertyTypeName> bookSimpleProperties = new HashMap<>();
+        bookSimpleProperties.put("name", new FactModelTree.PropertyTypeName("String"));
         Map<String, String> bookExpandableProperties = new HashMap<>();
         bookExpandableProperties.put("author", "Author");
-        Map<String, String> authorSimpleProperties = new HashMap<>();
-        authorSimpleProperties.put("books", "List");
+        Map<String, FactModelTree.PropertyTypeName> authorSimpleProperties = new HashMap<>();
+        authorSimpleProperties.put("books", new FactModelTree.PropertyTypeName("List"));
         Map<String, String> authorExpandableProperties = new HashMap<>();
         FactModelTree bookFactModelTreeMock = getMockedFactModelTree(bookSimpleProperties, bookExpandableProperties);
         FactModelTree authorFactModelTreeMock = getMockedFactModelTree(authorSimpleProperties, authorExpandableProperties);
@@ -125,7 +125,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioGridCommandTe
         assertTrue(((SetHeaderCellValueCommand) commandSpy).recursivelyFindIsPropertyType(scenarioSimulationContextLocal, bookFactModelTreeMock, Arrays.asList("author", "books")));
     }
 
-    private FactModelTree getMockedFactModelTree(Map<String, String> simpleProperties, Map<String, String> expandableProperties) {
+    private FactModelTree getMockedFactModelTree(Map<String, FactModelTree.PropertyTypeName> simpleProperties, Map<String, String> expandableProperties) {
         FactModelTree toReturn = mock(FactModelTree.class);
         when(toReturn.getSimpleProperties()).thenReturn(simpleProperties);
         when(toReturn.getExpandableProperties()).thenReturn(expandableProperties);
@@ -166,7 +166,7 @@ public class SetHeaderCellValueCommandTest extends AbstractScenarioGridCommandTe
         FactModelTree factModelTreeMock = mock(FactModelTree.class);
         doReturn(simplePropertyPresent).when((SetHeaderCellValueCommand) commandSpy).recursivelyFindIsPropertyType(eq(scenarioSimulationContextLocal), eq(factModelTreeMock), eq(MULTIPART_VALUE_ELEMENTS));
         if (factModelPresent) {
-            Map<String, String> simplePropertiesMock = mock(SortedMap.class);
+            Map<String, FactModelTree.PropertyTypeName> simplePropertiesMock = mock(SortedMap.class);
             when(factModelTreeMock.getSimpleProperties()).thenReturn(simplePropertiesMock);
             Map<String, String> expandablePropertiesMock = mock(SortedMap.class);
             when(factModelTreeMock.getExpandableProperties()).thenReturn(expandablePropertiesMock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDataManagementStrategyTest.java
@@ -43,6 +43,7 @@ import org.mockito.Captor;
 import org.uberfire.backend.vfs.ObservablePath;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -97,13 +98,15 @@ public class AbstractDataManagementStrategyTest extends AbstractScenarioSimulati
             String fullName = expectedClazz.getCanonicalName();
             String packageName = fullName.substring(0, fullName.lastIndexOf("."));
             assertEquals(packageName, retrieved.getFullPackage());
-            Map<String, String> simpleProperties = retrieved.getSimpleProperties();
+            Map<String, FactModelTree.PropertyTypeName> simpleProperties = retrieved.getSimpleProperties();
             assertNotNull(simpleProperties);
             assertEquals(1, simpleProperties.size());
             assertTrue(simpleProperties.containsKey(TestProperties.LOWER_CASE_VALUE));
-            String simplePropertyValue = simpleProperties.get(TestProperties.LOWER_CASE_VALUE);
+            FactModelTree.PropertyTypeName simplePropertyValue = simpleProperties.get(TestProperties.LOWER_CASE_VALUE);
             assertNotNull(simplePropertyValue);
-            assertEquals(fullName, simplePropertyValue);
+            assertEquals(fullName, simplePropertyValue.getTypeName());
+            assertEquals(fullName, simplePropertyValue.getPropertyTypeNameToVisualize());
+            assertFalse(simplePropertyValue.getBaseTypeName().isPresent());
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.drools.workbench.screens.scenariosimulation.client.factories;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,10 +43,10 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type.DMN;
 import static org.drools.scenariosimulation.api.model.ScenarioSimulationModel.Type.RULE;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2;
-import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_EXPANDABLE_TYPE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_EXPANDABLE_TYPE_2;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_SIMPLE_TYPE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.EXPECTED_MAP_FOR_SIMPLE_TYPE_2;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_FACT_CLASSNAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_CLASS_NAME;
@@ -114,20 +115,20 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
         when(factModelTreeMock.getSimpleProperties()).thenReturn(new HashMap<>());
         when(factModelTreeMock.getExpandableProperties()).thenReturn(new HashMap<>());
         /* This FactModelTree is used to test manageList and manageMap methods*/
-        when(factModelTreeMock1.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE);
-        when(factModelTreeMock1.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1);
+        when(factModelTreeMock1.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_SIMPLE_TYPE);
+        when(factModelTreeMock1.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_EXPANDABLE_TYPE);
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get(FULL_CLASS_NAME)).thenReturn(factModelTreeMock1);
-        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE.put("x", "y");
-        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1.put("a", "b");
+        EXPECTED_MAP_FOR_SIMPLE_TYPE.put("x", new FactModelTree.PropertyTypeName("y"));
+        EXPECTED_MAP_FOR_EXPANDABLE_TYPE.put("a", "b");
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get("testclass")).thenReturn(factModelTreeMock2);
-        when(factModelTreeMock2.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2);
-        when(factModelTreeMock2.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_1);
-        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2.put("z", "w");
+        when(factModelTreeMock2.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_SIMPLE_TYPE_2);
+        when(factModelTreeMock2.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_EXPANDABLE_TYPE);
+        EXPECTED_MAP_FOR_SIMPLE_TYPE_2.put("z", new FactModelTree.PropertyTypeName("w"));
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get(FULL_FACT_CLASSNAME)).thenReturn(factModelTreeMock3);
         when(scenarioSimulationContextLocal.getDataObjectFieldsMap().get(CLASS_NAME)).thenReturn(factModelTreeMock3);
-        when(factModelTreeMock3.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2);
-        when(factModelTreeMock3.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3);
-        EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_3.put("a", FULL_CLASS_NAME);
+        when(factModelTreeMock3.getSimpleProperties()).thenReturn(EXPECTED_MAP_FOR_SIMPLE_TYPE_2);
+        when(factModelTreeMock3.getExpandableProperties()).thenReturn(EXPECTED_MAP_FOR_EXPANDABLE_TYPE_2);
+        EXPECTED_MAP_FOR_EXPANDABLE_TYPE_2.put("a", FULL_CLASS_NAME);
     }
 
     @Test
@@ -159,9 +160,9 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
     @Test
     public void getExpandableProperties_NotSimpleType() {
         Map<String, Map<String, String>> expectedResult = new HashMap<>();
-        expectedResult.put("a", EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE_2);
+        expectedResult.put("a", Collections.singletonMap("z", "w"));
         Map<String, Map<String, String>> resultMap = collectionEditorSingletonDOMElementFactorySpy.getExpandablePropertiesMap(FULL_FACT_CLASSNAME);
-        assertEquals(resultMap, expectedResult);
+        assertEquals(expectedResult, resultMap);
     }
 
     @Test
@@ -180,7 +181,7 @@ public class CollectionEditorSingletonDOMElementFactoryTest extends AbstractFact
 
     @Test
     public void manageMap_NotRuleNotSimpleType() {
-        manageMap(FULL_CLASS_NAME, DMN, EXPECTED_MAP_FOR_NOT_SIMPLE_TYPE);
+        manageMap(FULL_CLASS_NAME, DMN, EXPECTED_MAP_FOR_EXPANDABLE_TYPE);
     }
 
     private void manageMap(String genericType1, ScenarioSimulationModel.Type type, Map<String, String> expectedMap1) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractTestToolsTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/AbstractTestToolsTest.java
@@ -75,12 +75,12 @@ abstract class AbstractTestToolsTest {
                     FactModelTree value = new FactModelTree(key, FACT_PACKAGE, getMockSimpleProperties(), new HashMap<>());
                     toReturn.put(key, value);
                     if (id == 1) {
-                        value.addSimpleProperty(getRandomString(), getRandomFactModelTree(toReturn, 0));
+                        value.addSimpleProperty(getRandomString(), getRandomType());
                     }
                     if (id == 2) {
-                        value.addSimpleProperty(getRandomString(), getRandomFactModelTree(toReturn, 1));
+                        value.addSimpleProperty(getRandomString(), getRandomType());
                         // Recursion
-                        value.addSimpleProperty(getRandomString(), value.getFactName());
+                        value.addSimpleProperty(getRandomString(), getRandomType());
                     }
                 });
         return toReturn;
@@ -89,18 +89,18 @@ abstract class AbstractTestToolsTest {
     protected SortedMap<String, FactModelTree> getSimpleJavaTypeFieldsMap() {
         SortedMap<String, FactModelTree> toReturn = new TreeMap<>();
         for (String key : DataManagementStrategy.SIMPLE_CLASSES_MAP.keySet()) {
-            Map<String, String> simpleProperties = new HashMap<>();
-            String fullName = DataManagementStrategy.SIMPLE_CLASSES_MAP.get(key).getCanonicalName();
+            Map<String, FactModelTree.PropertyTypeName> simpleProperties = new HashMap<>();
+            FactModelTree.PropertyTypeName fullName = new FactModelTree.PropertyTypeName(DataManagementStrategy.SIMPLE_CLASSES_MAP.get(key).getCanonicalName());
             simpleProperties.put(LOWER_CASE_VALUE, fullName);
-            String packageName = fullName.substring(0, fullName.lastIndexOf("."));
+            String packageName = fullName.getTypeName().substring(0, fullName.getTypeName().lastIndexOf("."));
             FactModelTree value = new FactModelTree(key, packageName, simpleProperties, new HashMap<>());
             toReturn.put(key, value);
         }
         return toReturn;
     }
 
-    protected Map<String, String> getMockSimpleProperties() {
-        Map<String, String> toReturn = new HashMap<>();
+    protected Map<String, FactModelTree.PropertyTypeName> getMockSimpleProperties() {
+        Map<String, FactModelTree.PropertyTypeName> toReturn = new HashMap<>();
         IntStream
                 .range(0, +3)
                 .forEach(id -> toReturn.put(getRandomString(), getRandomType()));
@@ -119,19 +119,19 @@ abstract class AbstractTestToolsTest {
         return builder.toString();
     }
 
-    protected String getRandomType() {
+    protected FactModelTree.PropertyTypeName getRandomType() {
         int type = new Random().nextInt(4);
         switch (type) {
             case 0:
-                return "lava.lang.String";
+                return new FactModelTree.PropertyTypeName("lava.lang.String");
             case 1:
-                return "byte";
+                return new FactModelTree.PropertyTypeName("byte");
             case 2:
-                return "java.lang.Integer";
+                return new FactModelTree.PropertyTypeName("java.lang.Integer");
             case 3:
-                return "java.lang.Boolean";
+                return new FactModelTree.PropertyTypeName("java.lang.Boolean");
             default:
-                return "int";
+                return new FactModelTree.PropertyTypeName("int");
         }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemPresenterTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.spy;
@@ -58,9 +59,9 @@ public class FieldItemPresenterTest extends AbstractTestToolsTest {
 
     @Test
     public void getLIElement() {
-        fieldItemPresenter.getLIElement("", FACT_NAME, FACT_NAME, FACT_MODEL_TREE.getFactName());
+        fieldItemPresenter.getLIElement("", FACT_NAME, FACT_NAME, FACT_MODEL_TREE.getFactName(), CLASS_NAME);
         verify(viewsProviderMock, times(1)).getFieldItemView();
-        verify(mockFieldItemView, times(1)).setFieldData(eq(""), eq(FACT_NAME), eq(FACT_NAME), eq(FACT_MODEL_TREE.getFactName()));
+        verify(mockFieldItemView, times(1)).setFieldData(eq(""), eq(FACT_NAME), eq(FACT_NAME), eq(FACT_MODEL_TREE.getFactName()), eq(CLASS_NAME));
         verify(mockFieldItemView, times(1)).setPresenter(eq(fieldItemPresenter));
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/FieldItemViewTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FACT_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FIELD_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PROPERTY_PATH;
@@ -64,7 +65,7 @@ public class FieldItemViewTest extends AbstractTestToolsTest {
     @Before
     public void setup() {
         super.setup();
-        INNER_HTML = "<a>" + FIELD_NAME + "</a> [" + FACT_MODEL_TREE.getFactName() + "]";
+        INNER_HTML = "<a>" + FIELD_NAME + "</a> [" + CLASS_NAME + "]";
         ID_ATTRIBUTE = "fieldElement-" + FACT_NAME + "-" + FIELD_NAME;
         this.fieldItemViewSpy = spy(new FieldItemViewImpl() {
             {
@@ -79,7 +80,7 @@ public class FieldItemViewTest extends AbstractTestToolsTest {
 
     @Test
     public void setFieldData() {
-        fieldItemViewSpy.setFieldData(FULL_PROPERTY_PATH, FACT_NAME, FIELD_NAME, FACT_MODEL_TREE.getFactName());
+        fieldItemViewSpy.setFieldData(FULL_PROPERTY_PATH, FACT_NAME, FIELD_NAME, FACT_MODEL_TREE.getFactName(), CLASS_NAME);
         verify(fieldNameElementMock, times(1)).setInnerHTML(eq(INNER_HTML));
         verify(fieldNameElementMock, times(1)).setAttribute(eq("id"), eq(ID_ATTRIBUTE));
         verify(fieldNameElementMock, times(1)).setAttribute(eq("fieldName"), eq(FIELD_NAME));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/ListGroupItemPresenterTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -167,10 +168,10 @@ public class ListGroupItemPresenterTest extends AbstractTestToolsTest {
     public void populateListGroupItemView() {
         listGroupItemPresenter.populateListGroupItemView(listGroupItemViewMock, "", FACT_MODEL_TREE.getFactName(), FACT_MODEL_TREE);
         verify(listGroupItemViewMock, times(1)).setFactName(eq(FACT_MODEL_TREE.getFactName()));
-        Map<String, String> simpleProperties = FACT_MODEL_TREE.getSimpleProperties();
+        Map<String, FactModelTree.PropertyTypeName> simpleProperties = FACT_MODEL_TREE.getSimpleProperties();
         for (String key : simpleProperties.keySet()) {
-            String value = simpleProperties.get(key);
-            verify(fieldItemPresenterSpy, times(1)).getLIElement(eq(FACT_MODEL_TREE.getFactName()), eq(FACT_MODEL_TREE.getFactName()), eq(key), eq(value));
+            FactModelTree.PropertyTypeName value = simpleProperties.get(key);
+            verify(fieldItemPresenterSpy, times(1)).getLIElement(eq(FACT_MODEL_TREE.getFactName()), eq(FACT_MODEL_TREE.getFactName()), eq(key), eq(value.getTypeName()), eq(value.getPropertyTypeNameToVisualize()));
         }
         verify(listGroupItemViewMock, times(simpleProperties.size())).addFactField(anyObject());
         reset(listGroupItemViewMock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/TestToolsPresenterTest.java
@@ -91,13 +91,13 @@ public class TestToolsPresenterTest extends AbstractTestToolsTest {
         final String firstKey = dataObjectFactTreeMap.firstKey();
         final FactModelTree factModelTree = dataObjectFactTreeMap.get(firstKey);
         final String firstPropertyKey = (String) new ArrayList(factModelTree.getSimpleProperties().keySet()).get(0);
-        final String firstPropertyClass = factModelTree.getSimpleProperties().get(firstPropertyKey);
+        final FactModelTree.PropertyTypeName firstPropertyClass = factModelTree.getSimpleProperties().get(firstPropertyKey);
 
         when(selectedListGroupItemViewMock.getActualClassName()).thenReturn(firstKey);
 
         when(selectedFieldItemViewMock.getFullPath()).thenReturn(firstKey);
         when(selectedFieldItemViewMock.getFieldName()).thenReturn(firstPropertyKey);
-        when(selectedFieldItemViewMock.getClassName()).thenReturn(firstPropertyClass);
+        when(selectedFieldItemViewMock.getClassName()).thenReturn(firstPropertyClass.getTypeName());
 
         when(listGroupItemPresenterMock.getDivElement(FACT_NAME, FACT_MODEL_TREE)).thenReturn(divItemContainerMock);
         this.testToolsPresenterSpy = spy(new TestToolsPresenter(testToolsViewMock, listGroupItemPresenterMock) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/AbstractKogitoDMNService.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/AbstractKogitoDMNService.java
@@ -504,9 +504,9 @@ public abstract class AbstractKogitoDMNService implements KogitoDMNService {
                                                          final String factName,
                                                          final String propertyClass,
                                                          final FactModelTree.Type fmType) {
-        Map<String, String> simpleProperties = new HashMap<>();
+        Map<String, FactModelTree.PropertyTypeName> simpleProperties = new HashMap<>();
         FactModelTree simpleFactModelTree = new FactModelTree(factName, "", simpleProperties, genericTypeInfoMap, fmType);
-        simpleFactModelTree.addSimpleProperty(VALUE, propertyClass);
+        simpleFactModelTree.addSimpleProperty(VALUE, new FactModelTree.PropertyTypeName(propertyClass));
         simpleFactModelTree.setSimple(true);
         return simpleFactModelTree;
     }
@@ -534,13 +534,13 @@ public abstract class AbstractKogitoDMNService implements KogitoDMNService {
         if (!type.isComposite() && !isToBeManagedAsComposite(type)) {
             throw new IllegalStateException(WRONG_DMN_MESSAGE);
         }
-        Map<String, String> simpleFields = new HashMap<>();
+        Map<String, FactModelTree.PropertyTypeName> simpleFields = new HashMap<>();
         FactModelTree toReturn = new FactModelTree(name, "", simpleFields, genericTypeInfoMap, fmType);
         for (Map.Entry<String, ClientDMNType> entry : type.getFields().entrySet()) {
             String expandablePropertyName = fullPropertyPath + "." + entry.getKey();
             if (isToBeManagedAsCollection(entry.getValue())) {  // if it is a collection, generate the generic and add as hidden fact a simple or composite fact model tree
                 FactModelTree fact = createFactModelTreeForCollection(new HashMap<>(), entry.getKey(), entry.getValue(), hiddenFacts, FactModelTree.Type.UNDEFINED, alreadyVisited);
-                simpleFields.put(entry.getKey(), List.class.getCanonicalName());
+                simpleFields.put(entry.getKey(), new FactModelTree.PropertyTypeName(List.class.getCanonicalName()));
                 genericTypeInfoMap.put(entry.getKey(), fact.getGenericTypeInfo(VALUE));
             } else {
                 String typeName = entry.getValue().getName();
@@ -552,7 +552,7 @@ public abstract class AbstractKogitoDMNService implements KogitoDMNService {
                     }
                     toReturn.addExpandableProperty(entry.getKey(), typeName);
                 } else {  // a simple type is just name -> type
-                    simpleFields.put(entry.getKey(), typeName);
+                    simpleFields.put(entry.getKey(), new FactModelTree.PropertyTypeName(typeName));
                 }
             }
         }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilder.java
@@ -379,22 +379,21 @@ public class KogitoScenarioSimulationBuilder {
         List<String> previousSteps = new ArrayList<>(readOnlyPreviousSteps);
         // if is a simple type it generates a single column
         if (factModelTree.isSimple()) {
-
-            String factType = factModelTree.getSimpleProperties().get(VALUE);
-            factMappingExtractor.getFactMapping(factModelTree, VALUE, previousSteps, factType);
+            FactModelTree.PropertyTypeName factType = factModelTree.getSimpleProperties().get(VALUE);
+            factMappingExtractor.getFactMapping(factModelTree, VALUE, previousSteps, factType.getTypeName());
         }
         // otherwise it adds a column for each simple properties direct or nested
         else {
-            for (Map.Entry<String, String> entry : factModelTree.getSimpleProperties().entrySet()) {
+            for (Map.Entry<String, FactModelTree.PropertyTypeName> entry : factModelTree.getSimpleProperties().entrySet()) {
                 String factName = entry.getKey();
-                String factType = entry.getValue();
+                String factTypeName = entry.getValue().getTypeName();
 
-                FactMapping factMapping = factMappingExtractor.getFactMapping(factModelTree, factName, previousSteps, factType);
+                FactMapping factMapping = factMappingExtractor.getFactMapping(factModelTree, factName, previousSteps, factTypeName);
 
-                if (ScenarioSimulationSharedUtils.isList(factType)) {
+                if (ScenarioSimulationSharedUtils.isList(factTypeName)) {
                     factMapping.setGenericTypes(factModelTree.getGenericTypeInfo(factName));
                 }
-                factMapping.addExpressionElement(factName, factType);
+                factMapping.addExpressionElement(factName, factTypeName);
             }
 
             for (Map.Entry<String, String> entry : factModelTree.getExpandableProperties().entrySet()) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/AbstractKogitoDMNServiceTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/AbstractKogitoDMNServiceTest.java
@@ -893,7 +893,9 @@ public class AbstractKogitoDMNServiceTest {
         FactModelTree inputDataNameFact = factModelTuple.getVisibleFacts().get("inputDataName");
         assertNotNull(inputDataNameFact);
         assertTrue(inputDataNameFact.getSimpleProperties().size() == 1);
-        assertTrue(inputDataNameFact.getSimpleProperties().values().contains("number"));
+        assertEquals("number", inputDataNameFact.getSimpleProperties().get(VALUE).getTypeName());
+        assertEquals("number", inputDataNameFact.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        assertFalse(inputDataNameFact.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
     }
 
     @Test
@@ -907,7 +909,9 @@ public class AbstractKogitoDMNServiceTest {
         FactModelTree decisionDataNameFact = factModelTuple.getVisibleFacts().get("inputDecisionName");
         assertNotNull(decisionDataNameFact);
         assertTrue(decisionDataNameFact.getSimpleProperties().size() == 1);
-        assertTrue(decisionDataNameFact.getSimpleProperties().values().contains("string"));
+        assertEquals("string", decisionDataNameFact.getSimpleProperties().get(VALUE).getTypeName());
+        assertEquals("string", decisionDataNameFact.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        assertFalse(decisionDataNameFact.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
     }
 
     @Test
@@ -924,11 +928,15 @@ public class AbstractKogitoDMNServiceTest {
         FactModelTree inputDataNameFact = factModelTuple.getVisibleFacts().get("inputDataName");
         assertNotNull(inputDataNameFact);
         assertTrue(inputDataNameFact.getSimpleProperties().size() == 1);
-        assertTrue(inputDataNameFact.getSimpleProperties().values().contains("number"));
+        assertEquals("number", inputDataNameFact.getSimpleProperties().get(VALUE).getTypeName());
+        assertEquals("number", inputDataNameFact.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        assertFalse(inputDataNameFact.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
         FactModelTree decisionDataNameFact = factModelTuple.getVisibleFacts().get("inputDecisionName");
         assertNotNull(decisionDataNameFact);
         assertTrue(decisionDataNameFact.getSimpleProperties().size() == 1);
-        assertTrue(decisionDataNameFact.getSimpleProperties().values().contains("string"));
+        assertEquals("string", decisionDataNameFact.getSimpleProperties().get(VALUE).getTypeName());
+        assertEquals("string", decisionDataNameFact.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
+        assertFalse(decisionDataNameFact.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
     }
 
     @Test
@@ -940,8 +948,9 @@ public class AbstractKogitoDMNServiceTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE));
-        assertTrue(retrieved.getExpandableProperties().isEmpty());
+        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals(simpleString.getName(), retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());
         assertTrue(retrieved.getGenericTypesMap().isEmpty());
     }
 
@@ -955,8 +964,9 @@ public class AbstractKogitoDMNServiceTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE));
-        assertTrue(retrieved.getExpandableProperties().isEmpty());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());        assertTrue(retrieved.getExpandableProperties().isEmpty());
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey(VALUE));
         Assert.assertNotNull(retrieved.getGenericTypesMap().get(VALUE));
@@ -973,9 +983,13 @@ public class AbstractKogitoDMNServiceTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(2, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey("friends"));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends"));
-        assertTrue(retrieved.getSimpleProperties().containsKey(TYPE_NAME));
-        assertEquals(TYPE_NAME, retrieved.getSimpleProperties().get(TYPE_NAME));
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends").getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get("friends").getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get("friends").getPropertyTypeNameToVisualize());
+        assertTrue(retrieved.getSimpleProperties().containsKey("name"));
+        assertEquals(TYPE_NAME, retrieved.getSimpleProperties().get("name").getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get("name").getBaseTypeName().isPresent());
+        assertEquals(TYPE_NAME, retrieved.getSimpleProperties().get("name").getPropertyTypeNameToVisualize());
         //
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey("friends"));
@@ -998,8 +1012,9 @@ public class AbstractKogitoDMNServiceTest {
         assertEquals("testPath", retrieved.getFactName());
         assertEquals(1, retrieved.getSimpleProperties().size());
         assertTrue(retrieved.getSimpleProperties().containsKey(VALUE));
-        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE));
-        assertTrue(retrieved.getExpandableProperties().isEmpty());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getTypeName());
+        assertFalse(retrieved.getSimpleProperties().get(VALUE).getBaseTypeName().isPresent());
+        assertEquals("java.util.List", retrieved.getSimpleProperties().get(VALUE).getPropertyTypeNameToVisualize());        assertTrue(retrieved.getExpandableProperties().isEmpty());
         assertEquals(1, retrieved.getGenericTypesMap().size());
         assertTrue(retrieved.getGenericTypesMap().containsKey(VALUE));
         Assert.assertNotNull(retrieved.getGenericTypesMap().get(VALUE));
@@ -1063,5 +1078,3 @@ public class AbstractKogitoDMNServiceTest {
         return new ClientDMNType(NAMESPACE, TYPE_NAME, null, true, true, compositePersonField, null);
     }
 }
-
-

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilderTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/dmn/KogitoScenarioSimulationBuilderTest.java
@@ -147,7 +147,7 @@ public class KogitoScenarioSimulationBuilderTest {
         factModelTree.addExpandableProperty("recursiveProperty", "recursive");
         String propertyType = String.class.getCanonicalName();
         String propertyName = "simpleProperty";
-        factModelTree.addSimpleProperty(propertyName, propertyType);
+        factModelTree.addSimpleProperty(propertyName, new FactModelTree.PropertyTypeName(propertyType));
 
         hiddenFacts.put("recursive", factModelTree);
 
@@ -187,10 +187,10 @@ public class KogitoScenarioSimulationBuilderTest {
         FactModelTree nested2 = new FactModelTree("tNested2", "", new HashMap<>(), Collections.emptyMap());
         String propertyType = String.class.getCanonicalName();
         String propertyName = "stingProperty";
-        nested1.addSimpleProperty(propertyName, propertyType);
+        nested1.addSimpleProperty(propertyName, new FactModelTree.PropertyTypeName(propertyType));
         String propertyType2 = Boolean.class.getCanonicalName();
         String propertyName2 = "booleanProperty";
-        nested2.addSimpleProperty(propertyName2, propertyType2);
+        nested2.addSimpleProperty(propertyName2, new FactModelTree.PropertyTypeName(propertyType2));
 
         hiddenFacts.put("tNested", nested1);
         hiddenFacts.put("tNested2", nested2);


### PR DESCRIPTION
@danielezonca @jstastny-cz 

Backport of https://github.com/kiegroup/drools-wb/pull/1397 (Cherrypicked, not other changes) in `7.39.x` branch 


https://issues.redhat.com/browse/DROOLS-5317
https://issues.redhat.com/browse/RHDM-1153