### PR TITLE
DROOLS-5883: Allow contains operator for string fields

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
@@ -209,7 +209,8 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null", "in", "not in"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches",
+                "soundslike", "not soundslike", "== null", "!= null", "in", "not in"});
     }
 
     @Test
@@ -221,7 +222,8 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches",
+                "soundslike", "not soundslike", "== null", "!= null"});
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/table/pages/FactPatternConstraintsPageTest.java
@@ -209,8 +209,9 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches",
-                "soundslike", "not soundslike", "== null", "!= null", "in", "not in"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=",
+                "contains", "not contains", "matches", "not matches", "soundslike", "not soundslike",
+                "== null", "!= null", "in", "not in"});
     }
 
     @Test
@@ -222,8 +223,9 @@ public class FactPatternConstraintsPageTest {
                                     conditionCol,
                                     callback);
 
-        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches",
-                "soundslike", "not soundslike", "== null", "!= null"});
+        verify(callback).callback(new String[]{"==", "!=", "<", ">", "<=", ">=",
+                "contains", "not contains", "matches", "not matches", "soundslike", "not soundslike",
+                "== null", "!= null"});
     }
 
     @Test


### PR DESCRIPTION
Guided decision table and guided rule editor will ofer 'contains' operator also for string fields

For more details see https://issues.redhat.com/browse/DROOLS-5883

**Thank you for submitting this pull request**

**JIRA**: [DROOLS-5883](https://issues.redhat.com/browse/DROOLS-5883)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-soup/pull/165
* kiegroup/drools#3281

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
