### PR TITLE
KOGITO-3302: Filtering out all DMNs inside target directory.

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -36,7 +36,7 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
 
     protected static final String DMN_FILE_SEARCH_PATTERN = "**/*.dmn";
     protected static final String TARGET_FOLDER = "target/";
-    protected static final String TARGET_FOLDER_NOT_ROOT = "/target/";
+    protected static final String TARGET_FOLDER_NOT_ROOT = "/" + TARGET_FOLDER;
 
 
     @Inject

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/main/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl.java
@@ -34,7 +34,10 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 @Dependent
 public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl implements ScenarioSimulationKogitoCreationAssetsDropdownProvider {
 
-    protected static final String DMN_FILE_SEARCH_PATTERN = "src/**/*.dmn";
+    protected static final String DMN_FILE_SEARCH_PATTERN = "**/*.dmn";
+    protected static final String TARGET_FOLDER = "target/";
+    protected static final String TARGET_FOLDER_NOT_ROOT = "/target/";
+
 
     @Inject
     protected KogitoResourceContentService resourceContentService;
@@ -51,6 +54,7 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
     protected RemoteCallback<List<String>> getRemoteCallback(Consumer<List<KieAssetsDropdownItem>> assetListConsumer) {
         return response -> {
             List<KieAssetsDropdownItem> toAccept = response.stream()
+                    .filter(item -> !isInTargetFolder(item))
                     .map(this::getKieAssetsDropdownItem)
                     .sorted(Comparator.comparing(KieAssetsDropdownItem::getText, String.CASE_INSENSITIVE_ORDER))
                     .collect(Collectors.toList());
@@ -69,5 +73,9 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImpl i
         int idx = fullPath.replaceAll("\\\\", "/").lastIndexOf('/');
         final String fileName = idx >= 0 ? fullPath.substring(idx + 1) : fullPath;
         return new KieAssetsDropdownItem(fileName, fullPath, fullPath, new HashMap<>());
+    }
+
+    private boolean isInTargetFolder(String path) {
+        return path.toLowerCase().startsWith(TARGET_FOLDER) || path.toLowerCase().contains(TARGET_FOLDER_NOT_ROOT);
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -80,15 +80,21 @@ public class ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTe
     @Test
     public void getRemoteCallBack() {
         RemoteCallback<List<String>> remoteCallBack = scenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplSpy.getRemoteCallback(assetConsumer);
-        remoteCallBack.callback(Arrays.asList("path/B", "a"));
+        remoteCallBack.callback(Arrays.asList("path/B", "a", "target/a", "TARGET/a", "/target/a", "/TARGET/a", "a/target/b", "a/TARGET/b", "mytarget/C", "q/mytarget/D"));
         verify(assetConsumer, times(1)).accept(dropDownListCaptor.capture());
-        assertTrue(dropDownListCaptor.getValue().size() == 2);
+        assertEquals(4, dropDownListCaptor.getValue().size());
         assertEquals("a", dropDownListCaptor.getValue().get(0).getText());
         assertEquals("a", dropDownListCaptor.getValue().get(0).getSubText());
         assertEquals("a", dropDownListCaptor.getValue().get(0).getValue());
         assertEquals("B", dropDownListCaptor.getValue().get(1).getText());
         assertEquals("path/B", dropDownListCaptor.getValue().get(1).getSubText());
         assertEquals("path/B", dropDownListCaptor.getValue().get(1).getValue());
+        assertEquals("C", dropDownListCaptor.getValue().get(2).getText());
+        assertEquals("mytarget/C", dropDownListCaptor.getValue().get(2).getSubText());
+        assertEquals("mytarget/C", dropDownListCaptor.getValue().get(2).getValue());
+        assertEquals("D", dropDownListCaptor.getValue().get(3).getText());
+        assertEquals("q/mytarget/D", dropDownListCaptor.getValue().get(3).getSubText());
+        assertEquals("q/mytarget/D", dropDownListCaptor.getValue().get(3).getValue());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-runtime/src/test/java/org/drools/workbench/screens/scenariosimulation/webapp/client/dropdown/ScenarioSimulationKogitoRuntimeCreationAssetsDropdownProviderImplTest.java
@@ -37,7 +37,6 @@ import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.spy;


### PR DESCRIPTION
I received some requests to modify the current pattern used to search DMN files. Currently it retrieves all DMN file under `src/**` glob, which is too strict in some cases (It's required to open VS with `src` as a root directory. 
Our requirement is to hide all duplicated DMN files on `target/` directory, so I decided to retrieve all DMN files from VSCode and apply a filter which follow that logic.

**JIRA**: https://issues.redhat.com/browse/KOGITO-3302


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
