### PR TITLE
[7.67.x-blue] DROOLS-6905: Added `drools-decisiontables` as dependency to compile xml decision tables assets

### DIFF
--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/main/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImpl.java
@@ -457,6 +457,8 @@ public class ScenarioSimulationServiceImpl
         return Arrays.asList(new GAV(ORG_DROOLS, "drools-scenario-simulation-api", kieVersion),
                              new GAV(ORG_DROOLS, "drools-scenario-simulation-backend", kieVersion),
                              new GAV(ORG_DROOLS, "drools-compiler", kieVersion),
+                             // needed to compile xml decision table
+                             new GAV(ORG_DROOLS, "drools-decisiontables", kieVersion),
                              // needed to compile guided decision table
                              new GAV(ORG_DROOLS, "drools-workbench-models-guided-dtable", kieVersion),
                              // needed in case of BPMN file in the project, but not used directly by scesim

--- a/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImplTest.java
+++ b/drools-wb-screens/drools-wb-scenario-simulation-editor/drools-wb-scenario-simulation-editor-backend/src/test/java/org/drools/workbench/screens/scenariosimulation/backend/server/ScenarioSimulationServiceImplTest.java
@@ -86,7 +86,6 @@ public class ScenarioSimulationServiceImplTest {
     private static final String ORG_KIE = "org.kie";
     private static final String ORG_JBPM = "org.jbpm";
 
-
     @Mock
     protected KieServiceOverviewLoader overviewLoaderMock;
     @Mock
@@ -446,6 +445,7 @@ public class ScenarioSimulationServiceImplTest {
         GAV scesimApiDependency = new GAV(ORG_DROOLS, "drools-scenario-simulation-api", null);
         GAV scesimBackendDependency = new GAV(ORG_DROOLS, "drools-scenario-simulation-backend", null);
         GAV droolsCompilerDependency = new GAV(ORG_DROOLS, "drools-compiler", null);
+        GAV dtableDependency = new GAV(ORG_DROOLS, "drools-decisiontables", null);
         GAV gtableDependency = new GAV(ORG_DROOLS, "drools-workbench-models-guided-dtable", null);
         GAV jbpmBpmn2Dependency = new GAV(ORG_JBPM, "jbpm-bpmn2", null);
         GAV dmnFeelDependency = new GAV(ORG_KIE, "kie-dmn-feel", null);
@@ -454,11 +454,12 @@ public class ScenarioSimulationServiceImplTest {
 
         List<GAV> dependencies = service.getDependencies(null);
 
-        assertEquals(8, dependencies.size());
+        assertEquals(9, dependencies.size());
         assertTrue(dependencies.contains(scesimApiDependency));
         assertTrue(dependencies.contains(scesimBackendDependency));
         assertTrue(dependencies.contains(droolsCompilerDependency));
         assertTrue(dependencies.contains(gtableDependency));
+        assertTrue(dependencies.contains(dtableDependency));
         assertTrue(dependencies.contains(jbpmBpmn2Dependency));
         assertTrue(dependencies.contains(dmnFeelDependency));
         assertTrue(dependencies.contains(dmnApi2Dependency));


### PR DESCRIPTION
Backport of https://github.com/kiegroup/drools-wb/pull/1542

JIRA: https://issues.redhat.com/browse/DROOLS-6905

When a scesim assets is added in the project, the drools-decisiontable will be automatically added in the project related pom.xml file.
This is required in case the user has XML decision table assets in its projects.