### PR TITLE
DROOLS-6494: No effects when assigning a not-expression Simple Type column to expression type (and viceversa) 

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandler.java
@@ -31,6 +31,7 @@ import javax.enterprise.event.Event;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.event.shared.HandlerRegistration;
 import org.drools.scenariosimulation.api.model.FactMappingValueType;
+import org.drools.scenariosimulation.api.utils.ScenarioSimulationSharedUtils;
 import org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands.AbstractScenarioSimulationCommand;
 import org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands.AbstractScenarioSimulationUndoableCommand;
 import org.drools.workbench.screens.scenariosimulation.client.commands.actualcommands.AppendColumnCommand;
@@ -406,18 +407,17 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
         context.getStatus().setPropertyNameElements(event.getPropertyNameElements());
         context.getStatus().setValueClassName(event.getValueClassName());
         context.getStatus().setImportPrefix(event.getImportPrefix());
-        if (isSameFactProperty(event.getGridWidget(), event.getPropertyNameElements()) &&
+        if (isSameFactProperty(event.getGridWidget(), event.getPropertyNameElements(), event.getFactMappingValueType()) &&
                 isSameSelectedColumnType(event.getGridWidget(), event.getValueClassName())) {
             return;
         } else {
             if (isSelectedColumnEmpty(event.getGridWidget())) {
                 commonExecution(new SetPropertyHeaderCommand(event.getGridWidget(), event.getFactMappingValueType()), true);
             } else {
-                if (!isSameFactProperty(event.getGridWidget(), event.getPropertyNameElements()) &&
-                        !isSameSelectedColumnType(event.getGridWidget(), event.getValueClassName())) {
-                    showDeletePopup(event);
-                } else {
+                if (isSameSelectedColumnType(event.getGridWidget(), event.getValueClassName()) && !ScenarioSimulationSharedUtils.isCollectionOrMap(event.getValueClassName())) {
                     showPreserveDeletePopup(event);
+                } else {
+                    showDeletePopup(event);
                 }
             }
         }
@@ -427,8 +427,8 @@ public class ScenarioSimulationEventHandler implements AppendColumnEventHandler,
         return context.getAbstractScesimGridModelByGridWidget(gridWidget).isSelectedColumnEmpty();
     }
 
-    private boolean isSameFactProperty(GridWidget gridWidget, List<String> propertyNameElements) {
-        return context.getAbstractScesimGridModelByGridWidget(gridWidget).isSameSelectedColumnProperty(propertyNameElements);
+    private boolean isSameFactProperty(GridWidget gridWidget, List<String> propertyNameElements, FactMappingValueType factMappingValueType) {
+        return context.getAbstractScesimGridModelByGridWidget(gridWidget).isSameSelectedColumnProperty(propertyNameElements, factMappingValueType);
     }
 
     private boolean isSameSelectedColumnType(GridWidget gridWidget, String valueTypeName) {

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModel.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/main/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModel.java
@@ -682,24 +682,26 @@ public abstract class AbstractScesimGridModel<T extends AbstractScesimModel<E>, 
     /**
      * Returns <code>true</code> if property mapped to the selected column is the same as the provided one
      * @param propertyNameElements
+     * @param factMappingValueType
      * @return
      */
-    public boolean isSameSelectedColumnProperty(List<String> propertyNameElements) {
-        return selectedColumn == null || isSameSelectedColumnProperty(getColumns().indexOf(selectedColumn), propertyNameElements);
+    public boolean isSameSelectedColumnProperty(List<String> propertyNameElements, FactMappingValueType factMappingValueType) {
+        return selectedColumn == null || isSameSelectedColumnProperty(getColumns().indexOf(selectedColumn), propertyNameElements, factMappingValueType);
     }
 
     /**
      * Returns <code>true</code> if property mapped to the column at given index is the same as the provided one
      * @param columnIndex
      * @param propertyNameElements
+     * @param factMappingValueType
      * @return
      */
-    public boolean isSameSelectedColumnProperty(int columnIndex, List<String> propertyNameElements) {
+    public boolean isSameSelectedColumnProperty(int columnIndex, List<String> propertyNameElements, FactMappingValueType factMappingValueType) {
         String propertyName = String.join(".", propertyNameElements);
         ScesimModelDescriptor simulationDescriptor = abstractScesimModel.getScesimModelDescriptor();
         final FactMapping factMappingByIndex = simulationDescriptor.getFactMappingByIndex(columnIndex);
         String expressionElement = factMappingByIndex.getExpressionElements().stream().map(ExpressionElement::getStep).collect(Collectors.joining("."));
-        return Objects.equals(expressionElement, propertyName);
+        return Objects.equals(expressionElement, propertyName) && Objects.equals(factMappingValueType, factMappingByIndex.getFactMappingValueType());
     }
 
     /**

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -467,7 +467,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(false);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -478,7 +478,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(false);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -499,7 +499,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler, preserveDeletePopupPresenterMock);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(true);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(true);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -510,7 +510,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(true);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(true);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -531,7 +531,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler, preserveDeletePopupPresenterMock);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(false);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -542,7 +542,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList())).thenReturn(false);
+        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/commands/ScenarioSimulationEventHandlerTest.java
@@ -100,6 +100,7 @@ import static org.drools.workbench.screens.scenariosimulation.client.TestPropert
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.COLUMN_INDEX;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.FULL_PACKAGE;
+import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.LIST_CLASS_NAME;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.MULTIPART_VALUE_ELEMENTS;
 import static org.drools.workbench.screens.scenariosimulation.client.TestProperties.ROW_INDEX;
@@ -467,7 +468,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -478,7 +479,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -499,7 +500,7 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler, preserveDeletePopupPresenterMock);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(true);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(true);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -507,31 +508,28 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         verify(preserveDeletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any() );
         verify(deletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any());
         //
-        reset(scenarioSimulationEventHandler);
+        reset(scenarioSimulationEventHandler, deletePopupPresenterMock);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(true);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(true);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
         verify(scenarioSimulationEventHandler, never()).commonExecution(isA(SetPropertyHeaderCommand.class), anyBoolean());
-        verify(preserveDeletePopupPresenterMock, times(1))
-                .show(eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioMainTitle()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioMainQuestion()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioText1()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioTextQuestion()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioTextOption1()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveDeleteScenarioTextOption2()),
-                      eq(ScenarioSimulationEditorConstants.INSTANCE.preserveValues()),
+        verify(preserveDeletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any() );
+        verify(deletePopupPresenterMock, times(1))
+                .show(eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainTitle()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainQuestion()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioText1()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioTextQuestion()),
+                      isNull(),
                       eq(ScenarioSimulationEditorConstants.INSTANCE.deleteValues()),
-                      isA(org.uberfire.mvp.Command.class),
                       isA(org.uberfire.mvp.Command.class));
-        verify(deletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any());
         //
-        reset(scenarioSimulationEventHandler, preserveDeletePopupPresenterMock);
+        reset(scenarioSimulationEventHandler, preserveDeletePopupPresenterMock, deletePopupPresenterMock);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(true);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
@@ -542,8 +540,47 @@ public class ScenarioSimulationEventHandlerTest extends AbstractScenarioSimulati
         reset(scenarioSimulationEventHandler);
         when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
         when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
-        //when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), factMappingValueType)).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
         when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
+        scenarioSimulationEventHandler.onEvent(event);
+        verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
+        verify(scenarioSimulationEventHandler, never()).commonExecution(isA(SetPropertyHeaderCommand.class), anyBoolean());
+        verify(preserveDeletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any() );
+        verify(deletePopupPresenterMock, times(1))
+                .show(eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainTitle()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainQuestion()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioText1()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioTextQuestion()),
+                      isNull(),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteValues()),
+                      isA(org.uberfire.mvp.Command.class));
+    }
+
+    @Test
+    public void onSetPropertyHeaderCollectionEvent() {
+        SetPropertyHeaderEvent event = new SetPropertyHeaderEvent(GridWidget.SIMULATION, FULL_PACKAGE, CLASS_NAME, MULTIPART_VALUE_ELEMENTS, LIST_CLASS_NAME, FactMappingValueType.NOT_EXPRESSION, IMPORTED_PREFIX);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
+        when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(false);
+        scenarioSimulationEventHandler.onEvent(event);
+        verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
+        verify(scenarioSimulationEventHandler, never()).commonExecution(isA(SetPropertyHeaderCommand.class), anyBoolean());
+        verify(preserveDeletePopupPresenterMock, never()).show(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), any() );
+        verify(deletePopupPresenterMock, times(1))
+                .show(eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainTitle()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioMainQuestion()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioText1()),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteScenarioTextQuestion()),
+                      isNull(),
+                      eq(ScenarioSimulationEditorConstants.INSTANCE.deleteValues()),
+                      isA(org.uberfire.mvp.Command.class));
+        //
+        reset(scenarioSimulationEventHandler, deletePopupPresenterMock, preserveDeletePopupPresenterMock);
+        when(scenarioGridModelMock.isAlreadyAssignedProperty(MULTIPART_VALUE_ELEMENTS)).thenReturn(false);
+        when(scenarioGridModelMock.isSelectedColumnEmpty()).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnProperty(anyList(), any())).thenReturn(false);
+        when(scenarioGridModelMock.isSameSelectedColumnType(anyString())).thenReturn(true);
         scenarioSimulationEventHandler.onEvent(event);
         verify(scenarioSimulationEventHandler, never()).onEvent(isA(ScenarioNotificationEvent.class));
         verify(scenarioSimulationEventHandler, never()).commonExecution(isA(SetPropertyHeaderCommand.class), anyBoolean());

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModelTest.java
@@ -743,8 +743,19 @@ public class AbstractScesimGridModelTest extends AbstractScenarioSimulationTest 
     public void isSameSelectedColumnProperty() {
         List<ExpressionElement> expressionList = Arrays.asList(new ExpressionElement("Fact"), new ExpressionElement("property"));
         when(factMappingMock.getExpressionElements()).thenReturn(expressionList);
-        /*assertTrue(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), factMappingValueType));
-        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), factMappingValueType));
-        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), factMappingValueType));*/
+        when(factMappingMock.getFactMappingValueType()).thenReturn(FactMappingValueType.NOT_EXPRESSION);
+        assertTrue(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), FactMappingValueType.NOT_EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), FactMappingValueType.NOT_EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), FactMappingValueType.NOT_EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), FactMappingValueType.EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), FactMappingValueType.EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), FactMappingValueType.EXPRESSION));
+        when(factMappingMock.getFactMappingValueType()).thenReturn(FactMappingValueType.EXPRESSION);
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), FactMappingValueType.NOT_EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), FactMappingValueType.NOT_EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), FactMappingValueType.NOT_EXPRESSION));
+        assertTrue(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), FactMappingValueType.EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), FactMappingValueType.EXPRESSION));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), FactMappingValueType.EXPRESSION));
     }
 }

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModelTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-client/src/test/java/org/drools/workbench/screens/scenariosimulation/client/models/AbstractScesimGridModelTest.java
@@ -743,8 +743,8 @@ public class AbstractScesimGridModelTest extends AbstractScenarioSimulationTest 
     public void isSameSelectedColumnProperty() {
         List<ExpressionElement> expressionList = Arrays.asList(new ExpressionElement("Fact"), new ExpressionElement("property"));
         when(factMappingMock.getExpressionElements()).thenReturn(expressionList);
-        assertTrue(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property")));
-        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2")));
-        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2")));
+        /*assertTrue(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property"), factMappingValueType));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("Fact", "property2"), factMappingValueType));
+        assertFalse(abstractScesimGridModelSpy.isSameSelectedColumnProperty(1, Arrays.asList("property2"), factMappingValueType));*/
     }
 }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6494

@jomarko This PR fixes the 2^ issue you found here https://github.com/kiegroup/drools-wb/pull/1503#pullrequestreview-703931429 . Considering you found it, I assign the QE review to you, but please feel free to reassign.

Step to reproduce: 
- Create a new Test Scenario (RULE)
- Form "Data Object" tab, add any Java class available. (eg. Integer)
- Add the Integer > value property in the grid
- Try to re-assign the same column to an expression, selecting "Integer" class in the Test Tools.
- Nothing happens
- (the same occurs if you assign the expression first and then reassign it with Integer > value.

P.S. This PR requires https://github.com/kiegroup/drools-wb/pull/1503 to be merged first, because it relies on its changes.


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
