### PR TITLE
[7.48.x] DROOLS-4986: Change dmn model does not update model name and namespac…

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/DMNMetadata.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/DMNMetadata.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.workbench.screens.scenariosimulation.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class DMNMetadata {
+
+    private String dmnName;
+    private String dmnNamespace;
+
+    public DMNMetadata() {
+        // Required by Marshaller
+    }
+
+    public DMNMetadata(final String dmnName, final String dmnNamespace) {
+        this.dmnName = dmnName;
+        this.dmnNamespace = dmnNamespace;
+    }
+
+    public void setDmnName(String dmnName) {
+        this.dmnName = dmnName;
+    }
+
+    public void setDmnNamespace(String dmnNamespace) {
+        this.dmnNamespace = dmnNamespace;
+    }
+
+    public String getDmnName() {
+        return dmnName;
+    }
+
+    public String getDmnNamespace() {
+        return dmnNamespace;
+    }
+}

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/service/DMNTypeService.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/service/DMNTypeService.java
@@ -16,6 +16,7 @@
 package org.drools.workbench.screens.scenariosimulation.service;
 
 import org.drools.scenariosimulation.api.model.Settings;
+import org.drools.workbench.screens.scenariosimulation.model.DMNMetadata;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTuple;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
@@ -39,4 +40,11 @@ public interface DMNTypeService {
      * @param dmnPath to dmn file
      */
     void initializeNameAndNamespace(Settings settings, Path path, String dmnPath);
+
+    /**
+     * It returns the DMN name and namespace given a dmnPath
+     * @param path to project
+     * @param dmnPath to dmn file
+     */
+    DMNMetadata getDMNMetadata(Path path, String dmnPath);
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImpl.java
@@ -32,6 +32,7 @@ import javax.enterprise.context.ApplicationScoped;
 import org.drools.scenariosimulation.api.model.Settings;
 import org.drools.scenariosimulation.backend.util.DMNSimulationUtils;
 import org.drools.workbench.screens.scenariosimulation.backend.server.exceptions.WrongDMNTypeException;
+import org.drools.workbench.screens.scenariosimulation.model.DMNMetadata;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTuple;
 import org.drools.workbench.screens.scenariosimulation.service.DMNTypeService;
@@ -92,6 +93,12 @@ public class DMNTypeServiceImpl
         DMNModel dmnModel = getDMNModel(path, dmnPath);
         settings.setDmnName(dmnModel.getName());
         settings.setDmnNamespace(dmnModel.getNamespace());
+    }
+
+    @Override
+    public DMNMetadata getDMNMetadata(Path path, String dmnPath) {
+        DMNModel dmnModel = getDMNModel(path, dmnPath);
+        return new DMNMetadata(dmnModel.getName(), dmnModel.getNamespace());
     }
 
     public DMNModel getDMNModel(Path path, String dmnPath) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/DMNTypeServiceImplTest.java
@@ -21,6 +21,7 @@ import java.util.TreeMap;
 
 import org.drools.scenariosimulation.api.model.Settings;
 import org.drools.workbench.screens.scenariosimulation.backend.server.exceptions.WrongDMNTypeException;
+import org.drools.workbench.screens.scenariosimulation.model.DMNMetadata;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTree;
 import org.drools.workbench.screens.scenariosimulation.model.typedescriptor.FactModelTuple;
 import org.junit.Before;
@@ -64,6 +65,13 @@ public class DMNTypeServiceImplTest extends AbstractDMNTest {
 
         assertEquals(NAMESPACE, settings.getDmnNamespace());
         assertEquals(MODEL_NAME, settings.getDmnName());
+    }
+
+    @Test
+    public void getDMNMetadata() {
+        DMNMetadata dmnMetadata = dmnTypeServiceImpl.getDMNMetadata(mock(Path.class), "");
+        assertEquals(NAMESPACE, dmnMetadata.getDmnNamespace());
+        assertEquals(MODEL_NAME, dmnMetadata.getDmnName());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -51,6 +51,7 @@ import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.Sce
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.type.ScenarioSimulationResourceType;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridWidget;
+import org.drools.workbench.screens.scenariosimulation.model.DMNMetadata;
 import org.drools.workbench.screens.scenariosimulation.model.ScenarioSimulationModelContent;
 import org.drools.workbench.screens.scenariosimulation.model.SimulationRunResult;
 import org.drools.workbench.screens.scenariosimulation.service.DMNTypeService;
@@ -246,6 +247,30 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     }
 
     @Override
+    public void getDMNMetadata() {
+        dmnTypeService.call(getUpdateMetadataCallback(),
+                            getUpdateMetadataErrorCallback())
+                .getDMNMetadata(getScenarioSimulationEditorPresenter().getPath(),
+                                getScenarioSimulationEditorPresenter().getModel().getSettings().getDmnFilePath());
+    }
+
+    private RemoteCallback<DMNMetadata> getUpdateMetadataCallback() {
+        return response -> {
+            getScenarioSimulationEditorPresenter().getModel().getSettings().setDmnName(response.getDmnName());
+            getScenarioSimulationEditorPresenter().getModel().getSettings().setDmnNamespace(response.getDmnNamespace());
+            getScenarioSimulationEditorPresenter().reloadSettingsDock();
+        };
+    }
+
+    private ErrorCallback<Object> getUpdateMetadataErrorCallback() {
+        return (message, throwable) -> {
+            scenarioSimulationEditorPresenter.sendNotification(message.toString(),
+                                                               NotificationEvent.NotificationType.ERROR);
+            return false;
+        };
+    }
+
+    @Override
     public Integer getOriginalHash() {
         return originalHash;
     }
@@ -349,10 +374,9 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
     @Override
     public void populateDocks(String identifier) {
         if (CoverageReportPresenter.IDENTIFIER.equals(identifier)) {
-            scenarioSimulationBusinessCentralDocksHandler.getCoverageReportPresenter().ifPresent(presenter -> {
-                setCoverageReport(presenter);
-                presenter.setCurrentPath(scenarioSimulationEditorPresenter.getPath());
-            });
+            CoverageReportView.Presenter coverageReportPresenter = scenarioSimulationBusinessCentralDocksHandler.getCoverageReportPresenter();
+            setCoverageReport(coverageReportPresenter);
+            coverageReportPresenter.setCurrentPath(scenarioSimulationEditorPresenter.getPath());
         } else {
             ScenarioSimulationEditorWrapper.super.populateDocks(identifier);
         }
@@ -484,8 +508,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
             addImportsTab(importsWidget);
         }
         baseView.hideBusyIndicator();
-        setOriginalHash(scenarioSimulationEditorPresenter.getJsonModel(model).hashCode());
         scenarioSimulationEditorPresenter.getModelSuccessCallbackMethod(dataManagementStrategy, model);
+        setOriginalHash(scenarioSimulationEditorPresenter.getJsonModel(model).hashCode());
     }
 
     protected void onBackgroundTabSelected() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapper.java
@@ -508,8 +508,8 @@ public class ScenarioSimulationEditorBusinessCentralWrapper extends KieEditor<Sc
             addImportsTab(importsWidget);
         }
         baseView.hideBusyIndicator();
-        scenarioSimulationEditorPresenter.getModelSuccessCallbackMethod(dataManagementStrategy, model);
         setOriginalHash(scenarioSimulationEditorPresenter.getJsonModel(model).hashCode());
+        scenarioSimulationEditorPresenter.getModelSuccessCallbackMethod(dataManagementStrategy, model);
     }
 
     protected void onBackgroundTabSelected() {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategy.java
@@ -36,8 +36,7 @@ public class BusinessCentralDMNDataManagementStrategy extends AbstractDMNDataMan
     @Override
     protected void retrieveFactModelTuple(final TestToolsView.Presenter testToolsPresenter,
                                           final ScenarioSimulationContext context,
-                                          final GridWidget gridWidget,
-                                          String dmnFilePath) {
+                                          final GridWidget gridWidget) {
         dmnTypeService.call(getSuccessCallback(testToolsPresenter, context, gridWidget),
                             getErrorCallback())
                 .retrieveFactModelTuple(currentPath, dmnFilePath);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/handlers/ScenarioSimulationBusinessCentralDocksHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/handlers/ScenarioSimulationBusinessCentralDocksHandler.java
@@ -16,7 +16,6 @@
 package org.drools.workbench.screens.scenariosimulation.businesscentral.client.handlers;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,11 +26,8 @@ import org.drools.workbench.screens.scenariosimulation.businesscentral.client.ri
 import org.drools.workbench.screens.scenariosimulation.businesscentral.client.rightpanel.testrunner.TestRunnerReportingPanelWrapper;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.AbstractScenarioSimulationDocksHandler;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
-import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SubDockView;
 import org.guvnor.common.services.shared.test.TestResultMessage;
 import org.kie.workbench.common.widgets.client.docks.DockPlaceHolderPlace;
-import org.uberfire.client.mvp.AbstractWorkbenchActivity;
-import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.mvp.PlaceRequest;
@@ -44,18 +40,20 @@ public class ScenarioSimulationBusinessCentralDocksHandler extends AbstractScena
 
     @Inject
     protected TestRunnerReportingPanelWrapper testRunnerReportingPanelWrapper;
+    @Inject
+    protected CoverageReportPresenter coverageReportPresenter;
 
-    private UberfireDock testRunnedDock;
+    private UberfireDock testRunnerDock;
     private UberfireDock coverageDock;
 
     @Override
     public Collection<UberfireDock> provideDocks(String perspectiveIdentifier) {
         Collection<UberfireDock> result = super.provideDocks(perspectiveIdentifier);
-        testRunnedDock = new UberfireDock(UberfireDockPosition.EAST,
+        testRunnerDock = new UberfireDock(UberfireDockPosition.EAST,
                                           "PLAY_CIRCLE",
                                           new DockPlaceHolderPlace(TEST_RUNNER_REPORTING_PANEL),
                                           perspectiveIdentifier);
-        result.add(testRunnedDock.withSize(450).withLabel(ScenarioSimulationEditorConstants.INSTANCE.testReport()));
+        result.add(testRunnerDock.withSize(450).withLabel(ScenarioSimulationEditorConstants.INSTANCE.testReport()));
         coverageDock = new UberfireDock(UberfireDockPosition.EAST,
                                         "BAR_CHART",
                                         new DefaultPlaceRequest(CoverageReportPresenter.IDENTIFIER),
@@ -66,13 +64,13 @@ public class ScenarioSimulationBusinessCentralDocksHandler extends AbstractScena
 
     @Override
     public void expandTestResultsDock() {
-        authoringWorkbenchDocks.expandAuthoringDock(testRunnedDock);
+        authoringWorkbenchDocks.expandAuthoringDock(testRunnerDock);
     }
 
     @Override
     public void resetDocks() {
         super.resetDocks();
-        getCoverageReportPresenter().ifPresent(SubDockView.Presenter::reset);
+        coverageReportPresenter.reset();
         testRunnerReportingPanelWrapper.reset();
     }
 
@@ -88,19 +86,8 @@ public class ScenarioSimulationBusinessCentralDocksHandler extends AbstractScena
         coverageDock.getPlaceRequest().addParameter(SCESIMEDITOR_ID, scesimEditorId);
     }
 
-    public Optional<CoverageReportView.Presenter> getCoverageReportPresenter() {
-        final Optional<CoverageReportView> coverageReportViewMap = getCoverageReportView(getCurrentRightDockPlaceRequest(CoverageReportPresenter.IDENTIFIER));
-        return coverageReportViewMap.map(CoverageReportView::getPresenter);
-    }
-
-    protected Optional<CoverageReportView> getCoverageReportView(PlaceRequest placeRequest) {
-        final Activity activity = placeManager.getActivity(placeRequest);
-        if (activity == null) {
-            return Optional.empty();
-        } else {
-            final AbstractWorkbenchActivity coverageActivity = (AbstractWorkbenchActivity) activity;
-            return Optional.of((CoverageReportView) coverageActivity.getWidget());
-        }
+    public CoverageReportView.Presenter getCoverageReportPresenter() {
+        return coverageReportPresenter;
     }
 
     public void updateTestRunnerReportingPanelResult(TestResultMessage testResultMessage) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/ScenarioSimulationEditorBusinessCentralWrapperTest.java
@@ -42,7 +42,9 @@ import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSh
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.type.ScenarioSimulationResourceType;
+import org.drools.workbench.screens.scenariosimulation.model.DMNMetadata;
 import org.drools.workbench.screens.scenariosimulation.model.SimulationRunResult;
+import org.drools.workbench.screens.scenariosimulation.service.DMNTypeService;
 import org.drools.workbench.screens.scenariosimulation.service.ImportExportService;
 import org.drools.workbench.screens.scenariosimulation.service.ImportExportType;
 import org.drools.workbench.screens.scenariosimulation.service.RunnerReportService;
@@ -180,6 +182,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     private CallerMock<ScenarioSimulationService> scenarioSimulationCaller;
     private CallerMock<ImportExportService> importExportCaller;
     private CallerMock<RunnerReportService> runnerReportServiceCaller;
+    private CallerMock<DMNTypeService> dmnTypeServiceCaller;
     private Promises promises;
     private ScenarioSimulationEditorBusinessCentralWrapper scenarioSimulationEditorBusinessClientWrapper;
     private SaveAndRenameCommandBuilder<ScenarioSimulationModel, Metadata> saveAndRenameCommandBuilderMock;
@@ -191,13 +194,14 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         scenarioSimulationCaller = spy(new CallerMock<>(scenarioSimulationServiceMock));
         importExportCaller = spy(new CallerMock<>(importExportServiceMock));
         runnerReportServiceCaller = spy(new CallerMock<>(runnerReportServiceMock));
+        dmnTypeServiceCaller = spy(new CallerMock<>(dmnTypeServiceMock));
         saveAndRenameCommandBuilderMock = spy(new SaveAndRenameCommandBuilder<>(null, null, null, null));
         scenarioSimulationEditorBusinessClientWrapper = spy(new ScenarioSimulationEditorBusinessCentralWrapper(scenarioSimulationCaller,
                                                                                                                scenarioSimulationEditorPresenterMock,
                                                                                                                importsWidgetPresenterMock,
                                                                                                                oracleFactoryMock,
                                                                                                                placeManagerMock,
-                                                                                                               new CallerMock<>(dmnTypeServiceMock),
+                                                                                                               dmnTypeServiceCaller,
                                                                                                                importExportCaller,
                                                                                                                runnerReportServiceCaller,
                                                                                                                scenarioSimulationBusinessCentralDocksHandlerMock) {
@@ -240,7 +244,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         when(multiPageEditorViewMock.getPageIndex(ScenarioSimulationEditorConstants.INSTANCE.backgroundTabTitle())).thenReturn(BACKGROUND_TAB_INDEX);
         when(navTabsMock.getWidget(SIMULATION_TAB_INDEX)).thenReturn(simulationTabListItemMock);
         when(navTabsMock.getWidget(BACKGROUND_TAB_INDEX)).thenReturn(backgroundTabListItemMock);
-        when(scenarioSimulationBusinessCentralDocksHandlerMock.getCoverageReportPresenter()).thenReturn(Optional.ofNullable(coverageReportPresenterMock));
+        when(scenarioSimulationBusinessCentralDocksHandlerMock.getCoverageReportPresenter()).thenReturn(coverageReportPresenterMock);
         when(scenarioSimulationBusinessCentralDocksHandlerMock.getTestRunnerReportingPanelWidget()).thenReturn(testRunnerReportingPanelWidgetMock);
         when(simulationRunResultMock.getTestResultMessage()).thenReturn(testResultMessageMock);
         when(simulationRunResultMock.getSimulationRunMetadata()).thenReturn(simulationRunMetadataMock);
@@ -334,6 +338,26 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
         scenarioSimulationEditorBusinessClientWrapper.onRunScenario(remoteCallback, errorCallback, simulationDescriptorMock, settingsLocal, scenarioWithIndexLocal, backgroundLocal);
         verify(scenarioSimulationCaller, times(1)).call(eq(remoteCallback), eq(errorCallback));
         verify(scenarioSimulationServiceMock, times(1)).runScenario(eq(observablePathMock), eq(simulationDescriptorMock), eq(scenarioWithIndexLocal), eq(settingsLocal), eq(backgroundLocal));
+    }
+
+    @Test
+    public void getDMNMetadata() {
+        ArgumentCaptor<ErrorCallback> errorCallbackArgumentCaptor = ArgumentCaptor.forClass(ErrorCallback.class);
+        String dmnPath = "src/test.dmn";
+        String dmnName = "DMN-NAME";
+        String dmnNameSpace = "DMN-namespace";
+        modelLocal.getSettings().setDmnFilePath(dmnPath);
+        when(dmnTypeServiceMock.getDMNMetadata(eq(pathMock), eq(dmnPath))).thenReturn(new DMNMetadata(dmnName, dmnNameSpace));
+        scenarioSimulationEditorBusinessClientWrapper.getDMNMetadata();
+        verify(dmnTypeServiceCaller, times(1)).call(isA(RemoteCallback.class),
+                                                                          errorCallbackArgumentCaptor.capture());
+        verify(dmnTypeServiceMock, times(1)).getDMNMetadata(eq(pathMock), eq(dmnPath));
+        verify(scenarioSimulationEditorPresenterMock, times(1)).reloadSettingsDock();
+        assertEquals(dmnName, modelLocal.getSettings().getDmnName());
+        assertEquals(dmnNameSpace, modelLocal.getSettings().getDmnNamespace());
+        errorCallbackArgumentCaptor.getValue().error("ERROR", new Throwable());
+        verify(scenarioSimulationEditorPresenterMock, times(1)).sendNotification(eq("ERROR"),
+                                                                                                       eq(NotificationEvent.NotificationType.ERROR) );
     }
 
     @Test
@@ -513,7 +537,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
 
     @Test
     public void populateRightDocks_Settings() {
-        doReturn(Optional.of(settingsPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerMock).getSettingsPresenter();
+        doReturn(settingsPresenterMock).when(scenarioSimulationBusinessCentralDocksHandlerMock).getSettingsPresenter();
         scenarioSimulationEditorBusinessClientWrapper.populateDocks(SettingsPresenter.IDENTIFIER);
         verify(scenarioSimulationEditorPresenterMock, times(1)).setSettings(eq(settingsPresenterMock));
         verify(settingsPresenterMock, times(1)).setCurrentPath(eq(pathMock));
@@ -525,7 +549,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
 
     @Test
     public void populateRightDocks_TestTools() {
-        doReturn(Optional.of(testToolsPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerMock).getTestToolsPresenter();
+        doReturn(testToolsPresenterMock).when(scenarioSimulationBusinessCentralDocksHandlerMock).getTestToolsPresenter();
         scenarioSimulationEditorBusinessClientWrapper.populateDocks(TestToolsPresenter.IDENTIFIER);
         verify(scenarioSimulationEditorPresenterMock, times(1)).setTestTools(eq(testToolsPresenterMock));
         verify(coverageReportPresenterMock, never()).setCurrentPath(any());
@@ -538,7 +562,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     @Test
     public void populateRightDocks_CheatSheetPresenter_NotShown() {
         when(cheatSheetPresenterMock.isCurrentlyShow(pathMock)).thenReturn(false);
-        doReturn(Optional.of(cheatSheetPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerMock).getCheatSheetPresenter();
+        doReturn(cheatSheetPresenterMock).when(scenarioSimulationBusinessCentralDocksHandlerMock).getCheatSheetPresenter();
         scenarioSimulationEditorBusinessClientWrapper.populateDocks(CheatSheetPresenter.IDENTIFIER);
         verify(cheatSheetPresenterMock, times(1)).setCurrentPath(pathMock);
         verify(scenarioSimulationEditorPresenterMock, times(1)).setCheatSheet(eq(cheatSheetPresenterMock));
@@ -551,7 +575,7 @@ public class ScenarioSimulationEditorBusinessCentralWrapperTest extends Abstract
     @Test
     public void populateRightDocks_CheatSheetPresenter_IsShown() {
         when(cheatSheetPresenterMock.isCurrentlyShow(pathMock)).thenReturn(true);
-        doReturn(Optional.of(cheatSheetPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerMock).getCheatSheetPresenter();
+        doReturn(cheatSheetPresenterMock).when(scenarioSimulationBusinessCentralDocksHandlerMock).getCheatSheetPresenter();
         scenarioSimulationEditorBusinessClientWrapper.populateDocks(CheatSheetPresenter.IDENTIFIER);
         verify(scenarioSimulationEditorPresenterMock, never()).setSettings(any());
         verify(settingsPresenterMock, never()).setCurrentPath(any());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/editor/strategies/BusinessCentralDMNDataManagementStrategyTest.java
@@ -79,6 +79,7 @@ public class BusinessCentralDMNDataManagementStrategyTest extends AbstractScenar
                 this.currentPath = currentPathMock;
                 this.model = modelLocal;
                 this.factModelTreeHolder = factModelTreeHolderMock;
+                this.dmnFilePath = "DMN_FILE_PATH";
             }
 
             @Override
@@ -95,7 +96,7 @@ public class BusinessCentralDMNDataManagementStrategyTest extends AbstractScenar
 
     @Test
     public void retrieveFactModelTuple() {
-        businessCentralDmnDataManagementStrategySpy.retrieveFactModelTuple(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION, "DMN_FILE_PATH");
+        businessCentralDmnDataManagementStrategySpy.retrieveFactModelTuple(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
         verify(businessCentralDmnDataManagementStrategySpy, times(1)).getSuccessCallback(eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
         verify(dmnTypeServiceMock, times(1)).retrieveFactModelTuple(eq(currentPathMock), eq("DMN_FILE_PATH"));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/handlers/ScenarioSimulationBusinessCentralDocksHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/handlers/ScenarioSimulationBusinessCentralDocksHandlerTest.java
@@ -17,12 +17,10 @@
 package org.drools.workbench.screens.scenariosimulation.businesscentral.client.handlers;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.businesscentral.client.rightpanel.coverage.CoverageReportPresenter;
-import org.drools.workbench.screens.scenariosimulation.businesscentral.client.rightpanel.coverage.CoverageReportView;
 import org.drools.workbench.screens.scenariosimulation.businesscentral.client.rightpanel.testrunner.TestRunnerReportingPanelWrapper;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetPresenter;
@@ -34,21 +32,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.widgets.client.docks.AuthoringEditorDock;
 import org.mockito.Mock;
-import org.uberfire.client.mvp.AbstractWorkbenchActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
-import org.uberfire.mvp.PlaceRequest;
 
 import static org.drools.workbench.screens.scenariosimulation.businesscentral.client.handlers.ScenarioSimulationBusinessCentralDocksHandler.TEST_RUNNER_REPORTING_PANEL;
 import static org.drools.workbench.screens.scenariosimulation.client.handlers.AbstractScenarioSimulationDocksHandler.SCESIMEDITOR_ID;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -93,14 +87,14 @@ public class ScenarioSimulationBusinessCentralDocksHandlerTest {
                 this.authoringWorkbenchDocks = authoringWorkbenchDocksMock;
                 this.testRunnerReportingPanelWrapper = testRunnerReportingPanelWrapperMock;
                 this.placeManager = placeManagerMock;
+                this.coverageReportPresenter = coverageReportPresenterMock;
+                this.settingsPresenter = settingsPresenterMock;
+                this.cheatSheetPresenter = cheatSheetPresenterMock;
+                this.testToolsPresenter = testToolsPresenterMock;
             }
 
         });
         when(testRunnerReportingPanelWrapperMock.asWidget()).thenReturn(testRunnerReportingPanelWidgetMock);
-        doReturn(Optional.of(cheatSheetPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerSpy).getCheatSheetPresenter();
-        doReturn(Optional.of(testToolsPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerSpy).getTestToolsPresenter();
-        doReturn(Optional.of(settingsPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerSpy).getSettingsPresenter();
-        doReturn(Optional.of(coverageReportPresenterMock)).when(scenarioSimulationBusinessCentralDocksHandlerSpy).getCoverageReportPresenter();
     }
 
     @Test
@@ -188,24 +182,5 @@ public class ScenarioSimulationBusinessCentralDocksHandlerTest {
         TestResultMessage testResultMessageMock = mock(TestResultMessage.class);
         scenarioSimulationBusinessCentralDocksHandlerSpy.updateTestRunnerReportingPanelResult(testResultMessageMock);
         verify(testRunnerReportingPanelWrapperMock, times(1)).onTestRun(eq(testResultMessageMock));
-    }
-
-    @Test
-    public void getCoverageView() {
-        CoverageReportView coverageReportView = mock(CoverageReportView.class);
-        AbstractWorkbenchActivity activityMock = mock(AbstractWorkbenchActivity.class);
-        when(activityMock.getWidget()).thenReturn(coverageReportView);
-        PlaceRequest placeRequest = scenarioSimulationBusinessCentralDocksHandlerSpy.getCurrentRightDockPlaceRequest(CoverageReportPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(activityMock);
-        Optional<CoverageReportView> optional = scenarioSimulationBusinessCentralDocksHandlerSpy.getCoverageReportView(placeRequest);
-        assertSame(coverageReportView, optional.get());
-    }
-
-    @Test
-    public void getCoverageView_NullActivity() {
-        PlaceRequest placeRequest = scenarioSimulationBusinessCentralDocksHandlerSpy.getCurrentRightDockPlaceRequest(CoverageReportPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(null);
-        Optional<CoverageReportView> optional = scenarioSimulationBusinessCentralDocksHandlerSpy.getCoverageReportView(placeRequest);
-        assertFalse(optional.isPresent());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -458,7 +458,9 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
     @Override
     public void onEvent(UpdateSettingsDataEvent updateSettingsDataEvent) {
         if (updateSettingsDataEvent.getSettingsValueChanged().test(context.getScenarioSimulationModel().getSettings())) {
-            commonExecution(new UpdateSettingsDataCommand(updateSettingsDataEvent.getSettingsChangeToApply()), false);
+            commonExecution(new UpdateSettingsDataCommand(updateSettingsDataEvent.getSettingsChangeToApply(),
+                                                          updateSettingsDataEvent.isDmnPathChanged()),
+                            false);
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/UpdateSettingsDataCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/UpdateSettingsDataCommand.java
@@ -32,9 +32,12 @@ import org.kie.workbench.common.command.client.impl.CommandResultImpl;
 public class UpdateSettingsDataCommand extends AbstractScenarioSimulationUndoableCommand<Settings> {
 
     private final Consumer<Settings> settingsConsumer;
+    private final boolean dmnPathChanged;
 
-    public UpdateSettingsDataCommand(Consumer<Settings> settingsConsumer) {
+    public UpdateSettingsDataCommand(final Consumer<Settings> settingsConsumer, 
+                                     final boolean dmnPathChanged) {
         this.settingsConsumer = settingsConsumer;
+        this.dmnPathChanged = dmnPathChanged;
     }
 
     @Override
@@ -56,6 +59,10 @@ public class UpdateSettingsDataCommand extends AbstractScenarioSimulationUndoabl
             final Settings originalSettings = context.getScenarioSimulationModel().getSettings().cloneSettings();
             context.getScenarioSimulationEditorPresenter().getModel().setSettings(restorableStatus);
             restorableStatus = originalSettings;
+            if (dmnPathChanged) {
+                context.getScenarioSimulationEditorPresenter().getPopulateTestToolsCommand().execute();
+                context.getScenarioSimulationEditorPresenter().validateSimulation();
+            }
             context.getScenarioSimulationEditorPresenter().reloadSettingsDock();
             return commonExecution(context);
         } catch (Exception e) {
@@ -66,7 +73,12 @@ public class UpdateSettingsDataCommand extends AbstractScenarioSimulationUndoabl
     @Override
     protected void internalExecute(ScenarioSimulationContext context)  {
         settingsConsumer.accept(context.getScenarioSimulationModel().getSettings());
-        context.getScenarioSimulationEditorPresenter().reloadSettingsDock();
+        if (dmnPathChanged) {
+            context.getScenarioSimulationEditorPresenter().getPopulateTestToolsCommand().execute();
+            context.getScenarioSimulationEditorPresenter().getUpdateDMNMetadataCommand().execute();
+        } else {
+            context.getScenarioSimulationEditorPresenter().reloadSettingsDock();
+        }
     }
 
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenter.java
@@ -231,7 +231,7 @@ public class ScenarioSimulationEditorPresenter {
     public void reloadTestTools(boolean disable) {
         populateRightDocks(TestToolsPresenter.IDENTIFIER);
         if (disable) {
-            abstractScenarioSimulationDocksHandler.getTestToolsPresenter().ifPresent(TestToolsView.Presenter::onDisableEditorTab);
+            abstractScenarioSimulationDocksHandler.getTestToolsPresenter().onDisableEditorTab();
         }
     }
 
@@ -239,7 +239,7 @@ public class ScenarioSimulationEditorPresenter {
      * To be called to force settings panel reload
      */
     public void reloadSettingsDock() {
-        abstractScenarioSimulationDocksHandler.getSettingsPresenter().ifPresent(this::updateSettings);
+        this.updateSettings(abstractScenarioSimulationDocksHandler.getSettingsPresenter());
     }
 
     public void onRunScenario() {
@@ -621,7 +621,7 @@ public class ScenarioSimulationEditorPresenter {
     }
 
     protected void clearTestToolsStatus() {
-        abstractScenarioSimulationDocksHandler.getTestToolsPresenter().ifPresent(TestToolsView.Presenter::onClearStatus);
+        abstractScenarioSimulationDocksHandler.getTestToolsPresenter().onClearStatus();
     }
 
     public void setCheatSheet(CheatSheetView.Presenter presenter) {
@@ -650,4 +650,6 @@ public class ScenarioSimulationEditorPresenter {
     private Command createPopulateTestToolsCommand() {
         return () -> populateRightDocks(TestToolsPresenter.IDENTIFIER);
     }
+
+    public Command getUpdateDMNMetadataCommand() { return () -> scenarioSimulationEditorWrapper.getDMNMetadata();}
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
@@ -30,7 +30,9 @@ import org.drools.scenariosimulation.api.model.SimulationRunMetadata;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.AbstractScenarioSimulationDocksHandler;
 import org.drools.workbench.screens.scenariosimulation.client.handlers.ScenarioSimulationHasBusyIndicatorDefaultErrorCallback;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetPresenter;
+import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsPresenter;
+import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridPanel;
 import org.drools.workbench.screens.scenariosimulation.client.widgets.ScenarioGridWidget;
@@ -61,6 +63,7 @@ public interface ScenarioSimulationEditorWrapper {
     void selectSimulationTab();
 
     void selectBackgroundTab();
+    void getDMNMetadata();
 
     AbstractScenarioSimulationDocksHandler getScenarioSimulationDocksHandler();
 
@@ -74,23 +77,19 @@ public interface ScenarioSimulationEditorWrapper {
     default void populateDocks(String identifier) {
         switch (identifier) {
             case SettingsPresenter.IDENTIFIER:
-                getScenarioSimulationDocksHandler().getSettingsPresenter().ifPresent(presenter -> {
-                    getScenarioSimulationEditorPresenter().setSettings(presenter);
-                    presenter.setCurrentPath(getScenarioSimulationEditorPresenter().getPath());
-                });
+                SettingsView.Presenter settingsPresenter = getScenarioSimulationDocksHandler().getSettingsPresenter();
+                getScenarioSimulationEditorPresenter().setSettings(settingsPresenter);
+                settingsPresenter.setCurrentPath(getScenarioSimulationEditorPresenter().getPath());
                 break;
             case TestToolsPresenter.IDENTIFIER:
-                getScenarioSimulationDocksHandler().getTestToolsPresenter().ifPresent(
-                        presenter -> getScenarioSimulationEditorPresenter().setTestTools(presenter));
+                getScenarioSimulationEditorPresenter().setTestTools(getScenarioSimulationDocksHandler().getTestToolsPresenter());
                 break;
             case CheatSheetPresenter.IDENTIFIER:
-                getScenarioSimulationDocksHandler().getCheatSheetPresenter().ifPresent(
-                        presenter -> {
-                            if (!presenter.isCurrentlyShow(getScenarioSimulationEditorPresenter().getPath())) {
-                                getScenarioSimulationEditorPresenter().setCheatSheet(presenter);
-                                presenter.setCurrentPath(getScenarioSimulationEditorPresenter().getPath());
-                            }
-                        });
+                CheatSheetView.Presenter cheatSheetPresenter = getScenarioSimulationDocksHandler().getCheatSheetPresenter();
+                if (!cheatSheetPresenter.isCurrentlyShow(getScenarioSimulationEditorPresenter().getPath())) {
+                    getScenarioSimulationEditorPresenter().setCheatSheet(cheatSheetPresenter);
+                    cheatSheetPresenter.setCurrentPath(getScenarioSimulationEditorPresenter().getPath());
+                }
                 break;
             default:
                 throw new IllegalArgumentException("Invalid identifier");

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorWrapper.java
@@ -63,6 +63,7 @@ public interface ScenarioSimulationEditorWrapper {
     void selectSimulationTab();
 
     void selectBackgroundTab();
+
     void getDMNMetadata();
 
     AbstractScenarioSimulationDocksHandler getScenarioSimulationDocksHandler();

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategy.java
@@ -15,6 +15,8 @@
  */
 package org.drools.workbench.screens.scenariosimulation.client.editor.strategies;
 
+import java.util.Objects;
+
 import com.google.gwt.event.shared.EventBus;
 import org.drools.workbench.screens.scenariosimulation.client.commands.ScenarioSimulationContext;
 import org.drools.workbench.screens.scenariosimulation.client.enums.GridWidget;
@@ -33,6 +35,7 @@ public abstract class AbstractDMNDataManagementStrategy extends AbstractDataMana
 
     protected final EventBus eventBus;
     protected Path currentPath;
+    protected String dmnFilePath;
 
     public AbstractDMNDataManagementStrategy(EventBus eventBus) {
         this.eventBus = eventBus;
@@ -40,17 +43,17 @@ public abstract class AbstractDMNDataManagementStrategy extends AbstractDataMana
 
     protected abstract void retrieveFactModelTuple(final TestToolsView.Presenter testToolsPresenter,
                                                    final ScenarioSimulationContext context,
-                                                   final GridWidget gridWidget,
-                                                   String dmnFilePath);
+                                                   final GridWidget gridWidget);
 
     @Override
     public void populateTestTools(final TestToolsView.Presenter testToolsPresenter,
-                                  final ScenarioSimulationContext context, final GridWidget gridWidget) {
-        if (factModelTreeHolder.getFactModelTuple() != null) {
+                                  final ScenarioSimulationContext context,
+                                  final GridWidget gridWidget) {
+        if (factModelTreeHolder.getFactModelTuple() != null && Objects.equals(dmnFilePath, model.getSettings().getDmnFilePath())) {
             getSuccessCallback(testToolsPresenter, context, gridWidget).callback(factModelTreeHolder.getFactModelTuple());
         } else {
-            String dmnFilePath = model.getSettings().getDmnFilePath();
-            retrieveFactModelTuple(testToolsPresenter, context, gridWidget, dmnFilePath);
+            dmnFilePath = model.getSettings().getDmnFilePath();
+            retrieveFactModelTuple(testToolsPresenter, context, gridWidget);
         }
     }
 

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/UpdateSettingsDataEvent.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/events/UpdateSettingsDataEvent.java
@@ -28,16 +28,27 @@ public class UpdateSettingsDataEvent extends GwtEvent<UpdateSettingsDataEventHan
 
     private final Consumer<Settings> settingsChangeToApply;
     private final Predicate<Settings> settingsValueChanged;
+    private final boolean dmnPathChanged;
 
     public UpdateSettingsDataEvent(final Consumer<Settings> settingsChangeToApply) {
         this.settingsChangeToApply = settingsChangeToApply;
         this.settingsValueChanged = settings -> true;
+        this.dmnPathChanged = false;
     }
 
     public UpdateSettingsDataEvent(final Consumer<Settings> settingsChangeToApply,
                                    final Predicate<Settings> settingsValueChanged) {
         this.settingsChangeToApply = settingsChangeToApply;
         this.settingsValueChanged = settingsValueChanged;
+        this.dmnPathChanged = false;
+    }
+
+    public UpdateSettingsDataEvent(final Consumer<Settings> settingsChangeToApply,
+                                   final Predicate<Settings> settingsValueChanged,
+                                   final boolean dmnPathChanged) {
+        this.settingsChangeToApply = settingsChangeToApply;
+        this.settingsValueChanged = settingsValueChanged;
+        this.dmnPathChanged = dmnPathChanged;
     }
 
     @Override
@@ -56,5 +67,9 @@ public class UpdateSettingsDataEvent extends GwtEvent<UpdateSettingsDataEventHan
 
     public Predicate<Settings> getSettingsValueChanged() {
         return settingsValueChanged;
+    }
+
+    public boolean isDmnPathChanged() {
+        return dmnPathChanged;
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationDocksHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationDocksHandler.java
@@ -18,7 +18,6 @@ package org.drools.workbench.screens.scenariosimulation.client.handlers;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -27,13 +26,10 @@ import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSh
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsView;
-import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SubDockView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenter;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsView;
 import org.kie.workbench.common.widgets.client.docks.AbstractWorkbenchDocksHandler;
 import org.kie.workbench.common.widgets.client.docks.AuthoringEditorDock;
-import org.uberfire.client.mvp.AbstractWorkbenchActivity;
-import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.PlaceStatus;
 import org.uberfire.client.workbench.docks.UberfireDock;
@@ -53,6 +49,12 @@ public abstract class AbstractScenarioSimulationDocksHandler extends AbstractWor
     protected AuthoringEditorDock authoringWorkbenchDocks;
     @Inject
     protected PlaceManager placeManager;
+    @Inject
+    protected TestToolsPresenter testToolsPresenter;
+    @Inject
+    protected SettingsPresenter settingsPresenter;
+    @Inject
+    protected CheatSheetPresenter cheatSheetPresenter;
 
     private UberfireDock settingsDock;
     private UberfireDock toolsDock;
@@ -109,9 +111,9 @@ public abstract class AbstractScenarioSimulationDocksHandler extends AbstractWor
     public abstract void expandTestResultsDock();
 
     public void resetDocks() {
-        getSettingsPresenter().ifPresent(SubDockView.Presenter::reset);
-        getCheatSheetPresenter().ifPresent(SubDockView.Presenter::reset);
-        getTestToolsPresenter().ifPresent(SubDockView.Presenter::reset);
+        settingsPresenter.reset();
+        cheatSheetPresenter.reset();
+        testToolsPresenter.reset();
     }
 
     public void setScesimEditorId(String scesimEditorId) {
@@ -121,19 +123,16 @@ public abstract class AbstractScenarioSimulationDocksHandler extends AbstractWor
         cheatSheetDock.getPlaceRequest().addParameter(SCESIMEDITOR_ID, scesimEditorId);
     }
 
-    public Optional<CheatSheetView.Presenter> getCheatSheetPresenter() {
-        final Optional<CheatSheetView> cheatSheetView = getCheatSheetView(getCurrentRightDockPlaceRequest(CheatSheetPresenter.IDENTIFIER));
-        return cheatSheetView.map(CheatSheetView::getPresenter);
+    public CheatSheetView.Presenter getCheatSheetPresenter() {
+        return cheatSheetPresenter;
     }
 
-    public Optional<TestToolsView.Presenter> getTestToolsPresenter() {
-        final Optional<TestToolsView> testToolsView = getTestToolsView(getTestToolsPlaceManager());
-        return testToolsView.map(TestToolsView::getPresenter);
+    public TestToolsView.Presenter getTestToolsPresenter() {
+        return testToolsPresenter;
     }
 
-    public Optional<SettingsView.Presenter> getSettingsPresenter() {
-        final Optional<SettingsView> settingsView = getSettingsView(getSettingsPlaceManager());
-        return settingsView.map(SettingsView::getPresenter);
+    public SettingsView.Presenter getSettingsPresenter() {
+        return settingsPresenter;
     }
 
     protected PlaceRequest getSettingsPlaceManager() {
@@ -153,35 +152,5 @@ public abstract class AbstractScenarioSimulationDocksHandler extends AbstractWor
         PlaceRequest toReturn = new DefaultPlaceRequest(identifier);
         toReturn.addParameter(SCESIMEDITOR_ID, String.valueOf(currentScesimEditorId));
         return toReturn;
-    }
-
-    protected Optional<TestToolsView> getTestToolsView(PlaceRequest placeRequest) {
-        final Activity activity = placeManager.getActivity(placeRequest);
-        if (activity == null) {
-            return Optional.empty();
-        } else {
-            final AbstractWorkbenchActivity testToolsActivity = (AbstractWorkbenchActivity) activity;
-            return Optional.of((TestToolsView) testToolsActivity.getWidget());
-        }
-    }
-
-    protected Optional<CheatSheetView> getCheatSheetView(PlaceRequest placeRequest) {
-        final Activity activity = placeManager.getActivity(placeRequest);
-        if (activity == null) {
-            return Optional.empty();
-        } else {
-            final AbstractWorkbenchActivity cheatSheetActivity = (AbstractWorkbenchActivity) activity;
-            return Optional.of((CheatSheetView) cheatSheetActivity.getWidget());
-        }
-    }
-
-    protected Optional<SettingsView> getSettingsView(PlaceRequest placeRequest) {
-        final Activity activity = placeManager.getActivity(placeRequest);
-        if (activity == null) {
-            return Optional.empty();
-        } else {
-            final AbstractWorkbenchActivity settingsActivity = (AbstractWorkbenchActivity) activity;
-            return Optional.of((SettingsView) settingsActivity.getWidget());
-        }
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/rightpanel/SettingsPresenter.java
@@ -160,7 +160,8 @@ public class SettingsPresenter extends AbstractSubDockPresenter<SettingsView> im
     public void syncDmnFilePath() {
         String dmnFilePath = getCleanValue(() -> settingsScenarioSimulationDropdown.getValue().map(KieAssetsDropdownItem::getValue).orElse(""));
         eventBus.fireEvent(new UpdateSettingsDataEvent(settingsToUpdate -> settingsToUpdate.setDmnFilePath(dmnFilePath),
-                                                       settingsToCheck -> !Objects.equals(settingsToCheck.getDmnFilePath(), dmnFilePath)));
+                                                       settingsToCheck -> !Objects.equals(settingsToCheck.getDmnFilePath(), dmnFilePath),
+                                                       true));
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -19,7 +19,6 @@ package org.drools.workbench.screens.scenariosimulation.client.editor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -165,8 +164,8 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         when(testToolsActivityMock.getWidget()).thenReturn(testToolsViewMock);
         when(placeRequestMock.getPath()).thenReturn(pathMock);
         when(simulationMock.getUnmodifiableData()).thenReturn(Arrays.asList(new Scenario()));
-        when(abstractScenarioSimulationDocksHandlerMock.getTestToolsPresenter()).thenReturn(Optional.ofNullable(testToolsPresenterMock));
-        when(abstractScenarioSimulationDocksHandlerMock.getSettingsPresenter()).thenReturn(Optional.ofNullable(settingsPresenterMock));
+        when(abstractScenarioSimulationDocksHandlerMock.getTestToolsPresenter()).thenReturn(testToolsPresenterMock);
+        when(abstractScenarioSimulationDocksHandlerMock.getSettingsPresenter()).thenReturn(settingsPresenterMock);
 
         this.presenterSpy = spy(new ScenarioSimulationEditorPresenter(abstractScenarioSimulationProducerMock,
                                                                       mock(ScenarioSimulationResourceType.class),
@@ -188,11 +187,6 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
                 this.exportToCSVMenuItem = exportToCsvMenuItemMock;
                 this.importMenuItem = importMenuItemMock;
                 this.scenarioSimulationEditorWrapper = scenarioSimulationEditorWrapperMock;
-            }
-
-            @Override
-            protected void clearTestToolsStatus() {
-
             }
 
             @Override
@@ -269,6 +263,7 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenterSpy.reloadTestTools(false);
         verify(presenterSpy, times(1)).populateRightDocks(eq(TestToolsPresenter.IDENTIFIER));
         verify(abstractScenarioSimulationDocksHandlerMock, never()).getTestToolsPresenter();
+        verify(testToolsPresenterMock, never()).onDisableEditorTab();
     }
 
     @Test
@@ -276,6 +271,14 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenterSpy.reloadTestTools(true);
         verify(presenterSpy, times(1)).populateRightDocks(eq(TestToolsPresenter.IDENTIFIER));
         verify(abstractScenarioSimulationDocksHandlerMock, times(1)).getTestToolsPresenter();
+        verify(testToolsPresenterMock, times(1)).onDisableEditorTab();
+    }
+
+    @Test
+    public void clearTestTools() {
+        presenterSpy.clearTestToolsStatus();
+        verify(abstractScenarioSimulationDocksHandlerMock, times(1)).getTestToolsPresenter();
+        verify(testToolsPresenterMock, times(1)).onClearStatus();
     }
 
     @Test
@@ -624,7 +627,7 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
     @Test
     public void setSettings() {
         presenterSpy.setSettings(settingsPresenterMock);
-        verify(settingsPresenterMock, times(1)).setScenarioType(isA(ScenarioSimulationModel.Type.class), any(), anyString());
+        verify(settingsPresenterMock, times(1)).setScenarioType(isA(ScenarioSimulationModel.Type.class), any(), any());
     }
 
     @Test
@@ -747,5 +750,11 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
         presenterSpy.reloadSettingsDock();
         verify(abstractScenarioSimulationDocksHandlerMock, times(1)).getSettingsPresenter();
         verify(presenterSpy, times(1)).updateSettings(settingsPresenterMock);
+    }
+
+    @Test
+    public void getUpdateDMNMetadataCommand() {
+        presenterSpy.getUpdateDMNMetadataCommand().execute();
+        verify(scenarioSimulationEditorWrapperMock, times(1)).getDMNMetadata();
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/ScenarioSimulationEditorPresenterTest.java
@@ -627,7 +627,7 @@ public class ScenarioSimulationEditorPresenterTest extends AbstractScenarioSimul
     @Test
     public void setSettings() {
         presenterSpy.setSettings(settingsPresenterMock);
-        verify(settingsPresenterMock, times(1)).setScenarioType(isA(ScenarioSimulationModel.Type.class), any(), any());
+        verify(settingsPresenterMock, times(1)).setScenarioType(isA(ScenarioSimulationModel.Type.class), any(), anyString());
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMNDataManagementStrategyTest.java
@@ -73,7 +73,7 @@ public class AbstractDMNDataManagementStrategyTest extends AbstractScenarioSimul
         modelLocal.getSettings().setDmnFilePath(DMN_FILE_PATH);
         abstractDMNDataManagementStrategySpy = spy(new AbstractDMNDataManagementStrategy(mock(EventBus.class)) {
             @Override
-            protected void retrieveFactModelTuple(TestToolsView.Presenter testToolsPresenter, ScenarioSimulationContext context, GridWidget gridWidget, String dmnFilePath) {
+            protected void retrieveFactModelTuple(TestToolsView.Presenter testToolsPresenter, ScenarioSimulationContext context, GridWidget gridWidget) {
 
             }
 
@@ -81,6 +81,7 @@ public class AbstractDMNDataManagementStrategyTest extends AbstractScenarioSimul
                 this.currentPath = mock(Path.class);
                 this.model = modelLocal;
                 this.factModelTreeHolder = factModelTreeHolderlocal;
+                this.dmnFilePath = DMN_FILE_PATH;
             }
         });
     }
@@ -89,14 +90,34 @@ public class AbstractDMNDataManagementStrategyTest extends AbstractScenarioSimul
     public void populateTestToolsWithoutFactModelTuple() {
         factModelTreeHolderlocal.setFactModelTuple(null);
         abstractDMNDataManagementStrategySpy.populateTestTools(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
+        verify(abstractDMNDataManagementStrategySpy, times(1)).retrieveFactModelTuple(eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
         verify(abstractDMNDataManagementStrategySpy, never()).getSuccessCallback(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
         verify(abstractDMNDataManagementStrategySpy, never()).getSuccessCallbackMethod(eq(factModelTupleLocal), eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
     }
 
     @Test
+    public void populateTestToolsWithoutFactModelTupleAndDifferentDMNPath() {
+        factModelTreeHolderlocal.setFactModelTuple(null);
+        modelLocal.getSettings().setDmnName("/src/test.dmn");
+        abstractDMNDataManagementStrategySpy.populateTestTools(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
+        verify(abstractDMNDataManagementStrategySpy, times(1)).retrieveFactModelTuple(eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
+        verify(abstractDMNDataManagementStrategySpy, never()).getSuccessCallback(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
+        verify(abstractDMNDataManagementStrategySpy, never()).getSuccessCallbackMethod(eq(factModelTupleLocal), eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
+    }
+
+    @Test
+    public void populateTestToolsWithFactDifferentDMNPath() {
+        modelLocal.getSettings().setDmnName("/src/test.dmn");
+        abstractDMNDataManagementStrategySpy.populateTestTools(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
+        verify(abstractDMNDataManagementStrategySpy, never()).retrieveFactModelTuple(any(), any(), any());
+        verify(abstractDMNDataManagementStrategySpy, times(1)).getSuccessCallback(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
+        verify(abstractDMNDataManagementStrategySpy, times(1)).getSuccessCallbackMethod(eq(factModelTupleLocal), eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
+    }
+
+    @Test
     public void populateTestToolsWithFactModelTuple() {
         abstractDMNDataManagementStrategySpy.populateTestTools(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
-        verify(dmnTypeServiceMock, never()).retrieveFactModelTuple(any(), eq(modelLocal.getSettings().getDmnFilePath()));
+        verify(abstractDMNDataManagementStrategySpy, never()).retrieveFactModelTuple(any(), any(), any());
         verify(abstractDMNDataManagementStrategySpy, times(1)).getSuccessCallback(testToolsPresenterMock, scenarioSimulationContextLocal, GridWidget.SIMULATION);
         verify(abstractDMNDataManagementStrategySpy, times(1)).getSuccessCallbackMethod(eq(factModelTupleLocal), eq(testToolsPresenterMock), eq(scenarioSimulationContextLocal), eq(GridWidget.SIMULATION));
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationDocksHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/handlers/AbstractScenarioSimulationDocksHandlerTest.java
@@ -16,22 +16,17 @@
 package org.drools.workbench.screens.scenariosimulation.client.handlers;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetPresenter;
-import org.drools.workbench.screens.scenariosimulation.client.rightpanel.CheatSheetView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsPresenter;
-import org.drools.workbench.screens.scenariosimulation.client.rightpanel.SettingsView;
 import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsPresenter;
-import org.drools.workbench.screens.scenariosimulation.client.rightpanel.TestToolsView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.widgets.client.docks.AuthoringEditorDock;
 import org.mockito.Mock;
-import org.uberfire.client.mvp.AbstractWorkbenchActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.PlaceStatus;
 import org.uberfire.client.workbench.docks.UberfireDock;
@@ -40,13 +35,9 @@ import org.uberfire.mvp.PlaceRequest;
 
 import static org.drools.workbench.screens.scenariosimulation.client.handlers.AbstractScenarioSimulationDocksHandler.SCESIMEDITOR_ID;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -82,6 +73,9 @@ public class AbstractScenarioSimulationDocksHandlerTest {
             {
                 this.authoringWorkbenchDocks = authoringWorkbenchDocksMock;
                 this.placeManager = placeManagerMock;
+                this.cheatSheetPresenter = cheatSheetPresenterMock;
+                this.settingsPresenter = settingsPresenterMock;
+                this.testToolsPresenter = testToolsPresenterMock;
             }
 
             @Override
@@ -89,10 +83,6 @@ public class AbstractScenarioSimulationDocksHandlerTest {
                 //Do nothing
             }
         });
-
-        doReturn(Optional.of(cheatSheetPresenterMock)).when(abstractScenarioSimulationDocksHandlerSpy).getCheatSheetPresenter();
-        doReturn(Optional.of(testToolsPresenterMock)).when(abstractScenarioSimulationDocksHandlerSpy).getTestToolsPresenter();
-        doReturn(Optional.of(settingsPresenterMock)).when(abstractScenarioSimulationDocksHandlerSpy).getSettingsPresenter();
     }
 
     @Test
@@ -205,62 +195,5 @@ public class AbstractScenarioSimulationDocksHandlerTest {
         assertNotNull(placeRequest);
         assertEquals("identifier", placeRequest.getIdentifier());
         assertNotNull(placeRequest.getParameter(SCESIMEDITOR_ID, ""));
-    }
-
-    @Test
-    public void getTestToolsView() {
-        TestToolsView testToolsViewMock = mock(TestToolsView.class);
-        AbstractWorkbenchActivity activityMock = mock(AbstractWorkbenchActivity.class);
-        when(activityMock.getWidget()).thenReturn(testToolsViewMock);
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(TestToolsPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(activityMock);
-        Optional<TestToolsView> optional = abstractScenarioSimulationDocksHandlerSpy.getTestToolsView(placeRequest);
-        assertSame(testToolsViewMock, optional.get());
-    }
-
-    @Test
-    public void getTestToolsView_NullActivity() {
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(TestToolsPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(null);
-        Optional<TestToolsView> optional = abstractScenarioSimulationDocksHandlerSpy.getTestToolsView(placeRequest);
-        assertFalse(optional.isPresent());
-    }
-
-    @Test
-    public void getCheatSheetView() {
-        CheatSheetView cheatSheetViewMock = mock(CheatSheetView.class);
-        AbstractWorkbenchActivity activityMock = mock(AbstractWorkbenchActivity.class);
-        when(activityMock.getWidget()).thenReturn(cheatSheetViewMock);
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(CheatSheetPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(activityMock);
-        Optional<CheatSheetView> optional = abstractScenarioSimulationDocksHandlerSpy.getCheatSheetView(placeRequest);
-        assertSame(cheatSheetViewMock, optional.get());
-    }
-
-    @Test
-    public void getCheatSheetView_NullActivity() {
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(CheatSheetPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(null);
-        Optional<CheatSheetView> optional = abstractScenarioSimulationDocksHandlerSpy.getCheatSheetView(placeRequest);
-        assertFalse(optional.isPresent());
-    }
-
-    @Test
-    public void getSettingsView() {
-        SettingsView settingsViewMock = mock(SettingsView.class);
-        AbstractWorkbenchActivity activityMock = mock(AbstractWorkbenchActivity.class);
-        when(activityMock.getWidget()).thenReturn(settingsViewMock);
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(SettingsPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(activityMock);
-        Optional<SettingsView> optional = abstractScenarioSimulationDocksHandlerSpy.getSettingsView(placeRequest);
-        assertSame(settingsViewMock, optional.get());
-    }
-
-    @Test
-    public void getSettings_NullActivity() {
-        PlaceRequest placeRequest = abstractScenarioSimulationDocksHandlerSpy.getCurrentRightDockPlaceRequest(SettingsPresenter.IDENTIFIER);
-        when(placeManagerMock.getActivity(eq(placeRequest))).thenReturn(null);
-        Optional<SettingsView> optional = abstractScenarioSimulationDocksHandlerSpy.getSettingsView(placeRequest);
-        assertFalse(optional.isPresent());
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/ScenarioSimulationEditorKogitoWrapper.java
@@ -65,6 +65,7 @@ import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.MainJs;
+import org.kie.workbench.common.dmn.webapp.kogito.marshaller.js.model.dmn12.JSITDefinitions;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerPresenter;
 import org.kie.workbench.common.kogito.client.editor.MultiPageEditorContainerView;
 import org.kie.workbench.common.kogito.client.resources.i18n.KogitoClientConstants;
@@ -73,6 +74,7 @@ import org.kie.workbench.common.widgets.client.menu.FileMenuBuilder;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.backend.vfs.impl.ObservablePathImpl;
+import org.uberfire.client.callbacks.Callback;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.PlaceStatus;
 import org.uberfire.client.promise.Promises;
@@ -288,6 +290,25 @@ public class ScenarioSimulationEditorKogitoWrapper extends MultiPageEditorContai
         if (item != null) {
             item.showTab(false);
         }
+    }
+
+    @Override
+    public void getDMNMetadata() {
+        final String dmnFilePath = getScenarioSimulationEditorPresenter().getModel().getSettings().getDmnFilePath();
+        final String dmnFileName = dmnFilePath.substring(dmnFilePath.lastIndexOf('/') + 1);
+        final Path dmnPath = PathFactory.newPath(dmnFileName, dmnFilePath);
+        scenarioSimulationKogitoDMNMarshallerService.getDMNContent(
+                dmnPath,
+                getUpdateDMNMetadataCallback(),
+                getDMNContentErrorCallback(dmnFilePath));
+    }
+
+    private Callback<JSITDefinitions> getUpdateDMNMetadataCallback() {
+        return jsitDefinitions -> {
+            getScenarioSimulationEditorPresenter().getModel().getSettings().setDmnName(jsitDefinitions.getName());
+            getScenarioSimulationEditorPresenter().getModel().getSettings().setDmnNamespace(jsitDefinitions.getNamespace());
+            getScenarioSimulationEditorPresenter().reloadSettingsDock();
+        };
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/strategies/KogitoDMNDataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/main/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/strategies/KogitoDMNDataManagementStrategy.java
@@ -49,8 +49,7 @@ public class KogitoDMNDataManagementStrategy extends AbstractDMNDataManagementSt
     @Override
     protected void retrieveFactModelTuple(final TestToolsView.Presenter testToolsPresenter,
                                           final ScenarioSimulationContext context,
-                                          final GridWidget gridWidget,
-                                          final String dmnFilePath) {
+                                          final GridWidget gridWidget) {
         String dmnFileName = dmnFilePath.substring(dmnFilePath.lastIndexOf('/') + 1);
         final Path dmnPath = PathFactory.newPath(dmnFileName, dmnFilePath);
         dmnMarshallerService.getDMNContent(dmnPath,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/strategies/KogitoDMNDataManagementStrategyTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-kogito-client/src/test/java/org/drools/workbench/screens/scenariosimulation/kogito/client/editor/strategies/KogitoDMNDataManagementStrategyTest.java
@@ -79,14 +79,18 @@ public class KogitoDMNDataManagementStrategyTest {
 
     @Before
     public void setup() {
-        kogitoDMNDataManagementStrategySpy = spy(new KogitoDMNDataManagementStrategy(eventBusMock, kogitoDMNDataManagerMock, dmnMarshallerServiceMock));
+        kogitoDMNDataManagementStrategySpy = spy(new KogitoDMNDataManagementStrategy(eventBusMock, kogitoDMNDataManagerMock, dmnMarshallerServiceMock) {
+            {
+                this.dmnFilePath = "path/dmnFile.dmn";
+            }
+        });
         when(kogitoDMNDataManagementStrategySpy.getSuccessCallback(eq(testToolsPresenterMock), eq(scenarioSimulationContextMock), eq(gridWidgetMock))).thenReturn(factModelTupleRemoteCallbackMock);
         when(kogitoDMNDataManagerMock.getFactModelTuple(eq(jsitDefinitionsMock))).thenReturn(factModelTupleMock);
     }
 
     @Test
     public void retrieveFactModelTuple() {
-        kogitoDMNDataManagementStrategySpy.retrieveFactModelTuple(testToolsPresenterMock, scenarioSimulationContextMock, gridWidgetMock, "path/dmnFile.dmn");
+        kogitoDMNDataManagementStrategySpy.retrieveFactModelTuple(testToolsPresenterMock, scenarioSimulationContextMock, gridWidgetMock);
         Path expectedPath = new PathFactory.PathImpl("dmnFile.dmn", "path/dmnFile.dmn");
         verify(dmnMarshallerServiceMock, times(1)).getDMNContent(eq(expectedPath), callbackArgumentCaptor.capture(), errorCallbackArgumentCaptor.capture());
 


### PR DESCRIPTION
Backporting of https://github.com/kiegroup/drools-wb/pull/1459

Changes introduced in this PR:
- When changing DMN reference in the Setting dock, DMN Name and DMN Namespace are now updated (BC and Kogito);
- When changing DMN reference in the Setting dock, the Fact list in the Test Tools dock is now updated (BC and Kogito);
- When changing DMN reference in the Setting dock a Validation is performed (BC only);

![Screencast from 02-02-2021 11_36_37 AM](https://user-images.githubusercontent.com/16005046/106589772-ae3bb300-654c-11eb-837d-c552419c58ef.gif)

**JIRA**: https://issues.redhat.com/browse/DROOLS-4986

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
