### PR TITLE
KOGITO-4122: Improve Test Scenario creation UX

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.html
@@ -13,13 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div class="modal fade" id="newscesim" >
+<div class="modal fade" data-backdrop="static" id="test-scenario-creation">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
-                    <span class="pficon pficon-close"></span>
-                </button>
                 <h4 class="modal-title" data-field="main-title"></h4>
             </div>
             <div class="modal-body">
@@ -51,7 +48,7 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-primary" data-dismiss="modal" data-field="ok-button" type="button">
-                    <i class="fa fa-plus"></i>
+                    <span class="fa fa-plus"></span>
                 </button>
                 <button class="btn btn-default" data-dismiss="modal" data-field="cancel-button" type="button"></button>
             </div>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.html
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.html
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div class="modal fade" data-backdrop="static" id="test-scenario-creation">
+<div class="modal fade" data-backdrop="static" data-keyboard="false" id="test-scenario-creation">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupView.java
@@ -76,6 +76,7 @@ public class ScenarioSimulationKogitoCreationPopupView extends AbstractScenarioP
     }
 
     protected void initialize() {
+        cancelButton.getElement().remove();
         okButton.setEnabled(false);
         cancelButton.setText(ScenarioSimulationEditorConstants.INSTANCE.cancelButton());
         dmnAssetsDivElement.setAttribute(ConstantHolder.HIDDEN, "");
@@ -129,8 +130,6 @@ public class ScenarioSimulationKogitoCreationPopupView extends AbstractScenarioP
     }
 
     protected void enableCreateButtonForDMNScenario() {
-        if (selectedPath != null && !selectedPath.isEmpty()) {
-            okButton.setEnabled(true);
-        }
+        okButton.setEnabled(selectedPath != null && !selectedPath.isEmpty());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/popup/ScenarioSimulationKogitoCreationPopupViewTest.java
@@ -40,9 +40,7 @@ import org.uberfire.client.views.pfly.widgets.Modal;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,6 +59,8 @@ public class ScenarioSimulationKogitoCreationPopupViewTest {
     private Button okButtonMock;
     @Mock
     private Button cancelButtonMock;
+    @Mock
+    private HTMLElement cancelButtonElementMock;
     @Mock
     private Command okCommandMock;
     @Mock
@@ -100,6 +100,7 @@ public class ScenarioSimulationKogitoCreationPopupViewTest {
             }
         });
         when(scenarioSimulationKogitoCreationAssetsDropdownMock.getElement()).thenReturn(htmlElementMock);
+        when(cancelButtonMock.getElement()).thenReturn(cancelButtonElementMock);
     }
 
     @Test
@@ -111,6 +112,7 @@ public class ScenarioSimulationKogitoCreationPopupViewTest {
     @Test
     public void initialize() {
         scenarioSimulationCreationPopupViewSpy.initialize();
+        verify(cancelButtonElementMock, times(1)).remove();
         verify(okButtonMock, times(1)).setEnabled(eq(false));
         verify(cancelButtonMock, times(1)).setText(eq(ScenarioSimulationEditorConstants.INSTANCE.cancelButton()));
         verify(dmnAssetsDivElementMock, times(1)).setAttribute(eq(ConstantHolder.HIDDEN), eq(""));
@@ -154,14 +156,14 @@ public class ScenarioSimulationKogitoCreationPopupViewTest {
     @Test
     public void enableCreateButtonForDMNScenarioNullPath() {
         scenarioSimulationCreationPopupViewSpy.enableCreateButtonForDMNScenario();
-        verify(okButtonMock, never()).setEnabled(anyBoolean());
+        verify(okButtonMock, times(1)).setEnabled(eq(false));
     }
 
     @Test
     public void enableCreateButtonForDMNScenarioEmptyPath() {
         scenarioSimulationCreationPopupViewSpy.selectedPath = "";
         scenarioSimulationCreationPopupViewSpy.enableCreateButtonForDMNScenario();
-        verify(okButtonMock, never()).setEnabled(anyBoolean());
+        verify(okButtonMock, times(1)).setEnabled(eq(false));
     }
 
     @Test


### PR DESCRIPTION
Aim of this PR is to enhance  Test Scenario creation User Experience in Kogito (VSCode). 
Improved features are:
![Screenshot from 2021-01-08 14-22-28](https://user-images.githubusercontent.com/16005046/104161296-ec80ff00-53f2-11eb-8f9a-3f8b31c651e2.png)

- Currently is possible for the user to close the creation popup. Closing it, the user will land in a dead state, where is not possible to apply any action ( only closing and opening again the file). For this reason, I removed closing buttons. 



![Screenshot from 2021-01-08 14-23-39](https://user-images.githubusercontent.com/16005046/104161611-7335dc00-53f3-11eb-9ddc-b00a91478ce0.png)
- "Create Button" enablement. Currently if the user select a DMN file from the dropdown and then select "Select" item in the dropdown, the button remains enabled. Clicking on it will lead to an error. With this PR the button will be disabled in such a case.


**JIRA**: https://issues.redhat.com/browse/KOGITO-4122

[link](https://www.example.com)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
