### PR TITLE
DROOLS-5576: Cancel editing mode properly for header cells

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElement.java
@@ -78,4 +78,11 @@ public class ScenarioHeaderTextAreaDOMElement extends ScenarioCellTextAreaDOMEle
         }
     }
 
+    @Override
+    public void detach() {
+        super.detach();
+        if (scenarioHeaderMetaData != null) {
+            scenarioHeaderMetaData.setEditingMode(false);
+        }
+    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/domelements/ScenarioHeaderTextAreaDOMElementTest.java
@@ -120,8 +120,10 @@ public class ScenarioHeaderTextAreaDOMElementTest extends AbstractFactoriesTest 
 
     @Test
     public void testDetachCancelEditMode() {
+        scenarioHeaderTextAreaDOMElement.setScenarioHeaderMetaData(scenarioHeaderMetaDataMock);
         scenarioHeaderTextAreaDOMElement.detach();
 
         verify(scenarioGridCellMock).setEditingMode(false);
+        verify(scenarioHeaderMetaDataMock).setEditingMode(false);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/AbstractFactoriesTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/factories/AbstractFactoriesTest.java
@@ -16,15 +16,12 @@
 package org.drools.workbench.screens.scenariosimulation.client.factories;
 
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.user.client.Element;
 import com.google.gwtmockito.GwtMockito;
 import com.google.gwtmockito.fakes.FakeProvider;
 import org.drools.workbench.screens.scenariosimulation.client.AbstractScenarioSimulationTest;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.junit.Before;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
@@ -42,10 +39,6 @@ public abstract class AbstractFactoriesTest extends AbstractScenarioSimulationTe
     protected Element elementMock;
     @Mock
     protected Style styleMock;
-    @Captor
-    protected ArgumentCaptor<KeyDownHandler> keyDownHandlerArgumentCaptor;
-
-
 
     @Before
     public void setup() {


### PR DESCRIPTION
The issue was intorduced by fixing scrolling when edit mode was active (DROOLS-4584).
The current state cancel edit mode when scrolling occurs.

For more details see:
- https://issues.redhat.com/browse/DROOLS-5576
- https://issues.redhat.com/browse/DROOLS-4584

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

paste the link(s) from GitHub here

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
