### PR TITLE
DROOLS-4863: Doughnut chart tooltip doesn't show correctly at Coverage Report panel 

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportDonutPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportDonutPresenter.java
@@ -30,6 +30,8 @@ import org.dashbuilder.displayer.client.DisplayerLocator;
 import org.drools.workbench.screens.scenariosimulation.client.resources.i18n.ScenarioSimulationEditorConstants;
 import org.jboss.errai.common.client.dom.elemental2.Elemental2DomUtil;
 
+import static org.drools.workbench.screens.scenariosimulation.client.utils.ConstantHolder.STYLE;
+
 @Dependent
 public class CoverageReportDonutPresenter {
 
@@ -78,6 +80,11 @@ public class CoverageReportDonutPresenter {
                                                 displayer.asWidget());
     }
 
+    public void initializeCSS() {
+        manageChartLabels();
+        manageChartTooltip();
+    }
+
     /**
      * Scope of this method is to manage the labels inside the Donut chart. The requirements is to:
      * - Remove all labels inside any arc of the chart. This is required because the chart current dimension is very
@@ -85,14 +92,31 @@ public class CoverageReportDonutPresenter {
      * To achieve these requirements without a native support of the component, it navigates the <code>container</code>
      * DOM to retrieve manually the text tags elements which handle the labels.
      */
-    public void manageChartLabels() {
+    private void manageChartLabels() {
         NodeList<Element> listE = container.getElementsByTagName("text");
         for (int i = 0; i < listE.getLength(); i++) {
             Element element = listE.getAt(i);
             String className = element.getAttribute("class");
              if (element.innerHTML != null && element.innerHTML.endsWith("%") && className.isEmpty()) {
-                String style = element.getAttribute("style");
-                element.setAttribute("style", style.concat("display:none;"));
+                String style = element.getAttribute(STYLE);
+                element.setAttribute(STYLE, style.concat("display:none;"));
+            }
+        }
+    }
+
+    /**
+     * Scope of this method is to change C3 native component position to "sticky"
+     */
+    private void manageChartTooltip() {
+        NodeList<Element> divs = container.getElementsByTagName("div");
+        for (int i = 0; i < divs.getLength(); i++) {
+            Element element = divs.getAt(i);
+            String className = element.getAttribute("class");
+            if ("c3-tooltip-container".equals(className)) {
+                String style = element.getAttribute(STYLE);
+                String replaceStyle = style.replace("absolute", "sticky").concat("position: -webkit-sticky;");
+                element.setAttribute(STYLE, replaceStyle);
+                break;
             }
         }
     }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportPresenter.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/main/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportPresenter.java
@@ -154,7 +154,7 @@ public class CoverageReportPresenter extends AbstractSubDockPresenter<CoverageRe
         coverageReportDonutPresenter.showCoverageReport(executed,
                                                         available - executed,
                                                         numberFormatNoDecimal.format(coveragePercentage) + "%");
-        coverageReportDonutPresenter.manageChartLabels();
+        coverageReportDonutPresenter.initializeCSS();
     }
 
     protected void populateList(Map<String, Integer> outputCounter) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportPresenterTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-businesscentral-client/src/test/java/org/drools/workbench/screens/scenariosimulation/businesscentral/client/rightpanel/coverage/CoverageReportPresenterTest.java
@@ -210,7 +210,7 @@ public class CoverageReportPresenterTest {
         verify(coverageReportDonutPresenterMock, times(1)).showCoverageReport(eq(executedLocal),
                                                                               eq(delta),
                                                                               endsWith("%"));
-        verify(coverageReportDonutPresenterMock, times(1)).manageChartLabels();
+        verify(coverageReportDonutPresenterMock, times(1)).initializeCSS();
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ConstantHolder.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/utils/ConstantHolder.java
@@ -33,6 +33,7 @@ public class ConstantHolder {
     public static final String DISABLED = "disabled";
     public static final String SELECTED = "selected";
     public static final String INPUT = "input";
+    public static final String STYLE = "style";
 
     public static final String EXPRESSION = "expression";
     public static final String EXPRESSION_INSTANCE_PLACEHOLDER = EXPRESSION + " </>";


### PR DESCRIPTION
This PR modifies Doughnut chart tooltip in order to be fixed (sticky), avoiding the reported issue (see JIRA)


![Screenshot from 2021-04-21 16-46-08](https://user-images.githubusercontent.com/16005046/116239998-9cd90000-a763-11eb-9edd-9765f417cfa8.png)
![Screenshot from 2021-04-21 16-48-42](https://user-images.githubusercontent.com/16005046/116240010-a19db400-a763-11eb-8227-23fc24b1dac2.png)


**JIRA**: https://issues.redhat.com/browse/DROOLS-4863
[link](https://drive.google.com/file/d/1t5VfpXcUdJsqun465OMF3tMErjY582Rr/view?usp=sharing)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
