### PR TITLE
[7.67.x-blue]Update plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
         <artifactId>powermock-core</artifactId>
         <version>${version.org.powermock}</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]
Linked PRs :
https://github.com/kiegroup/jbpm-work-items/pull/333
https://github.com/kiegroup/kie-jpmml-integration/pull/96
https://github.com/kiegroup/kie-wb-distributions/pull/1251
https://github.com/kiegroup/kie-wb-common/pull/3848
https://github.com/kiegroup/process-migration-service/pull/145
