### PR TITLE
KOGITO-4919: [DMN Designer] SDM is broken on -kogito-webapp-runtime

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -1118,6 +1118,11 @@
     <!-- DMN Editor - Client side FEEL -->
     <dependency>
       <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-feel-gwt-functions</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
       <artifactId>kie-dmn-feel-gwt</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
**JIRA**: [KOGITO-4919](https://issues.redhat.com/browse/KOGITO-4919): [DMN Designer] SDM is broken on -kogito-webapp-runtime

--

**Part of an ensemble:**
- https://github.com/kiegroup/kie-wb-common/pull/3611
- https://github.com/kiegroup/drools-wb/pull/1484
- https://github.com/kiegroup/kie-wb-distributions/pull/1097

--

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
