### PR TITLE
DROOLS-5230: Managing a List of structures in Test Scenario editor produces an Exception

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementView.java
@@ -106,6 +106,8 @@ public interface ElementView<T extends ElementView.Presenter> extends HasPresent
      */
     String getItemId();
 
+    void setItemSeparatorText(String itemSeparatorText);
+
     /**
      * @return the <code>LIElement</code> containing all the item properties
      */

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementViewImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementViewImpl.java
@@ -89,6 +89,11 @@ public abstract class ElementViewImpl<T extends ElementView.Presenter> implement
     }
 
     @Override
+    public void setItemSeparatorText(String itemSeparatorText) {
+        this.itemSeparatorText.setInnerText(itemSeparatorText);
+    }
+
+    @Override
     public LIElement getItemContainer() {
         return itemContainer;
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
@@ -54,9 +54,12 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     public void onToggleRowExpansion(ItemElementView itemElementView, boolean isShown) {
         CollectionEditorUtils.toggleRowExpansion(itemElementView.getFaAngleRight(), !isShown);
         propertyPresenter.onToggleRowExpansion(itemElementView.getItemId(), isShown);
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(generateExpandableItemElementID(itemElementView,
-                                                                                                                                                                                expandablePropertyName),
-                                                                                                                                                isShown));
+        if (itemIdExpandablePropertiesMap.containsKey(itemElementView.getItemId())) {
+            itemIdExpandablePropertiesMap.get(itemElementView.getItemId())
+                    .forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(generateExpandableItemElementID(itemElementView,
+                                                                                                                              expandablePropertyName),
+                                                                                              isShown));
+        }
         updateCommonToggleStatus(isShown);
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
@@ -54,7 +54,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     public void onToggleRowExpansion(ItemElementView itemElementView, boolean isShown) {
         CollectionEditorUtils.toggleRowExpansion(itemElementView.getFaAngleRight(), !isShown);
         propertyPresenter.onToggleRowExpansion(itemElementView.getItemId(), isShown);
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(expandablePropertyName, isShown));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(itemElementView.getItemId() + "." + expandablePropertyName, isShown));
         updateCommonToggleStatus(isShown);
     }
 
@@ -64,7 +64,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
             onToggleRowExpansion(itemElementView, false);
         }
         propertyPresenter.editProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.editProperties(expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.editProperties(itemElementView.getItemId() + "." + expandablePropertyName));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.INLINE);
         collectionEditorPresenter.toggleEditingStatus(true);
     }
@@ -72,7 +72,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void onStopEditingItem(ItemElementView itemElementView) {
         propertyPresenter.stopEditProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.stopEditProperties(expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.stopEditProperties(itemElementView.getItemId() + "." + expandablePropertyName));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.NONE);
         collectionEditorPresenter.toggleEditingStatus(false);
     }
@@ -80,7 +80,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void updateItem(ItemElementView itemElementView) {
         propertyPresenter.updateProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.updateProperties(expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.updateProperties(itemElementView.getItemId() + "." + expandablePropertyName));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.NONE);
         collectionEditorPresenter.toggleEditingStatus(false);
     }
@@ -88,7 +88,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void onDeleteItem(ItemElementView itemElementView) {
         propertyPresenter.deleteProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.deleteProperties(expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.deleteProperties(itemElementView.getItemId() + "." + expandablePropertyName));
         itemElementView.getItemContainer().removeFromParent();
         elementViewList.remove(itemElementView);
         collectionEditorPresenter.toggleEditingStatus(false);
@@ -108,7 +108,7 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
             final List<String> expandablePropertiesNames = itemIdExpandablePropertiesMap.get(itemElementView.getItemId());
             Map<String, Map<String, String>> expandableProperties = new HashMap<>();
             expandablePropertiesNames.forEach(expandablePropertyName -> {
-                final Map<String, String> simpleProperties = propertyPresenter.getSimpleProperties(expandablePropertyName);
+                final Map<String, String> simpleProperties = propertyPresenter.getSimpleProperties(itemElementView.getItemId() + "." + expandablePropertyName);
                 expandableProperties.put(expandablePropertyName, simpleProperties);
             });
             toReturn.put(itemElementView.getItemId(), expandableProperties);
@@ -120,12 +120,13 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
         final ItemElementView itemElementView = viewsProvider.getListEditorElementView();
         itemElementView.init(this);
         final UListElement innerItemContainer = itemElementView.getInnerItemContainer();
+        itemElementView.setItemSeparatorText(expandablePropertyName);
         itemElementView.getEditItemButton().removeFromParent();
         itemElementView.getDeleteItemButton().removeFromParent();
         itemElementView.getSaveChange().removeFromParent();
-        itemElementView.setItemId(expandablePropertyName);
+        itemElementView.setItemId(containerItemElementView.getItemId() + "." + expandablePropertyName);
         propertiesMap.forEach((propertyName, propertyValue) ->
-                                            innerItemContainer.appendChild(propertyPresenter.getPropertyFields(expandablePropertyName, propertyName, propertyValue)));
+                              innerItemContainer.appendChild(propertyPresenter.getPropertyFields(containerItemElementView.getItemId() + "." + expandablePropertyName, propertyName, propertyValue)));
         containerItemElementView.getInnerItemContainer().insertBefore(itemElementView.getItemContainer(), containerItemElementView.getSaveChange());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenter.java
@@ -54,7 +54,9 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     public void onToggleRowExpansion(ItemElementView itemElementView, boolean isShown) {
         CollectionEditorUtils.toggleRowExpansion(itemElementView.getFaAngleRight(), !isShown);
         propertyPresenter.onToggleRowExpansion(itemElementView.getItemId(), isShown);
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(itemElementView.getItemId() + "." + expandablePropertyName, isShown));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.onToggleRowExpansion(generateExpandableItemElementID(itemElementView,
+                                                                                                                                                                                expandablePropertyName),
+                                                                                                                                                isShown));
         updateCommonToggleStatus(isShown);
     }
 
@@ -64,7 +66,8 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
             onToggleRowExpansion(itemElementView, false);
         }
         propertyPresenter.editProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.editProperties(itemElementView.getItemId() + "." + expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.editProperties(generateExpandableItemElementID(itemElementView,
+                                                                                                                                                                          expandablePropertyName)));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.INLINE);
         collectionEditorPresenter.toggleEditingStatus(true);
     }
@@ -72,7 +75,8 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void onStopEditingItem(ItemElementView itemElementView) {
         propertyPresenter.stopEditProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.stopEditProperties(itemElementView.getItemId() + "." + expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.stopEditProperties(generateExpandableItemElementID(itemElementView,
+                                                                                                                                                                              expandablePropertyName)));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.NONE);
         collectionEditorPresenter.toggleEditingStatus(false);
     }
@@ -80,7 +84,8 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void updateItem(ItemElementView itemElementView) {
         propertyPresenter.updateProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.updateProperties(itemElementView.getItemId() + "." + expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.updateProperties(generateExpandableItemElementID(itemElementView,
+                                                                                                                                                                            expandablePropertyName)));
         itemElementView.getSaveChange().getStyle().setDisplay(Style.Display.NONE);
         collectionEditorPresenter.toggleEditingStatus(false);
     }
@@ -88,7 +93,8 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
     @Override
     public void onDeleteItem(ItemElementView itemElementView) {
         propertyPresenter.deleteProperties(itemElementView.getItemId());
-        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.deleteProperties(itemElementView.getItemId() + "." + expandablePropertyName));
+        itemIdExpandablePropertiesMap.get(itemElementView.getItemId()).forEach(expandablePropertyName -> propertyPresenter.deleteProperties(generateExpandableItemElementID(itemElementView,
+                                                                                                                                                                            expandablePropertyName)));
         itemElementView.getItemContainer().removeFromParent();
         elementViewList.remove(itemElementView);
         collectionEditorPresenter.toggleEditingStatus(false);
@@ -108,7 +114,8 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
             final List<String> expandablePropertiesNames = itemIdExpandablePropertiesMap.get(itemElementView.getItemId());
             Map<String, Map<String, String>> expandableProperties = new HashMap<>();
             expandablePropertiesNames.forEach(expandablePropertyName -> {
-                final Map<String, String> simpleProperties = propertyPresenter.getSimpleProperties(itemElementView.getItemId() + "." + expandablePropertyName);
+                final Map<String, String> simpleProperties = propertyPresenter.getSimpleProperties(generateExpandableItemElementID(itemElementView,
+                                                                                                                                   expandablePropertyName));
                 expandableProperties.put(expandablePropertyName, simpleProperties);
             });
             toReturn.put(itemElementView.getItemId(), expandableProperties);
@@ -120,13 +127,20 @@ public class ItemElementPresenter extends ElementPresenter<ItemElementView> impl
         final ItemElementView itemElementView = viewsProvider.getListEditorElementView();
         itemElementView.init(this);
         final UListElement innerItemContainer = itemElementView.getInnerItemContainer();
+        final String expandableItemID = generateExpandableItemElementID(containerItemElementView, expandablePropertyName);
         itemElementView.setItemSeparatorText(expandablePropertyName);
         itemElementView.getEditItemButton().removeFromParent();
         itemElementView.getDeleteItemButton().removeFromParent();
         itemElementView.getSaveChange().removeFromParent();
-        itemElementView.setItemId(containerItemElementView.getItemId() + "." + expandablePropertyName);
+        itemElementView.setItemId(expandableItemID);
         propertiesMap.forEach((propertyName, propertyValue) ->
-                              innerItemContainer.appendChild(propertyPresenter.getPropertyFields(containerItemElementView.getItemId() + "." + expandablePropertyName, propertyName, propertyValue)));
+                              innerItemContainer.appendChild(propertyPresenter.getPropertyFields(expandableItemID,
+                                                                                                 propertyName,
+                                                                                                 propertyValue)));
         containerItemElementView.getInnerItemContainer().insertBefore(itemElementView.getItemContainer(), containerItemElementView.getSaveChange());
+    }
+
+    protected String generateExpandableItemElementID(final ItemElementView itemElementView, final String expandablePropertyName) {
+        return itemElementView.getItemId() + "." + expandablePropertyName;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenter.java
@@ -50,14 +50,16 @@ public class PropertyPresenter implements PropertyView.Presenter {
         if (propertySpanElementMap.containsKey(propertyName)) {
             return propertySpanElementMap.get(propertyName).getInnerText();
         } else {
-            throw new Exception(propertyName + " not found");
+            throw new IllegalStateException(propertyName + " not found");
         }
     }
 
     @Override
     public void editProperties(String itemId) {
-        propertyViewMap.get(itemId)
-                .forEach(this::startEditPropertyView);
+        if (propertyViewMap.containsKey(itemId)) {
+            propertyViewMap.get(itemId)
+                    .forEach(this::startEditPropertyView);
+        }
     }
 
     @Override
@@ -73,12 +75,14 @@ public class PropertyPresenter implements PropertyView.Presenter {
     @Override
     public Map<String, String> getSimpleProperties(String itemId) {
         Map<String, String> toReturn = new HashMap<>();
-        propertyViewMap.get(itemId)
-                .forEach(propertyEditorView -> {
-                    String propertyName = propertyEditorView.getPropertyName().getInnerText();
-                    propertyName = propertyName.substring(propertyName.lastIndexOf("#") + 1);
-                    toReturn.put(propertyName, propertyEditorView.getPropertyValueSpan().getInnerText());
-                });
+        if (propertyViewMap.containsKey(itemId)) {
+            propertyViewMap.get(itemId)
+                    .forEach(propertyEditorView -> {
+                        String propertyName = propertyEditorView.getPropertyName().getInnerText();
+                        propertyName = propertyName.substring(propertyName.lastIndexOf('#') + 1);
+                        toReturn.put(propertyName, propertyEditorView.getPropertyValueSpan().getInnerText());
+                    });
+        }
         return toReturn;
     }
 
@@ -117,23 +121,28 @@ public class PropertyPresenter implements PropertyView.Presenter {
 
     @Override
     public void onToggleRowExpansion(String itemId, boolean isShown) {
-        propertyViewMap.get(itemId)
-                .forEach(propertyEditorView -> CollectionEditorUtils.toggleRowExpansion(propertyEditorView.getPropertyFields(), isShown));
+        if (propertyViewMap.containsKey(itemId)) {
+            propertyViewMap.get(itemId)
+                    .forEach(propertyEditorView -> CollectionEditorUtils.toggleRowExpansion(
+                            propertyEditorView.getPropertyFields(), isShown));
+        }
     }
 
     @Override
     public void deleteProperties(String itemId) {
-        propertyViewMap.get(itemId)
-                .forEach(this::deletePropertyView);
-        propertyViewMap.remove(itemId);
+        if (propertyViewMap.containsKey(itemId)) {
+            propertyViewMap.get(itemId)
+                    .forEach(this::deletePropertyView);
+            propertyViewMap.remove(itemId);
+        }
     }
 
     protected Map<String, String> stopEdit(String itemId, boolean toUpdate) {
         Map<String, String> toReturn = new HashMap<>();
-        propertyViewMap.get(itemId)
-                .forEach(propertyEditorView -> {
-                    stopEditPropertyView(toReturn, propertyEditorView, toUpdate);
-                });
+        if (propertyViewMap.containsKey(itemId)) {
+            propertyViewMap.get(itemId)
+                    .forEach(propertyEditorView -> stopEditPropertyView(toReturn, propertyEditorView, toUpdate));
+        }
         return toReturn;
     }
 
@@ -162,7 +171,7 @@ public class PropertyPresenter implements PropertyView.Presenter {
         toStopEdit.getPropertyValueInput().getStyle().setDisplay(Style.Display.NONE);
         toStopEdit.getPropertyValueInput().setDisabled(true);
         String propertyName = toStopEdit.getPropertyName().getInnerText();
-        propertyName = propertyName.substring(propertyName.lastIndexOf("#") + 1);
+        propertyName = propertyName.substring(propertyName.lastIndexOf('#') + 1);
         toPopulate.put(propertyName, toStopEdit.getPropertyValueSpan().getInnerText());
     }
 
@@ -170,6 +179,5 @@ public class PropertyPresenter implements PropertyView.Presenter {
         String propertyName = toDelete.getPropertyName().getAttribute("data-i18n-key");
         toDelete.getPropertyFields().removeFromParent();
         propertySpanElementMap.remove(propertyName);
-
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/AbstractCollectionEditorTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/AbstractCollectionEditorTest.java
@@ -26,7 +26,7 @@ import org.mockito.Mock;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
-public class AbstractCollectionEditorTest {
+public abstract class AbstractCollectionEditorTest {
 
     @Mock
     protected ViewsProvider viewsProviderMock;
@@ -56,11 +56,13 @@ public class AbstractCollectionEditorTest {
     protected LIElement itemSeparatorMock;
 
     @Mock
+    protected SpanElement itemSeparatorTextMock;
+
+    @Mock
     protected LIElement editingPropertyFieldsMock;
 
     @Mock
     protected ClickEvent clickEventMock;
-
 
     protected void setup() {
         when(saveChangeMock.getStyle()).thenReturn(styleMock);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ElementViewImplTest.java
@@ -34,13 +34,9 @@ public abstract class ElementViewImplTest<E extends ElementView, T extends Eleme
 
     protected E elementView;
 
-
     protected void setup() {
         super.setup();
-
-    
     }
-
 
     @Test
     public void onFaAngleRightClick() {
@@ -77,6 +73,7 @@ public abstract class ElementViewImplTest<E extends ElementView, T extends Eleme
         verify(clickEventMock, times(1)).stopPropagation();
     }
 
+
     @Test
     public void onCancelChangeButton() {
         elementView.onCancelChangeButton(clickEventMock);
@@ -105,6 +102,12 @@ public abstract class ElementViewImplTest<E extends ElementView, T extends Eleme
         verify(faAngleRightMock, times(1)).addClassName(eq(classToAdd));
         verify(faAngleRightMock, times(1)).removeClassName(eq(classToRemove));
         reset(faAngleRightMock);
+    }
+
+    @Test
+    public void setItemSeparatorText() {
+        elementView.setItemSeparatorText("itemName");
+        verify(itemSeparatorTextMock).setInnerText(eq("itemName"));
     }
 
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementPresenterTest.java
@@ -103,7 +103,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
         verify(elementPresenter, never()).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).editProperties(eq(elementView1Mock.getItemId()));
         for (String expandableProperty : EXPANDABLE_PROPERTIES) {
-            verify(propertyPresenterMock, times(1)).editProperties(eq(expandableProperty));
+            verify(propertyPresenterMock, times(1)).editProperties(eq(ELEMENT1_ID + "." + expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
         verify(collectionPresenterMock, times(1)).toggleEditingStatus(eq(true));
@@ -116,7 +116,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
         verify(elementPresenter, times(1)).onToggleRowExpansion(eq(elementView1Mock), eq((false)));
         verify(propertyPresenterMock, times(1)).editProperties(eq(elementView1Mock.getItemId()));
         for (String expandableProperty : EXPANDABLE_PROPERTIES) {
-            verify(propertyPresenterMock, times(1)).editProperties(eq(expandableProperty));
+            verify(propertyPresenterMock, times(1)).editProperties(eq(ELEMENT1_ID + "." + expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
         verify(collectionPresenterMock, times(1)).toggleEditingStatus(eq(true));
@@ -145,7 +145,7 @@ public class ItemElementPresenterTest extends ElementPresenterTest<ItemElementVi
         elementPresenter.updateItem(elementView1Mock);
         verify(propertyPresenterMock, times(1)).updateProperties(eq(elementView1Mock.getItemId()));
         for (String expandableProperty : EXPANDABLE_PROPERTIES) {
-            verify(propertyPresenterMock, times(1)).updateProperties(eq(expandableProperty));
+            verify(propertyPresenterMock, times(1)).updateProperties(eq(ELEMENT1_ID + "." + expandableProperty));
         }
         verify(styleMock, times(1)).setDisplay(Style.Display.NONE);
         verify(collectionPresenterMock, times(1)).toggleEditingStatus(eq(false));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/ItemElementViewImplTest.java
@@ -32,6 +32,7 @@ public class ItemElementViewImplTest extends ElementViewImplTest<ItemElementView
             {
                 this.presenter = elementPresenterMock;
                 this.faAngleRight = faAngleRightMock;
+                this.itemSeparatorText = itemSeparatorTextMock;
             }
         });
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementViewImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/KeyValueElementViewImplTest.java
@@ -32,6 +32,7 @@ public class KeyValueElementViewImplTest extends ElementViewImplTest<KeyValueEle
             {
                 this.presenter = elementPresenterMock;
                 this.faAngleRight = faAngleRightMock;
+                this.itemSeparatorText = itemSeparatorTextMock;
             }
         });
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/collectioneditor/PropertyPresenterTest.java
@@ -40,8 +40,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -129,6 +132,17 @@ public class PropertyPresenterTest extends AbstractCollectionEditorTest {
     }
 
     @Test
+    public void editPropertiesNoSimpleProperties() {
+        propertyEditorPresenter.editProperties("missing-item");
+        verify(spanElementMock, never()).getStyle();
+        verify(styleMock, never()).setDisplay(any());
+        verify(propertyValueInputMock, never()).setValue(anyString());
+        verify(propertyValueInputMock, never()).getStyle();
+        verify(styleMock, never()).setDisplay(any());
+        verify(propertyValueInputMock, never()).setDisabled(anyBoolean());
+    }
+
+    @Test
     public void stopEditProperties() {
         propertyEditorPresenter.stopEditProperties(ITEM_ID);
         verify(propertyEditorPresenter, times(1)).stopEdit(eq(ITEM_ID), eq(false));
@@ -142,7 +156,8 @@ public class PropertyPresenterTest extends AbstractCollectionEditorTest {
 
     @Test
     public void getProperties() {
-        assertNotNull(propertyEditorPresenter.getSimpleProperties(ITEM_ID));
+        assertFalse(propertyEditorPresenter.getSimpleProperties(ITEM_ID).isEmpty());
+        assertTrue(propertyEditorPresenter.getSimpleProperties("missing-item").isEmpty());
     }
 
     @Test
@@ -178,11 +193,24 @@ public class PropertyPresenterTest extends AbstractCollectionEditorTest {
     }
 
     @Test
+    public void onToggleRowExpansionNoSimpleProperties() {
+        propertyEditorPresenter.onToggleRowExpansion(eq("missing-item"), anyBoolean());
+        verify(propertyFieldsMock, never()).addClassName(anyString());
+        verify(styleMock, never()).setDisplay(any());
+    }
+
+    @Test
     public void deleteProperties() {
         propertyEditorPresenter.deleteProperties(ITEM_ID);
         verify(propertyFieldsMock, times(1)).removeFromParent();
         assertFalse(propertySpanElementMapLocal.containsKey(TEST_PROPERTYNAME));
         assertFalse(propertyViewMapLocal.containsKey(ITEM_ID));
+    }
+
+    @Test
+    public void deletePropertiesNoSimpleProperties() {
+        propertyEditorPresenter.deleteProperties("missing-item");
+        verify(propertyFieldsMock, never()).removeFromParent();
     }
 
     @Test
@@ -195,16 +223,26 @@ public class PropertyPresenterTest extends AbstractCollectionEditorTest {
         commonStopEdit(false);
     }
 
-    private void commonStopEdit(boolean toUdate) {
-        final Map<String, String> retrieved = propertyEditorPresenter.stopEdit(ITEM_ID, toUdate);
+    private void commonStopEdit(boolean toUpdate) {
+        final Map<String, String> retrieved = propertyEditorPresenter.stopEdit(ITEM_ID, toUpdate);
         assertNotNull(retrieved);
         assertTrue(retrieved.containsKey(INNER_TEXT));
-        if (toUdate) {
+        if (toUpdate) {
             verify(spanElementMock, times(1)).setInnerText(eq(TEST_NEWVALUE));
         }
         assertEquals(INNER_TEXT, retrieved.get(INNER_TEXT));
         verify(styleMock, times(1)).setDisplay(Style.Display.INLINE);
         verify(styleMock, times(1)).setDisplay(Style.Display.NONE);
         verify(propertyValueInputMock, times(1)).setDisabled(eq(true));
+    }
+
+    @Test
+    public void stopEditNoSimpleProperties() {
+        final Map<String, String> retrieved = propertyEditorPresenter.stopEdit(eq(ITEM_ID), anyBoolean());
+        assertTrue(retrieved.isEmpty());
+        verify(spanElementMock, never()).setInnerText(anyString());
+        verify(styleMock, never()).setDisplay(any());
+        verify(styleMock, never()).setDisplay(any());
+        verify(propertyValueInputMock, never()).setDisabled(anyBoolean());
     }
 }


### PR DESCRIPTION
The issue occurs when a "user defined" java class is used as type parameter of a List eg. `List<Clazz>` and that class contains a field which is a "user defined" java class as well. Screenshot show an example:

![Screenshot from 2021-01-20 10-02-49](https://user-images.githubusercontent.com/16005046/105151889-c94b0380-5b06-11eb-903c-90fff05c67ba.png)

Author
+ books (List<Book>)
   . isAvailable (boolean)
   . name (string) 
   . ....
   + **author (Author)**    _<----  Issue occurs with this nested class field_
       . name
       . ...

With current version there are several issues:
- Not possible to correctly delete / modify a list item 
- the nested **author (Author)** reference is THE SAME for all items (eg. try to create multiple items of the list. If you try to change a field of Author, this will be propagated to all items!)


**JIRA**: https://issues.redhat.com/browse/DROOLS-5230

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
