### PR TITLE
[7.67.x] Revert "RHPAM-4387 xml-apis:xml-apis excluded"

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -223,12 +223,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>


### PR DESCRIPTION
jbpm-wb not needed

Related PRs:

* https://github.com/kiegroup/kie-wb-distributions/pull/1189
* https://github.com/kiegroup/drools-wb/pull/1554
* https://github.com/kiegroup/kie-wb-common/pull/3773