### PR TITLE
DROOLS-5512: Unsaved changes dialog for a Test Scenario executed right after creation

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -484,8 +484,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
             addImportsTab(importsWidget);
         }
         baseView.hideBusyIndicator();
-        setOriginalHash(scenarioSimulationEditorPresenter.getJsonModel(model).hashCode());
         scenarioSimulationEditorPresenter.getModelSuccessCallbackMethod(dataManagementStrategy, model);
+        setOriginalHash(scenarioSimulationEditorPresenter.getJsonModel(model).hashCode());
     }
 
     protected void onBackgroundTabSelected() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
@@ -67,6 +67,7 @@ import org.kie.workbench.common.widgets.metadata.client.validation.AssetUpdateVa
 import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.mvp.PerspectiveManager;
@@ -96,10 +97,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -586,8 +589,10 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         /* Not possible to mock a new Instance, for this reason any()s are used */
         verify(importsWidgetPresenterMock, times(1)).setContent(any(), any(), anyBoolean());
         verify(scenarioSimulationViewMock, times(1)).hideBusyIndicator();
-        verify(scenarioSimulationEditorPresenterMock, times(1)).getJsonModel(eq(modelLocal));
-        verify(scenarioSimulationEditorPresenterMock, times(1)).getModelSuccessCallbackMethod(isA(DataManagementStrategy.class), eq(modelLocal));
+        InOrder inOrder = inOrder(scenarioSimulationEditorBusinessClientWrapper, scenarioSimulationEditorPresenterMock);
+        inOrder.verify(scenarioSimulationEditorPresenterMock, times(1)).getModelSuccessCallbackMethod(isA(DataManagementStrategy.class), eq(modelLocal));
+        inOrder.verify(scenarioSimulationEditorPresenterMock, times(1)).getJsonModel(eq(modelLocal));
+        inOrder.verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setOriginalHash(anyInt());
     }
 
     @Test
@@ -604,6 +609,10 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         verify(scenarioSimulationViewMock, times(1)).hideBusyIndicator();
         verify(scenarioSimulationEditorPresenterMock, times(1)).getJsonModel(eq(modelLocal));
         verify(scenarioSimulationEditorPresenterMock, times(1)).getModelSuccessCallbackMethod(isA(DataManagementStrategy.class), eq(modelLocal));
+        InOrder inOrder = inOrder(scenarioSimulationEditorBusinessClientWrapper, scenarioSimulationEditorPresenterMock);
+        inOrder.verify(scenarioSimulationEditorPresenterMock, times(1)).getModelSuccessCallbackMethod(isA(DataManagementStrategy.class), eq(modelLocal));
+        inOrder.verify(scenarioSimulationEditorPresenterMock, times(1)).getJsonModel(eq(modelLocal));
+        inOrder.verify(scenarioSimulationEditorBusinessClientWrapper, times(1)).setOriginalHash(anyInt());
     }
 
     @Test


### PR DESCRIPTION
The issue occurs when a new Test Scenario is created in BC and the user closes it right after its creation. In this case, the Unsaved changes modal appears even if no changes are applied by the user.

**JIRA**: https://issues.redhat.com/browse/DROOLS-5512

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
