### PR TITLE
DROOLS-5122: Test Scenario is not clearing alert 

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/pom.xml
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/pom.xml
@@ -190,6 +190,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-commons</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-message-console-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-library-api</artifactId>

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -59,6 +60,7 @@ import org.drools.workbench.screens.scenariosimulation.service.RunnerReportServi
 import org.drools.workbench.screens.scenariosimulation.service.ScenarioSimulationService;
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
+import org.guvnor.messageconsole.events.UnpublishMessagesEvent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
@@ -90,6 +92,7 @@ import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.Menus;
 
@@ -112,6 +115,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     private Caller<ImportExportService> importExportService;
     private Caller<RunnerReportService> runnerReportService;
     private ScenarioSimulationBusinessCentralDocksHandler scenarioSimulationBusinessCentralDocksHandler;
+    private Event<UnpublishMessagesEvent> unpublishMessagesEvent;
+    private SessionInfo sessionInfo;
     protected SimulationRunResult lastRunResult;
 
     public ScenarioSimulationEditorBusinessCentralWrapper() {
@@ -127,6 +132,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
                                                           final Caller<DMNTypeService> dmnTypeService,
                                                           final Caller<ImportExportService> importExportService,
                                                           final Caller<RunnerReportService> runnerReportService,
+                                                          final SessionInfo sessionInfo,
+                                                          final Event<UnpublishMessagesEvent> unpublishMessagesEvent,
                                                           final ScenarioSimulationBusinessCentralDocksHandler scenarioSimulationBusinessCentralDocksHandler) {
         super(scenarioSimulationEditorPresenter.getView());
         this.scenarioSimulationEditorPresenter = scenarioSimulationEditorPresenter;
@@ -138,6 +145,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
         this.oracleFactory = oracleFactory;
         this.placeManager = placeManager;
         this.type = scenarioSimulationEditorPresenter.getType();
+        this.unpublishMessagesEvent = unpublishMessagesEvent;
+        this.sessionInfo = sessionInfo;
         this.scenarioSimulationBusinessCentralDocksHandler = scenarioSimulationBusinessCentralDocksHandler;
     }
 
@@ -154,6 +163,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     public void onClose() {
         this.versionRecordManager.clear();
         scenarioSimulationEditorPresenter.onClose();
+        unPublishTestResultsAlerts();
         super.onClose();
     }
 
@@ -237,12 +247,22 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
 
     @Override
     public void onRunScenario(RemoteCallback<SimulationRunResult> refreshModelCallback, ScenarioSimulationHasBusyIndicatorDefaultErrorCallback scenarioSimulationHasBusyIndicatorDefaultErrorCallback, ScesimModelDescriptor simulationDescriptor, Settings settings, List<ScenarioWithIndex> toRun, Background background) {
+        unPublishTestResultsAlerts();
         service.call(refreshModelCallback, scenarioSimulationHasBusyIndicatorDefaultErrorCallback)
                 .runScenario(versionRecordManager.getCurrentPath(),
                              simulationDescriptor,
                              toRun,
                              settings,
                              background);
+    }
+
+    @Override
+    public void unPublishTestResultsAlerts() {
+        final UnpublishMessagesEvent unpublishMessagesEvent = new UnpublishMessagesEvent();
+        unpublishMessagesEvent.setShowSystemConsole(false);
+        unpublishMessagesEvent.setMessageType("TestResults");
+        unpublishMessagesEvent.setSessionId(sessionInfo.getId());
+        this.unpublishMessagesEvent.fire(unpublishMessagesEvent);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -163,7 +163,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     public void onClose() {
         this.versionRecordManager.clear();
         scenarioSimulationEditorPresenter.onClose();
-        unPublishTestResultsAlerts();
+        unpublishTestResultsAlerts();
         super.onClose();
     }
 
@@ -247,7 +247,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
 
     @Override
     public void onRunScenario(RemoteCallback<SimulationRunResult> refreshModelCallback, ScenarioSimulationHasBusyIndicatorDefaultErrorCallback scenarioSimulationHasBusyIndicatorDefaultErrorCallback, ScesimModelDescriptor simulationDescriptor, Settings settings, List<ScenarioWithIndex> toRun, Background background) {
-        unPublishTestResultsAlerts();
+        unpublishTestResultsAlerts();
         service.call(refreshModelCallback, scenarioSimulationHasBusyIndicatorDefaultErrorCallback)
                 .runScenario(versionRecordManager.getCurrentPath(),
                              simulationDescriptor,
@@ -257,12 +257,12 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     }
 
     @Override
-    public void unPublishTestResultsAlerts() {
-        final UnpublishMessagesEvent unpublishMessagesEvent = new UnpublishMessagesEvent();
-        unpublishMessagesEvent.setShowSystemConsole(false);
-        unpublishMessagesEvent.setMessageType("TestResults");
-        unpublishMessagesEvent.setSessionId(sessionInfo.getId());
-        this.unpublishMessagesEvent.fire(unpublishMessagesEvent);
+    public void unpublishTestResultsAlerts() {
+        final UnpublishMessagesEvent event = new UnpublishMessagesEvent();
+        event.setShowSystemConsole(false);
+        event.setMessageType("TestResults");
+        event.setSessionId(sessionInfo.getId());
+        this.unpublishMessagesEvent.fire(event);
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import javax.enterprise.event.Event;
+
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.scenariosimulation.api.model.AbstractScesimModel;
@@ -52,6 +54,7 @@ import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.test.TestResultMessage;
 import org.guvnor.messageconsole.client.console.widget.button.AlertsButtonMenuItemBuilder;
+import org.guvnor.messageconsole.events.UnpublishMessagesEvent;
 import org.gwtbootstrap3.client.ui.NavTabs;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.jboss.errai.common.client.api.ErrorCallback;
@@ -85,6 +88,7 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.promise.SyncPromises;
+import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 
@@ -174,6 +178,10 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     private CoverageReportPresenter coverageReportPresenterMock;
     @Mock
     private ObservablePath pathMock;
+    @Mock
+    private Event<UnpublishMessagesEvent> unpublishMessagesEventMock;
+    @Mock
+    private SessionInfo sessionInfoMock;
     @Captor
     private ArgumentCaptor<Command> commandArgumentCaptor;
 
@@ -200,6 +208,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
                                                                                                                new CallerMock<>(dmnTypeServiceMock),
                                                                                                                importExportCaller,
                                                                                                                runnerReportServiceCaller,
+                                                                                                               sessionInfoMock,
+                                                                                                               unpublishMessagesEventMock,
                                                                                                                scenarioSimulationBusinessCentralDocksHandlerMock) {
             {
                 this.kieView = kieViewMock;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -459,6 +459,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(UpdateSettingsDataEvent updateSettingsDataEvent) {
         if (updateSettingsDataEvent.getSettingsValueChanged().test(context.getScenarioSimulationModel().getSettings())) {
             commonExecution(new UpdateSettingsDataCommand(updateSettingsDataEvent.getSettingsChangeToApply()), false);
+            scenarioSimulationEditorPresenter.unPublishTestResultsAlerts();
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -459,7 +459,7 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     public void onEvent(UpdateSettingsDataEvent updateSettingsDataEvent) {
         if (updateSettingsDataEvent.getSettingsValueChanged().test(context.getScenarioSimulationModel().getSettings())) {
             commonExecution(new UpdateSettingsDataCommand(updateSettingsDataEvent.getSettingsChangeToApply()), false);
-            scenarioSimulationEditorPresenter.unPublishTestResultsAlerts();
+            scenarioSimulationEditorPresenter.unpublishTestResultsAlerts();
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -651,7 +651,7 @@ public class ScenarioSimulationEditorPresenter {
         return () -> populateRightDocks(TestToolsPresenter.IDENTIFIER);
     }
 
-    public void unPublishTestResultsAlerts() {
-        scenarioSimulationEditorWrapper.unPublishTestResultsAlerts();
+    public void unpublishTestResultsAlerts() {
+        scenarioSimulationEditorWrapper.unpublishTestResultsAlerts();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -650,4 +650,8 @@ public class ScenarioSimulationEditorPresenter {
     private Command createPopulateTestToolsCommand() {
         return () -> populateRightDocks(TestToolsPresenter.IDENTIFIER);
     }
+
+    public void unPublishTestResultsAlerts() {
+        scenarioSimulationEditorWrapper.unPublishTestResultsAlerts();
+    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
@@ -62,6 +62,8 @@ public interface ScenarioSimulationEditorWrapper {
 
     void selectBackgroundTab();
 
+    void unPublishTestResultsAlerts();
+
     AbstractScenarioSimulationDocksHandler getScenarioSimulationDocksHandler();
 
     ScenarioSimulationEditorPresenter getScenarioSimulationEditorPresenter();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
@@ -62,7 +62,7 @@ public interface ScenarioSimulationEditorWrapper {
 
     void selectBackgroundTab();
 
-    void unPublishTestResultsAlerts();
+    void unpublishTestResultsAlerts();
 
     AbstractScenarioSimulationDocksHandler getScenarioSimulationDocksHandler();
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -496,6 +496,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         scenarioSimulationEventHandler.onEvent(event);
         verify(predicateMock, times(1)).test(eq(settingsLocal));
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(isA(UpdateSettingsDataCommand.class), eq(false));
+        verify(scenarioSimulationEditorPresenterMock, times(1)).unpublishTestResultsAlerts();
     }
 
     @Test
@@ -507,6 +508,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         scenarioSimulationEventHandler.onEvent(event);
         verify(predicateMock, times(1)).test(eq(settingsLocal));
         verify(scenarioSimulationEventHandler, never()).commonExecution(isA(UpdateSettingsDataCommand.class), eq(false));
+        verify(scenarioSimulationEditorPresenterMock, never()).unpublishTestResultsAlerts();
     }
 
     @Test
@@ -515,6 +517,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         UpdateSettingsDataEvent event = new UpdateSettingsDataEvent(consumerMock);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, times(1)).commonExecution(isA(UpdateSettingsDataCommand.class), eq(false));
+        verify(scenarioSimulationEditorPresenterMock, times(1)).unpublishTestResultsAlerts();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -748,4 +748,10 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         verify(abstractScenarioSimulationDocksHandlerMock, times(1)).getSettingsPresenter();
         verify(presenterSpy, times(1)).updateSettings(settingsPresenterMock);
     }
+
+    @Test
+    public void unpublishTestResultsAlerts(){
+        presenterSpy.unpublishTestResultsAlerts();
+        verify(scenarioSimulationEditorWrapperMock, times(1)).unpublishTestResultsAlerts();
+    }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -291,6 +291,11 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
     }
 
     @Override
+    public void unPublishTestResultsAlerts() {
+        // Not used in Kogito
+    }
+
+    @Override
     public AbstractScenarioSimulationDocksHandler getScenarioSimulationDocksHandler() {
         return scenarioSimulationKogitoDocksHandler;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -291,7 +291,7 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
     }
 
     @Override
-    public void unPublishTestResultsAlerts() {
+    public void unpublishTestResultsAlerts() {
         // Not used in Kogito
     }
 


### PR DESCRIPTION
A cleanup of "TestResults" Alerts is now performed when:
- A Test Scenario run is launched;
- Setting data are changed;
- Test Scenario editor is closed;

**JIRA**: https://issues.redhat.com/browse/DROOLS-5122

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
