### PR TITLE
DROOLS-6477: Collections Data Objects can be filled with expressions only.

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTree.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/main/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTree.java
@@ -16,7 +16,6 @@
 package org.drools.workbench.screens.scenariosimulation.model.typedescriptor;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +25,8 @@ import java.util.stream.Collectors;
 import org.jboss.errai.common.client.api.annotations.Portable;
 
 import static org.drools.scenariosimulation.api.utils.ConstantsHolder.VALUE;
+import static org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils.isCollectionOrMap;
+import static org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils.isMap;
 
 /**
  * Class used to recursively represent a given fact with its ModelFields eventually expanded
@@ -85,9 +86,22 @@ public class FactModelTree {
     public static FactModelTree ofSimpleDMO(String factName, String fullPackage, String simplePropertyFullClass, String typeName) {
         Map<String, FactModelTree.PropertyTypeName> simpleProperties = new HashMap<>();
         simpleProperties.put(VALUE, new FactModelTree.PropertyTypeName(simplePropertyFullClass));
-        FactModelTree toReturn = new FactModelTree(factName, fullPackage, simpleProperties, Collections.emptyMap(), Type.UNDEFINED, typeName, null);
+        FactModelTree toReturn = new FactModelTree(factName, fullPackage, simpleProperties, retrieveSimpleGenericTypesMap(simplePropertyFullClass), Type.UNDEFINED, typeName, null);
         toReturn.setSimple(true);
         return toReturn;
+    }
+
+    private static Map<String, List<String>> retrieveSimpleGenericTypesMap(String simplePropertyFullClass) {
+        Map<String, List<String>> genericTypesMap = new HashMap<>();
+        if (isCollectionOrMap(simplePropertyFullClass)) {
+            List<String> generics = new ArrayList<>();
+            generics.add(Object.class.getCanonicalName());
+            if (isMap(simplePropertyFullClass)) {
+                generics.add(Object.class.getCanonicalName());
+            }
+            genericTypesMap.put(VALUE, generics);
+        }
+        return genericTypesMap;
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTreeTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-api/src/test/java/org/drools/workbench/screens/scenariosimulation/model/typedescriptor/FactModelTreeTest.java
@@ -16,6 +16,8 @@
 package org.drools.workbench.screens.scenariosimulation.model.typedescriptor;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.drools.scenariosimulation.api.utils.ConstantsHolder;
 import org.junit.Test;
@@ -31,6 +33,8 @@ public class FactModelTreeTest {
     private final static String PACKAGE = "com";
     private final static String FACT_TYPE = "FactType";
     private final static String SIMPLE_PROPERTY_TYPE = "numeric";
+    private final static String LIST_PROPERTY_TYPE = List.class.getCanonicalName();
+    private final static String MAP_PROPERTY_TYPE = Map.class.getCanonicalName();
     private final static String IMPORT_PREFIX = "imp";
 
     @Test
@@ -89,6 +93,43 @@ public class FactModelTreeTest {
         assertEquals(1, factModelTree.getSimpleProperties().size());
         assertEquals(SIMPLE_PROPERTY_TYPE, factModelTree.getSimpleProperties().get(ConstantsHolder.VALUE).getTypeName());
         assertEquals(0, factModelTree.getGenericTypesMap().size());
+        assertEquals(FactModelTree.Type.UNDEFINED, factModelTree.getType());
+        assertTrue(factModelTree.isSimple());
+        assertNull(factModelTree.getImportPrefix());
+    }
+
+    @Test
+    public void ofSimpleCollectionDMO() {
+        FactModelTree factModelTree = FactModelTree.ofSimpleDMO(FACT_NAME, PACKAGE, LIST_PROPERTY_TYPE, FACT_TYPE);
+        assertEquals(FACT_NAME, factModelTree.getFactName());
+        assertEquals(FACT_TYPE, factModelTree.getTypeName());
+        assertEquals(PACKAGE, factModelTree.getFullPackage());
+        assertEquals(PACKAGE + "." + FACT_TYPE, factModelTree.getFullTypeName());
+        assertEquals(FACT_NAME, factModelTree.getFactName());
+        assertEquals(1, factModelTree.getSimpleProperties().size());
+        assertEquals(LIST_PROPERTY_TYPE, factModelTree.getSimpleProperties().get(ConstantsHolder.VALUE).getTypeName());
+        assertEquals(1, factModelTree.getGenericTypesMap().size());
+        assertEquals(1, factModelTree.getGenericTypesMap().get(ConstantsHolder.VALUE).size());
+        assertEquals(Object.class.getCanonicalName(), factModelTree.getGenericTypesMap().get(ConstantsHolder.VALUE).get(0));
+        assertEquals(FactModelTree.Type.UNDEFINED, factModelTree.getType());
+        assertTrue(factModelTree.isSimple());
+        assertNull(factModelTree.getImportPrefix());
+    }
+
+    @Test
+    public void ofSimpleMapDMO() {
+        FactModelTree factModelTree = FactModelTree.ofSimpleDMO(FACT_NAME, PACKAGE, MAP_PROPERTY_TYPE, FACT_TYPE);
+        assertEquals(FACT_NAME, factModelTree.getFactName());
+        assertEquals(FACT_TYPE, factModelTree.getTypeName());
+        assertEquals(PACKAGE, factModelTree.getFullPackage());
+        assertEquals(PACKAGE + "." + FACT_TYPE, factModelTree.getFullTypeName());
+        assertEquals(FACT_NAME, factModelTree.getFactName());
+        assertEquals(1, factModelTree.getSimpleProperties().size());
+        assertEquals(MAP_PROPERTY_TYPE, factModelTree.getSimpleProperties().get(ConstantsHolder.VALUE).getTypeName());
+        assertEquals(1, factModelTree.getGenericTypesMap().size());
+        assertEquals(2, factModelTree.getGenericTypesMap().get(ConstantsHolder.VALUE).size());
+        assertEquals(Object.class.getCanonicalName(), factModelTree.getGenericTypesMap().get(ConstantsHolder.VALUE).get(0));
+        assertEquals(Object.class.getCanonicalName(), factModelTree.getGenericTypesMap().get(ConstantsHolder.VALUE).get(1));
         assertEquals(FactModelTree.Type.UNDEFINED, factModelTree.getType());
         assertTrue(factModelTree.isSimple());
         assertNull(factModelTree.getImportPrefix());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/actualcommands/AbstractSelectedColumnCommand.java
@@ -251,7 +251,7 @@ public abstract class AbstractSelectedColumnCommand extends AbstractScenarioGrid
                                                                                         context.getStatus().isKeepData(),
                                                                                         factMappingValueType,
                                                                                         context.getScenarioSimulationModel().getSettings().getType());
-        if (ScenarioSimulationSharedUtils.isCollection(propertyClass) && factMappingValueType.equals(FactMappingValueType.NOT_EXPRESSION)) {
+        if (ScenarioSimulationSharedUtils.isCollectionOrMap(propertyClass) && factMappingValueType.equals(FactMappingValueType.NOT_EXPRESSION)) {
             manageCollectionProperty(context, selectedColumn, factName, columnIndex, propertyNameElements);
         } else {
             selectedColumn.setFactory(context.getAbstractScesimGridModelByGridWidget(gridWidget).getDOMElementFactory(propertyClass,

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMODataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/AbstractDMODataManagementStrategy.java
@@ -172,7 +172,7 @@ public abstract class AbstractDMODataManagementStrategy extends AbstractDataMana
             if (!modelField.getName().equals("this")) {
                 String className = defineClassNameField(modelField.getClassName(), superTypeMap);
                 simpleProperties.put(modelField.getName(), new FactModelTree.PropertyTypeName(className));
-                if (ScenarioSimulationSharedUtils.isCollection(className)) {
+                if (ScenarioSimulationSharedUtils.isCollectionOrMap(className)) {
                     populateGenericTypeMap(genericTypesMap, factName, modelField.getName(), ScenarioSimulationSharedUtils.isList(className));
                 }
             }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -22,6 +22,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,7 +63,10 @@ public interface DataManagementStrategy {
             new AbstractMap.SimpleEntry<>(Date.class.getSimpleName(), new SimpleClassEntry(Date.class)),
             new AbstractMap.SimpleEntry<>(Double.class.getSimpleName(), new SimpleClassEntry(Double.class)),
             new AbstractMap.SimpleEntry<>(Float.class.getSimpleName(), new SimpleClassEntry(Float.class)),
+            new AbstractMap.SimpleEntry<>(HashMap.class.getSimpleName(), new SimpleClassEntry(HashMap.class)),
             new AbstractMap.SimpleEntry<>(Integer.class.getSimpleName(), new SimpleClassEntry(Integer.class)),
+            new AbstractMap.SimpleEntry<>(LinkedList.class.getSimpleName(), new SimpleClassEntry(LinkedList.class)),
+            new AbstractMap.SimpleEntry<>(LinkedHashMap.class.getSimpleName(), new SimpleClassEntry(LinkedHashMap.class)),
             new AbstractMap.SimpleEntry<>(List.class.getSimpleName(), new SimpleClassEntry(List.class)),
             new AbstractMap.SimpleEntry<>(Long.class.getSimpleName(), new SimpleClassEntry(Long.class)),
             new AbstractMap.SimpleEntry<>(Map.class.getSimpleName(), new SimpleClassEntry(Map.class)),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -18,8 +18,11 @@ package org.drools.workbench.screens.scenariosimulation.client.editor.strategies
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,16 +50,20 @@ import static org.drools.workbench.screens.scenariosimulation.client.utils.Const
 public interface DataManagementStrategy {
 
     Map<String, SimpleClassEntry> SIMPLE_CLASSES_MAP = Collections.unmodifiableMap(Stream.of(
+            new AbstractMap.SimpleEntry<>(ArrayList.class.getSimpleName(), new SimpleClassEntry(ArrayList.class)),
             new AbstractMap.SimpleEntry<>(BigDecimal.class.getSimpleName(), new SimpleClassEntry(BigDecimal.class)),
             new AbstractMap.SimpleEntry<>(BigInteger.class.getSimpleName(), new SimpleClassEntry(BigInteger.class)),
             new AbstractMap.SimpleEntry<>(Boolean.class.getSimpleName(), new SimpleClassEntry(Boolean.class)),
             new AbstractMap.SimpleEntry<>(Byte.class.getSimpleName(), new SimpleClassEntry(Byte.class)),
             new AbstractMap.SimpleEntry<>(Character.class.getSimpleName(), new SimpleClassEntry(Character.class)),
+            new AbstractMap.SimpleEntry<>(Collection.class.getSimpleName(), new SimpleClassEntry(Collection.class)),
             new AbstractMap.SimpleEntry<>(Date.class.getSimpleName(), new SimpleClassEntry(Date.class)),
             new AbstractMap.SimpleEntry<>(Double.class.getSimpleName(), new SimpleClassEntry(Double.class)),
             new AbstractMap.SimpleEntry<>(Float.class.getSimpleName(), new SimpleClassEntry(Float.class)),
             new AbstractMap.SimpleEntry<>(Integer.class.getSimpleName(), new SimpleClassEntry(Integer.class)),
+            new AbstractMap.SimpleEntry<>(List.class.getSimpleName(), new SimpleClassEntry(List.class)),
             new AbstractMap.SimpleEntry<>(Long.class.getSimpleName(), new SimpleClassEntry(Long.class)),
+            new AbstractMap.SimpleEntry<>(Map.class.getSimpleName(), new SimpleClassEntry(Map.class)),
             new AbstractMap.SimpleEntry<>(Number.class.getSimpleName(), new SimpleClassEntry(Number.class)),
             new AbstractMap.SimpleEntry<>(Object.class.getSimpleName(), new SimpleClassEntry(Object.class)),
             new AbstractMap.SimpleEntry<>(Short.class.getSimpleName(), new SimpleClassEntry(Short.class)),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,7 +75,7 @@ public interface DataManagementStrategy {
             new AbstractMap.SimpleEntry<>(Object.class.getSimpleName(), new SimpleClassEntry(Object.class)),
             new AbstractMap.SimpleEntry<>(Short.class.getSimpleName(), new SimpleClassEntry(Short.class)),
             new AbstractMap.SimpleEntry<>(String.class.getSimpleName(), new SimpleClassEntry(String.class)),
-            // java.time (JSR-310) is not supported by GWT, therefore LocalDate and LocaleDateTime are not natively
+            new AbstractMap.SimpleEntry<>(TreeMap.class.getSimpleName(), new SimpleClassEntry(TreeMap.class)),            // java.time (JSR-310) is not supported by GWT, therefore LocalDate and LocaleDateTime are not natively
             new AbstractMap.SimpleEntry<>(LOCALDATE_SIMPLE_NAME, new SimpleClassEntry(LOCALDATE_SIMPLE_NAME, LOCALDATE_CANONICAL_NAME)),
             new AbstractMap.SimpleEntry<>(LOCALTIME_SIMPLE_NAME, new SimpleClassEntry(LOCALTIME_SIMPLE_NAME, LOCALTIME_CANONICAL_NAME)),
             new AbstractMap.SimpleEntry<>(LOCALDATETIME_SIMPLE_NAME, new SimpleClassEntry(LOCALDATETIME_SIMPLE_NAME, LOCALDATETIME_CANONICAL_NAME)),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/editor/strategies/DataManagementStrategy.java
@@ -75,7 +75,8 @@ public interface DataManagementStrategy {
             new AbstractMap.SimpleEntry<>(Object.class.getSimpleName(), new SimpleClassEntry(Object.class)),
             new AbstractMap.SimpleEntry<>(Short.class.getSimpleName(), new SimpleClassEntry(Short.class)),
             new AbstractMap.SimpleEntry<>(String.class.getSimpleName(), new SimpleClassEntry(String.class)),
-            new AbstractMap.SimpleEntry<>(TreeMap.class.getSimpleName(), new SimpleClassEntry(TreeMap.class)),            // java.time (JSR-310) is not supported by GWT, therefore LocalDate and LocaleDateTime are not natively
+            new AbstractMap.SimpleEntry<>(TreeMap.class.getSimpleName(), new SimpleClassEntry(TreeMap.class)),
+            // java.time (JSR-310) is not supported by GWT, therefore LocalDate and LocaleDateTime are not natively
             new AbstractMap.SimpleEntry<>(LOCALDATE_SIMPLE_NAME, new SimpleClassEntry(LOCALDATE_SIMPLE_NAME, LOCALDATE_CANONICAL_NAME)),
             new AbstractMap.SimpleEntry<>(LOCALTIME_SIMPLE_NAME, new SimpleClassEntry(LOCALTIME_SIMPLE_NAME, LOCALTIME_CANONICAL_NAME)),
             new AbstractMap.SimpleEntry<>(LOCALDATETIME_SIMPLE_NAME, new SimpleClassEntry(LOCALDATETIME_SIMPLE_NAME, LOCALDATETIME_CANONICAL_NAME)),

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/factories/CollectionEditorSingletonDOMElementFactory.java
@@ -124,7 +124,7 @@ public class CollectionEditorSingletonDOMElementFactory extends BaseSingletonDOM
         if (RULE.equals(type) && !isSimpleJavaType(genericTypeName0)) {
             genericTypeName0 = getRuleComplexType(genericTypeName0);
         }
-        if (ScenarioSimulationSharedUtils.isList(propertyClass)) {
+        if (ScenarioSimulationSharedUtils.isCollection(propertyClass)) {
             manageList(collectionEditorView, key, genericTypeName0, type);
         } else {
             manageMap(collectionEditorView, key, genericTypeName0, genericTypes.get(1), type);

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModel.java
@@ -394,7 +394,7 @@ public abstract class AbstractScesimGridModel<T extends AbstractScesimModel<E>, 
         return setCell(rowIndex, columnIndex, () -> {
             ScenarioGridCell newCell = new ScenarioGridCell((ScenarioGridCellValue) value);
             FactMapping factMappingByIndex = abstractScesimModel.getScesimModelDescriptor().getFactMappingByIndex(columnIndex);
-            if (ScenarioSimulationSharedUtils.isCollection((factMappingByIndex.getClassName()))) {
+            if (ScenarioSimulationSharedUtils.isCollectionOrMap((factMappingByIndex.getClassName()))) {
                 newCell.setListMap(ScenarioSimulationSharedUtils.isList((factMappingByIndex.getClassName())));
             }
             return newCell;
@@ -973,7 +973,7 @@ public abstract class AbstractScesimGridModel<T extends AbstractScesimModel<E>, 
                                                                         factMappingByIndex.getClassName());
             setCell(rowIndex, columnIndex, () -> {
                 ScenarioGridCell newCell = new ScenarioGridCell(new ScenarioGridCellValue(null, placeHolder));
-                if (ScenarioSimulationSharedUtils.isCollection((factMappingByIndex.getClassName()))) {
+                if (ScenarioSimulationSharedUtils.isCollectionOrMap((factMappingByIndex.getClassName()))) {
                     newCell.setListMap(ScenarioSimulationSharedUtils.isList((factMappingByIndex.getClassName())));
                 }
                 return newCell;
@@ -1103,7 +1103,7 @@ public abstract class AbstractScesimGridModel<T extends AbstractScesimModel<E>, 
                                                                ScenarioSimulationModel.Type modelType,
                                                                FactMappingValueType valueType) {
         boolean isRuleScenario = Objects.equals(ScenarioSimulationModel.Type.RULE, modelType);
-        if (ScenarioSimulationSharedUtils.isCollection(className) && Objects.equals(FactMappingValueType.NOT_EXPRESSION, valueType)) {
+        if (ScenarioSimulationSharedUtils.isCollectionOrMap(className) && Objects.equals(FactMappingValueType.NOT_EXPRESSION, valueType)) {
             return collectionEditorSingletonDOMElementFactory;
         }
         if (Objects.equals(FactMappingValueType.EXPRESSION, valueType) && isRuleScenario) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/BackgroundGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/BackgroundGridModel.java
@@ -66,7 +66,7 @@ public class BackgroundGridModel extends AbstractScesimGridModel<Background, Bac
                 String placeHolder = ((ScenarioGridColumn) columns.get(columnIndex)).getPlaceHolder();
                 setCell(rowIndex, columnIndex, () -> {
                     ScenarioGridCell newCell = new ScenarioGridCell(new ScenarioGridCellValue(stringValue, placeHolder));
-                    if (ScenarioSimulationSharedUtils.isCollection((factMappingByIndex.getClassName()))) {
+                    if (ScenarioSimulationSharedUtils.isCollectionOrMap((factMappingByIndex.getClassName()))) {
                         newCell.setListMap(ScenarioSimulationSharedUtils.isList((factMappingByIndex.getClassName())));
                     }
                     return newCell;

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/ScenarioGridModel.java
@@ -64,7 +64,7 @@ public class ScenarioGridModel extends AbstractScesimGridModel<Simulation, Scena
                 String placeHolder = ((ScenarioGridColumn) columns.get(columnIndex)).getPlaceHolder();
                 setCell(rowIndex, columnIndex, () -> {
                     ScenarioGridCell newCell = new ScenarioGridCell(new ScenarioGridCellValue(stringValue, placeHolder));
-                    if (ScenarioSimulationSharedUtils.isCollection((factMappingByIndex.getClassName()))) {
+                    if (ScenarioSimulationSharedUtils.isCollectionOrMap((factMappingByIndex.getClassName()))) {
                         newCell.setListMap(ScenarioSimulationSharedUtils.isList((factMappingByIndex.getClassName())));
                     }
                     return newCell;


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6477

**referenced Pull Requests**: 
* https://github.com/kiegroup/drools/pull/3725

The issue occurs when the user imports a Collection or a Map from the "Data Object" tab.
![Screencast from 07-08-2021 10_35_28 AM](https://user-images.githubusercontent.com/16005046/124891273-1cdbdb80-dfd9-11eb-99be-bb1c43b48cfb.gif)

In the  Test Tools area, the Collection (eg. ArrayList) will wrongly show `empty` as a field. Selecting it or the `ArrayList`fact, will not enable the Guided Collection Editor as expected. 

With the change introduced with this PR, now `value` field will be shown. As a results, adding the value parameter in the grid, will  show the Guided Collection Editor.

![Screencast from 07-08-2021 10_34_29 AM](https://user-images.githubusercontent.com/16005046/124892251-008c6e80-dfda-11eb-96f3-24564f248089.gif)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
