### PR TITLE
[7.59.x] Backport ignored test for ScenarioRunnerServiceTest.testIsGithubContributor

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerServiceTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerServiceTest.java
@@ -28,6 +28,7 @@ import org.guvnor.common.services.shared.test.TestResultMessage;
 import org.guvnor.structure.server.config.ConfigurationService;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
@@ -161,6 +162,7 @@ public class ScenarioRunnerServiceTest {
     }
 
     @Test
+    @Ignore( "Connects to github. Not reliable.")
     public void testIsGithubContributor() throws Exception {
         initKieSession("isGithubContributor.gdst");
         testScenario("testContributors.scenario", true);


### PR DESCRIPTION
backporting https://github.com/kiegroup/drools-wb/pull/1532

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
